### PR TITLE
feat: default Bastion NSG and Azure Firewall UDR for security hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this project will be documented in this file.  
 This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres to [Semantic Versioning](https://semver.org/).
 
+## [v1.0.8] - 2026-04-16
+### Added
+- New parameter `policyManagedPrivateDns` (`bool`, default `false`) to skip Private DNS Zone and DNS zone group creation. Use this in environments where Azure Policy manages Private DNS Zone linking (e.g., CAF Enterprise-Scale Platform Landing Zone). (PR #4, fixes #2)
+- New parameter `privateEndpointLocation` to override the Azure region for private endpoint creation. Supports scenarios where the VNet is in a different region than the deployed resources. (PR #6, fixes #1)
+- New parameter `privateEndpointResourceGroupName` to specify a dedicated resource group for private endpoints. (PR #6, fixes #3)
+- New variable `_deployPrivateDnsZones` that gates all Private DNS Zone module deployments based on `networkIsolation && !policyManagedPrivateDns`.
+- New variables `_peLocation`, `_defaultPeResourceGroupName`, and `_peResourceGroupName` for resolving PE location and resource group overrides with backward-compatible fallbacks.
+
+### Changed
+- All Private DNS Zone modules now conditionally deploy based on `_deployPrivateDnsZones` instead of `_networkIsolation`, allowing policy-managed environments to opt out.
+- All private endpoint `privateDnsZoneGroup` configurations are conditionally set to `{}` when `policyManagedPrivateDns` is `true`.
+- All 8 private endpoint module invocations updated to use `_peLocation` and `_peResourceGroupName` instead of hardcoded `location` and inline ternary expressions.
+- Updated `main.parameters.json` with `privateEndpointLocation` and `privateEndpointResourceGroupName` entries supporting `azd` env var substitution (`AZURE_PE_LOCATION`, `AZURE_PE_RESOURCE_GROUP_NAME`).
+
+### Refactored
+- Extracted default PE resource group resolution into a separate `_defaultPeResourceGroupName` variable for improved readability.
+
 ## [v1.0.7] - 2026-04-14
 ### Fixed
 - Fixed Log Analytics provisioning failure in Sweden Central (and other regions enforcing CMK validation) by explicitly setting `forceCmkForQuery: false` in the `logAnalytics` module. The AVM module defaults this to `true`, which requires a fully configured Customer Managed Key setup that the landing zone does not provision.

--- a/main.bicep
+++ b/main.bicep
@@ -424,7 +424,8 @@ var _jumpbxSubnetId = _networkIsolation ? '${virtualNetworkResourceId}/subnets/$
 var _agentSubnetId = _networkIsolation ? '${virtualNetworkResourceId}/subnets/${agentSubnetName}' : ''
 
 var _peLocation = !empty(privateEndpointLocation) ? privateEndpointLocation : location
-var _peResourceGroupName = !empty(privateEndpointResourceGroupName) ? privateEndpointResourceGroupName : (useExistingVNet && !sideBySideDeploy ? varExistingVnetResourceGroupName : resourceGroup().name)
+var _defaultPeResourceGroupName = useExistingVNet && !sideBySideDeploy ? varExistingVnetResourceGroupName : resourceGroup().name
+var _peResourceGroupName = !empty(privateEndpointResourceGroupName) ? privateEndpointResourceGroupName : _defaultPeResourceGroupName
 
 // ----------------------------------------------------------------------
 // VM vars

--- a/main.bicep
+++ b/main.bicep
@@ -206,6 +206,12 @@ param deploySubnets bool = true
 @description('Will deploy network security groups.')
 param deployNsgs bool = true
 
+@description('Deploy Azure Firewall with UDR for egress traffic control. Defaults to true when networkIsolation is enabled.')
+param deployAzureFirewall bool = true
+
+@description('List of trusted source IP CIDRs allowed to connect to the Bastion public IP on port 443. When empty, all internet inbound to port 443 is denied by default.')
+param bastionAllowedSourceIPs array = []
+
 @description('Will deploy network resources side by side with the Azure resources.')
 param sideBySideDeploy bool = true
 
@@ -475,12 +481,38 @@ var _useCAppAPIKey  = empty(string(useCAppAPIKey))? false : bool(useCAppAPIKey)
 // Networking
 ///////////////////////////////////////////////////////////////////////////
 
+// Bastion NSG — restricts inbound 443 to trusted IPs only
+module bastionNsg 'modules/networking/bastion-nsg.bicep' = if (deployVM && _networkIsolation && deployNsgs) {
+  name: 'bastionNsgDeployment'
+  params: {
+    name: 'nsg-${vnetName}-${azureBastionSubnetName}'
+    location: location
+    bastionAllowedSourceIPs: bastionAllowedSourceIPs
+  }
+}
+
+// Firewall FQDN allowlist for essential outbound connectivity
+#disable-next-line no-hardcoded-env-urls
+var _firewallEssentialAuthFqdns = ['login.microsoftonline.com', 'graph.microsoft.com']
+var _firewallEssentialContainerFqdns = ['mcr.microsoft.com', '*.data.mcr.microsoft.com']
+
+// Route Table for egress traffic control through Azure Firewall
+resource routeTable 'Microsoft.Network/routeTables@2024-07-01' = if (_networkIsolation) {
+  name: '${const.abbrs.networking.routeTable}${resourceToken}'
+  location: location
+  tags: _tags
+  properties: {
+    disableBgpRoutePropagation: true
+  }
+}
+
 // Base subnets that are always included
 var baseSubnets = [
       {
         name: agentSubnetName
         addressPrefix: agentSubnetPrefix 
         delegation: 'Microsoft.app/environments'
+        routeTableResourceId: routeTable.id
         serviceEndpoints: [
           'Microsoft.CognitiveServices'
         ]
@@ -488,6 +520,7 @@ var baseSubnets = [
       {
         name: peSubnetName
         addressPrefix: peSubnetPrefix 
+        routeTableResourceId: routeTable.id
         serviceEndpoints: [
           'Microsoft.AzureCosmosDB'
         ]        
@@ -501,7 +534,9 @@ var baseSubnets = [
       }
       {
         name: azureBastionSubnetName
-        addressPrefix: azureBastionSubnetPrefix 
+        addressPrefix: azureBastionSubnetPrefix
+        #disable-next-line BCP318
+        networkSecurityGroupResourceId: bastionNsg.outputs.id
         delegation: ''
         serviceEndpoints : []
       }
@@ -521,6 +556,7 @@ var baseSubnets = [
         name: jumpboxSubnetName
         addressPrefix: jumpboxSubnetPrefix 
         natGatewayResourceId: natGateway.id
+        routeTableResourceId: routeTable.id
         delegation: ''
         serviceEndpoints : []
       }
@@ -528,6 +564,7 @@ var baseSubnets = [
         name: acaEnvironmentSubnetName
         addressPrefix: acaEnvironmentSubnetPrefix  
         delegation: 'Microsoft.app/environments'
+        routeTableResourceId: routeTable.id
         serviceEndpoints: [
           'Microsoft.AzureCosmosDB'
         ]
@@ -535,6 +572,7 @@ var baseSubnets = [
       {
         name: devopsBuildAgentsSubnetName
         addressPrefix: devopsBuildAgentsSubnetPrefix 
+        routeTableResourceId: routeTable.id
         delegation: ''
         serviceEndpoints : []
       }
@@ -604,6 +642,143 @@ module testVmBastionHost 'br/public:avm/res/network/bastion-host:0.8.0' = if (de
     #disable-next-line BCP321
     useExistingVNet ? virtualNetworkSubnets : null
   ]
+}
+
+// Azure Firewall for egress traffic control
+///////////////////////////////////////////////////////////////////////////
+
+resource firewallPublicIp 'Microsoft.Network/publicIPAddresses@2024-07-01' = if (deployAzureFirewall && _networkIsolation) {
+  name: '${const.abbrs.networking.publicIPAddress}${const.abbrs.networking.firewall}${resourceToken}'
+  location: location
+  sku: {
+    name: 'Standard'
+    tier: 'Regional'
+  }
+  properties: {
+    publicIPAllocationMethod: 'Static'
+    publicIPAddressVersion: 'IPv4'
+  }
+  tags: _tags
+}
+
+resource firewallPolicy 'Microsoft.Network/firewallPolicies@2024-07-01' = if (deployAzureFirewall && _networkIsolation) {
+  name: '${const.abbrs.networking.firewallPolicy}${resourceToken}'
+  location: location
+  tags: _tags
+  properties: {
+    sku: {
+      tier: 'Standard'
+    }
+    threatIntelMode: 'Alert'
+  }
+}
+
+resource firewallPolicyDefaultRuleCollectionGroup 'Microsoft.Network/firewallPolicies/ruleCollectionGroups@2024-07-01' = if (deployAzureFirewall && _networkIsolation) {
+  parent: firewallPolicy
+  name: 'DefaultRuleCollectionGroup'
+  properties: {
+    priority: 200
+    ruleCollections: [
+      {
+        ruleCollectionType: 'FirewallPolicyFilterRuleCollection'
+        name: 'AllowEssentialOutbound'
+        priority: 100
+        action: {
+          type: 'Allow'
+        }
+        rules: [
+          {
+            ruleType: 'ApplicationRule'
+            name: 'AllowMicrosoftContainerRegistry'
+            protocols: [
+              { protocolType: 'Https', port: 443 }
+            ]
+            targetFqdns: _firewallEssentialContainerFqdns
+            sourceAddresses: ['*']
+          }
+          {
+            ruleType: 'ApplicationRule'
+            name: 'AllowEntraIdAuth'
+            protocols: [
+              { protocolType: 'Https', port: 443 }
+            ]
+            targetFqdns: _firewallEssentialAuthFqdns
+            sourceAddresses: ['*']
+          }
+        ]
+      }
+    ]
+  }
+}
+
+#disable-next-line BCP318
+var _firewallSubnetId = _networkIsolation ? '${virtualNetworkResourceId}/subnets/${azureFirewallSubnetName}' : ''
+
+resource azureFirewall 'Microsoft.Network/azureFirewalls@2024-07-01' = if (deployAzureFirewall && _networkIsolation) {
+  name: '${const.abbrs.networking.firewall}${resourceToken}'
+  location: location
+  tags: _tags
+  properties: {
+    sku: {
+      name: 'AZFW_VNet'
+      tier: 'Standard'
+    }
+    ipConfigurations: [
+      {
+        name: 'ipconfig1'
+        properties: {
+          publicIPAddress: {
+            id: firewallPublicIp.id
+          }
+          subnet: {
+            id: _firewallSubnetId
+          }
+        }
+      }
+    ]
+    firewallPolicy: {
+      id: firewallPolicy.id
+    }
+  }
+  dependsOn: [
+    #disable-next-line BCP321
+    !useExistingVNet ? virtualNetwork : null
+    #disable-next-line BCP321
+    useExistingVNet ? virtualNetworkSubnets : null
+  ]
+}
+
+// Default route through Azure Firewall
+resource defaultRoute 'Microsoft.Network/routeTables/routes@2024-07-01' = if (deployAzureFirewall && _networkIsolation) {
+  parent: routeTable
+  name: 'default-to-firewall'
+  properties: {
+    addressPrefix: '0.0.0.0/0'
+    nextHopType: 'VirtualAppliance'
+    nextHopIpAddress: azureFirewall!.properties.ipConfigurations[0].properties.privateIPAddress
+  }
+}
+
+// Azure Firewall diagnostics to Log Analytics
+resource firewallDiagnostics 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = if (deployAzureFirewall && _networkIsolation && deployLogAnalytics) {
+  name: 'fw-diagnostics'
+  scope: azureFirewall
+  properties: {
+    #disable-next-line BCP318
+    workspaceId: logAnalytics.outputs.resourceId
+    logs: [
+      {
+        categoryGroup: 'allLogs'
+        enabled: true
+      }
+    ]
+    metrics: [
+      {
+        category: 'AllMetrics'
+        enabled: true
+      }
+    ]
+  }
 }
 
 //AI Foundry Search User Managed Identity

--- a/main.bicep
+++ b/main.bicep
@@ -89,6 +89,12 @@ When false (default), the module creates and manages all Private DNS Zones and l
 Requires networkIsolation to be true to have any effect.''')
 param policyManagedPrivateDns bool = false
 
+@description('The Azure region where private endpoints will be created. Defaults to the main deployment location. Use this when your VNet is in a different region than the resources.')
+param privateEndpointLocation string = ''
+
+@description('The name of the resource group where private endpoints will be created. When empty, private endpoints are placed in the VNet resource group (for existing VNets with sideBySideDeploy disabled) or the deployment resource group.')
+param privateEndpointResourceGroupName string = ''
+
 @description('Use an existing Virtual Network. When false, a new VNet will be created.')
 param useExistingVNet bool = false
 
@@ -416,6 +422,9 @@ var _caEnvSubnetId = _networkIsolation ? '${virtualNetworkResourceId}/subnets/${
 var _jumpbxSubnetId = _networkIsolation ? '${virtualNetworkResourceId}/subnets/${jumpboxSubnetName}' : ''
 #disable-next-line BCP318
 var _agentSubnetId = _networkIsolation ? '${virtualNetworkResourceId}/subnets/${agentSubnetName}' : ''
+
+var _peLocation = !empty(privateEndpointLocation) ? privateEndpointLocation : location
+var _peResourceGroupName = !empty(privateEndpointResourceGroupName) ? privateEndpointResourceGroupName : (useExistingVNet && !sideBySideDeploy ? varExistingVnetResourceGroupName : resourceGroup().name)
 
 // ----------------------------------------------------------------------
 // VM vars
@@ -1176,8 +1185,8 @@ module privateEndpointStorageBlob 'modules/networking/private-endpoint.bicep' = 
   name: 'blob-private-endpoint'
   params: {
     name: '${const.abbrs.networking.privateEndpoint}${storageAccountName}'
-    resourceGroupName: useExistingVNet && !sideBySideDeploy ? varExistingVnetResourceGroupName : resourceGroup().name
-    location: location
+    resourceGroupName: _peResourceGroupName
+    location: _peLocation
     tags: _tags
     subnetResourceId: _peSubnetId
     privateLinkServiceConnections: [
@@ -1211,8 +1220,8 @@ module privateEndpointCosmos 'modules/networking/private-endpoint.bicep' = if (_
   name: 'cosmos-private-endpoint'
   params: {
     name: '${const.abbrs.networking.privateEndpoint}${dbAccountName}'
-    resourceGroupName: useExistingVNet && !sideBySideDeploy ? varExistingVnetResourceGroupName : resourceGroup().name
-    location: location
+    resourceGroupName: _peResourceGroupName
+    location: _peLocation
     tags: _tags
     subnetResourceId: _peSubnetId
     privateLinkServiceConnections: [
@@ -1247,8 +1256,8 @@ module privateEndpointSearch 'modules/networking/private-endpoint.bicep' = if (_
   name: 'search-private-endpoint'
   params: {
     name: '${const.abbrs.networking.privateEndpoint}${searchServiceName}'
-    resourceGroupName: useExistingVNet && !sideBySideDeploy ? varExistingVnetResourceGroupName : resourceGroup().name
-    location: location
+    resourceGroupName: _peResourceGroupName
+    location: _peLocation
     tags: _tags
     subnetResourceId: _peSubnetId
     privateLinkServiceConnections: [
@@ -1283,8 +1292,8 @@ module privateEndpointKeyVault 'modules/networking/private-endpoint.bicep' = if 
   name: 'kv-private-endpoint'
   params: {
     name: '${const.abbrs.networking.privateEndpoint}${keyVaultName}'
-    resourceGroupName: useExistingVNet && !sideBySideDeploy ? varExistingVnetResourceGroupName : resourceGroup().name
-    location: location
+    resourceGroupName: _peResourceGroupName
+    location: _peLocation
     tags: _tags
     subnetResourceId: _peSubnetId
     privateLinkServiceConnections: [
@@ -1319,8 +1328,8 @@ module privateEndpointAppConfig 'modules/networking/private-endpoint.bicep' = if
   name: 'appconfig-private-endpoint'
   params: {
     name: '${const.abbrs.networking.privateEndpoint}${appConfigName}'
-    resourceGroupName: useExistingVNet && !sideBySideDeploy ? varExistingVnetResourceGroupName : resourceGroup().name
-    location: location
+    resourceGroupName: _peResourceGroupName
+    location: _peLocation
     tags: _tags
     subnetResourceId: _peSubnetId
     privateLinkServiceConnections: [
@@ -1355,8 +1364,8 @@ module privateEndpointContainerAppsEnv 'modules/networking/private-endpoint.bice
   name: 'dep-containerapps-env-private-endpoint'
   params: {
     name: '${const.abbrs.networking.privateEndpoint}${containerEnvName}'
-    resourceGroupName: useExistingVNet && !sideBySideDeploy ? varExistingVnetResourceGroupName : resourceGroup().name
-    location: location
+    resourceGroupName: _peResourceGroupName
+    location: _peLocation
     tags: _tags
     subnetResourceId: _peSubnetId
     privateLinkServiceConnections: [
@@ -1390,8 +1399,8 @@ module privateEndpointAcr 'modules/networking/private-endpoint.bicep' = if (_net
   name: 'dep-acr-private-endpoint'
   params: {
     name: '${const.abbrs.networking.privateEndpoint}${containerRegistryName}'
-    resourceGroupName: useExistingVNet && !sideBySideDeploy ? varExistingVnetResourceGroupName : resourceGroup().name
-    location: location
+    resourceGroupName: _peResourceGroupName
+    location: _peLocation
     tags: _tags
     subnetResourceId: _peSubnetId
     privateLinkServiceConnections: [
@@ -1750,8 +1759,8 @@ module privateEndpointPrivateLinkScope 'modules/networking/private-endpoint.bice
   name: 'privatelink-scope-private-endpoint'
   params: {
     name: '${const.abbrs.networking.privateEndpoint}${const.abbrs.networking.privateLinkScope}${resourceToken}'
-    location: location
-    resourceGroupName: useExistingVNet && !sideBySideDeploy ? varExistingVnetResourceGroupName : resourceGroup().name
+    location: _peLocation
+    resourceGroupName: _peResourceGroupName
     tags: _tags
     subnetResourceId: _peSubnetId
     privateLinkServiceConnections: [

--- a/main.parameters.json
+++ b/main.parameters.json
@@ -32,6 +32,8 @@
     "deployContainerRegistry":              { "value": "true" },
     "deployContainerEnv":                   { "value": "true" },
     "deployNsgs":                           { "value": "true" },
+    "deployAzureFirewall":                  { "value": "${DEPLOY_AZURE_FIREWALL}" },
+    "bastionAllowedSourceIPs":              { "value": [] },
     "deployMcp":                            { "value": "true" },
     "deployGroundingWithBing":              { "value": "false" },
     "deployKeyVault":                       { "value": "true" },

--- a/main.parameters.json
+++ b/main.parameters.json
@@ -12,6 +12,8 @@
     "principalId":                         { "value": "${AZURE_PRINCIPAL_ID}" },
 
     "networkIsolation":                    { "value": "${NETWORK_ISOLATION}" },
+    "privateEndpointLocation":             { "value": "${AZURE_PE_LOCATION}" },
+    "privateEndpointResourceGroupName":    { "value": "${AZURE_PE_RESOURCE_GROUP_NAME}" },
     "useUAI":                              { "value": "${USE_UAI}" },
     "useCAppAPIKey":                       { "value": "${USE_CAPP_API_KEY}" },    
     "useZoneRedundancy":                   { "value": "false" },    

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
-  "tag": "v1.0.7",
+  "tag": "v1.0.8",
   "repo": "https://github.com/azure/bicep-ptn-aiml-landing-zone.git",
-  "ailz_tag": "v1.0.7",
+  "ailz_tag": "v1.0.8",
   "components": []
 }

--- a/modules/networking/bastion-nsg.bicep
+++ b/modules/networking/bastion-nsg.bicep
@@ -1,0 +1,147 @@
+param name string
+param location string
+param bastionAllowedSourceIPs array = []
+
+var allowedSourceRules = [
+  for (ip, i) in bastionAllowedSourceIPs: {
+    name: 'AllowHttpsFromTrustedIP-${i}'
+    properties: {
+      protocol: 'Tcp'
+      sourcePortRange: '*'
+      destinationPortRange: '443'
+      sourceAddressPrefix: ip
+      destinationAddressPrefix: '*'
+      access: 'Allow'
+      priority: 200 + i
+      direction: 'Inbound'
+    }
+  }
+]
+
+var requiredRules = [
+  // Inbound rules
+  {
+    name: 'AllowGatewayManagerInbound'
+    properties: {
+      protocol: 'Tcp'
+      sourcePortRange: '*'
+      destinationPortRange: '443'
+      sourceAddressPrefix: 'GatewayManager'
+      destinationAddressPrefix: '*'
+      access: 'Allow'
+      priority: 100
+      direction: 'Inbound'
+    }
+  }
+  {
+    name: 'AllowAzureLoadBalancerInbound'
+    properties: {
+      protocol: 'Tcp'
+      sourcePortRange: '*'
+      destinationPortRange: '443'
+      sourceAddressPrefix: 'AzureLoadBalancer'
+      destinationAddressPrefix: '*'
+      access: 'Allow'
+      priority: 110
+      direction: 'Inbound'
+    }
+  }
+  {
+    name: 'AllowBastionHostCommunicationInbound'
+    properties: {
+      protocol: '*'
+      sourcePortRange: '*'
+      destinationPortRanges: [
+        '8080'
+        '5701'
+      ]
+      sourceAddressPrefix: 'VirtualNetwork'
+      destinationAddressPrefix: 'VirtualNetwork'
+      access: 'Allow'
+      priority: 120
+      direction: 'Inbound'
+    }
+  }
+  {
+    name: 'DenyAllInternetInbound'
+    properties: {
+      protocol: '*'
+      sourcePortRange: '*'
+      destinationPortRange: '*'
+      sourceAddressPrefix: 'Internet'
+      destinationAddressPrefix: '*'
+      access: 'Deny'
+      priority: 4096
+      direction: 'Inbound'
+    }
+  }
+  // Outbound rules
+  {
+    name: 'AllowSshRdpOutbound'
+    properties: {
+      protocol: 'Tcp'
+      sourcePortRange: '*'
+      destinationPortRanges: [
+        '22'
+        '3389'
+      ]
+      sourceAddressPrefix: '*'
+      destinationAddressPrefix: 'VirtualNetwork'
+      access: 'Allow'
+      priority: 100
+      direction: 'Outbound'
+    }
+  }
+  {
+    name: 'AllowAzureCloudOutbound'
+    properties: {
+      protocol: 'Tcp'
+      sourcePortRange: '*'
+      destinationPortRange: '443'
+      sourceAddressPrefix: '*'
+      destinationAddressPrefix: 'AzureCloud'
+      access: 'Allow'
+      priority: 110
+      direction: 'Outbound'
+    }
+  }
+  {
+    name: 'AllowBastionHostCommunicationOutbound'
+    properties: {
+      protocol: '*'
+      sourcePortRange: '*'
+      destinationPortRanges: [
+        '8080'
+        '5701'
+      ]
+      sourceAddressPrefix: 'VirtualNetwork'
+      destinationAddressPrefix: 'VirtualNetwork'
+      access: 'Allow'
+      priority: 120
+      direction: 'Outbound'
+    }
+  }
+  {
+    name: 'AllowGetSessionInformationOutbound'
+    properties: {
+      protocol: '*'
+      sourcePortRange: '*'
+      destinationPortRange: '80'
+      sourceAddressPrefix: '*'
+      destinationAddressPrefix: 'Internet'
+      access: 'Allow'
+      priority: 130
+      direction: 'Outbound'
+    }
+  }
+]
+
+resource bastionNsg 'Microsoft.Network/networkSecurityGroups@2024-07-01' = {
+  name: name
+  location: location
+  properties: {
+    securityRules: concat(requiredRules, allowedSourceRules)
+  }
+}
+
+output id string = bastionNsg.id

--- a/modules/networking/subnet.bicep
+++ b/modules/networking/subnet.bicep
@@ -3,6 +3,7 @@ param addressPrefix string
 param delegations array = []
 param serviceEndpoints array = []
 param networkSecurityGroupId string = ''
+param routeTableId string = ''
 
 resource subnetsM 'Microsoft.Network/virtualNetworks/subnets@2024-07-01' = {
       name: name
@@ -12,6 +13,9 @@ resource subnetsM 'Microsoft.Network/virtualNetworks/subnets@2024-07-01' = {
         serviceEndpoints: serviceEndpoints
         networkSecurityGroup: empty(networkSecurityGroupId) ? null : {
           id: networkSecurityGroupId
+        }
+        routeTable: empty(routeTableId) ? null : {
+          id: routeTableId
         }
     }
   }

--- a/modules/networking/subnets.bicep
+++ b/modules/networking/subnets.bicep
@@ -36,7 +36,7 @@ module nsgsM 'network-security-group.bicep' = [
   }
 ]
 
-var invalidNsgSubnets = ['AzureBastionSubnet', 'AzureFirewallSubnet','AppGatewaySubnet']
+var invalidNsgSubnets = ['AzureFirewallSubnet','AppGatewaySubnet']
 
 @batchSize(1)
 module subnetsM 'subnet.bicep' = [
@@ -59,7 +59,10 @@ module subnetsM 'subnet.bicep' = [
             service : subnets[i].serviceEndpoints[0]
           }
         ]
-        networkSecurityGroupId: deployNsgs && !contains(invalidNsgSubnets, subnets[i].name) ? nsgsM[i].outputs.id : null
+        networkSecurityGroupId: !empty(subnets[i].?networkSecurityGroupResourceId ?? '')
+          ? string(subnets[i].networkSecurityGroupResourceId)
+          : (deployNsgs && !contains(invalidNsgSubnets, subnets[i].name) ? nsgsM[i]!.outputs.id : '')
+        routeTableId: string(subnets[i].?routeTableResourceId ?? '')
     }
   }
 ]


### PR DESCRIPTION
## Purpose

Harden the default network security posture of the landing zone by:

1. **Bastion NSG (Fixes #8)**: Deploy a dedicated NSG on the `AzureBastionSubnet` that denies all internet inbound on port 443 by default. Operators add trusted source IPs via the `bastionAllowedSourceIPs` parameter. All required Bastion control-plane rules (GatewayManager, AzureLoadBalancer, BastionHostCommunication) are included.

2. **Azure Firewall + UDR (Fixes #9)**: Deploy Azure Firewall with a Standard firewall policy and a route table that forces `0.0.0.0/0` egress through the firewall for workload subnets. Includes essential outbound FQDN rules (MCR, Entra ID) and wires diagnostics to Log Analytics.

Both features are enabled by default when network isolation is active — security hardened out of the box.

## Type of change

- [x] Feature

## Related Backlog Item or Issue

- Fixes #8 — Default Bastion NSG to restrict inbound access on port 443
- Fixes #9 — Default UDR with Azure Firewall for egress traffic control

## Code quality checklist

- [x] I verified the changes locally to ensure they work as expected
- [x] I tested the new functionality and ensured existing features still work
- [ ] I added at least one reviewer to this Pull Request