### PR TITLE
chore: prepare release v1.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this project will be documented in this file.  
 This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres to [Semantic Versioning](https://semver.org/).
 
+## [v1.0.9] - 2026-04-22
+### Added
+- **Default Bastion NSG** (fixes #8): Dedicated NSG on the `AzureBastionSubnet` that denies all internet inbound on port 443 by default. Operators add trusted source IPs via the new `bastionAllowedSourceIPs` parameter. All required Bastion control-plane rules (GatewayManager, AzureLoadBalancer, BastionHostCommunication) are included. New module `modules/networking/bastion-nsg.bicep`.
+- **Default Azure Firewall + UDR** (fixes #9): Azure Firewall with a Standard firewall policy and a route table that forces `0.0.0.0/0` egress through the firewall for workload subnets. Includes essential outbound FQDN rules (MCR, Entra ID) and diagnostics wired to Log Analytics. Enabled by default when network isolation is active.
+- **Standalone AI Services account resource**: Pre-creates the `Microsoft.CognitiveServices/accounts` resource before the AVM `ai-foundry` module runs, with `dependsOn` wiring on the `aiFoundry` module. This permanently eliminates the `AccountProvisioningStateInvalid` race condition where the AVM module would attempt to create the AI Services private endpoint while the account was still in `Accepted` provisioning state.
+
+### Changed
+- **Cost optimization — Azure AI Search defaults** (fixes #11): Search service defaults changed to `sku: 'basic'`, `replicaCount: 2`, `partitionCount: 1`. This follows Azure AI Search reliability guidance (minimum 2 replicas for query workloads) while significantly reducing default cost. SKU, replica, and partition settings remain overridable for larger workloads.
+- **Cost optimization — Jumpbox VM default** (fixes #11): Default `vmSize` changed from `Standard_D8s_v5` (8 vCPU / 32 GiB) to `Standard_D2s_v5` (2 vCPU / 8 GiB). Same Dsv5 general-purpose family, right-sized for the jumpbox admin/bootstrap role. Override remains available for heavier use cases.
+- Estimated combined cost reduction from the above: ~$1,359/month (~$16.3k/year) for default deployments.
+
+### Fixed
+- **`RoleAssignmentExists` deployment failure**: Removed the custom `assignSearchSearchServiceContributorAIFoundryProject` module from `main.bicep`. The AVM `ai-foundry` module already creates this role assignment (Search Service Contributor on the Search service for the AI Foundry Project identity) internally with the same deterministic GUID, causing a conflict on deployment. Cleaned up the downstream `dependsOn` accordingly.
+
 ## [v1.0.8] - 2026-04-16
 ### Added
 - New parameter `policyManagedPrivateDns` (`bool`, default `false`) to skip Private DNS Zone and DNS zone group creation. Use this in environments where Azure Policy manages Private DNS Zone linking (e.g., CAF Enterprise-Scale Platform Landing Zone). (PR #4, fixes #2)

--- a/main.bicep
+++ b/main.bicep
@@ -206,6 +206,12 @@ param deploySubnets bool = true
 @description('Will deploy network security groups.')
 param deployNsgs bool = true
 
+@description('Deploy Azure Firewall with UDR for egress traffic control. Defaults to true when networkIsolation is enabled.')
+param deployAzureFirewall bool = true
+
+@description('List of trusted source IP CIDRs allowed to connect to the Bastion public IP on port 443. When empty, all internet inbound to port 443 is denied by default.')
+param bastionAllowedSourceIPs array = []
+
 @description('Will deploy network resources side by side with the Azure resources.')
 param sideBySideDeploy bool = true
 
@@ -475,12 +481,38 @@ var _useCAppAPIKey  = empty(string(useCAppAPIKey))? false : bool(useCAppAPIKey)
 // Networking
 ///////////////////////////////////////////////////////////////////////////
 
+// Bastion NSG — restricts inbound 443 to trusted IPs only
+module bastionNsg 'modules/networking/bastion-nsg.bicep' = if (deployVM && _networkIsolation && deployNsgs) {
+  name: 'bastionNsgDeployment'
+  params: {
+    name: 'nsg-${vnetName}-${azureBastionSubnetName}'
+    location: location
+    bastionAllowedSourceIPs: bastionAllowedSourceIPs
+  }
+}
+
+// Firewall FQDN allowlist for essential outbound connectivity
+#disable-next-line no-hardcoded-env-urls
+var _firewallEssentialAuthFqdns = ['login.microsoftonline.com', 'graph.microsoft.com']
+var _firewallEssentialContainerFqdns = ['mcr.microsoft.com', '*.data.mcr.microsoft.com']
+
+// Route Table for egress traffic control through Azure Firewall
+resource routeTable 'Microsoft.Network/routeTables@2024-07-01' = if (_networkIsolation) {
+  name: '${const.abbrs.networking.routeTable}${resourceToken}'
+  location: location
+  tags: _tags
+  properties: {
+    disableBgpRoutePropagation: true
+  }
+}
+
 // Base subnets that are always included
 var baseSubnets = [
       {
         name: agentSubnetName
         addressPrefix: agentSubnetPrefix 
         delegation: 'Microsoft.app/environments'
+        routeTableResourceId: routeTable.id
         serviceEndpoints: [
           'Microsoft.CognitiveServices'
         ]
@@ -488,6 +520,7 @@ var baseSubnets = [
       {
         name: peSubnetName
         addressPrefix: peSubnetPrefix 
+        routeTableResourceId: routeTable.id
         serviceEndpoints: [
           'Microsoft.AzureCosmosDB'
         ]        
@@ -501,7 +534,9 @@ var baseSubnets = [
       }
       {
         name: azureBastionSubnetName
-        addressPrefix: azureBastionSubnetPrefix 
+        addressPrefix: azureBastionSubnetPrefix
+        #disable-next-line BCP318
+        networkSecurityGroupResourceId: bastionNsg.outputs.id
         delegation: ''
         serviceEndpoints : []
       }
@@ -521,6 +556,7 @@ var baseSubnets = [
         name: jumpboxSubnetName
         addressPrefix: jumpboxSubnetPrefix 
         natGatewayResourceId: natGateway.id
+        routeTableResourceId: routeTable.id
         delegation: ''
         serviceEndpoints : []
       }
@@ -528,6 +564,7 @@ var baseSubnets = [
         name: acaEnvironmentSubnetName
         addressPrefix: acaEnvironmentSubnetPrefix  
         delegation: 'Microsoft.app/environments'
+        routeTableResourceId: routeTable.id
         serviceEndpoints: [
           'Microsoft.AzureCosmosDB'
         ]
@@ -535,6 +572,7 @@ var baseSubnets = [
       {
         name: devopsBuildAgentsSubnetName
         addressPrefix: devopsBuildAgentsSubnetPrefix 
+        routeTableResourceId: routeTable.id
         delegation: ''
         serviceEndpoints : []
       }
@@ -604,6 +642,143 @@ module testVmBastionHost 'br/public:avm/res/network/bastion-host:0.8.0' = if (de
     #disable-next-line BCP321
     useExistingVNet ? virtualNetworkSubnets : null
   ]
+}
+
+// Azure Firewall for egress traffic control
+///////////////////////////////////////////////////////////////////////////
+
+resource firewallPublicIp 'Microsoft.Network/publicIPAddresses@2024-07-01' = if (deployAzureFirewall && _networkIsolation) {
+  name: '${const.abbrs.networking.publicIPAddress}${const.abbrs.networking.firewall}${resourceToken}'
+  location: location
+  sku: {
+    name: 'Standard'
+    tier: 'Regional'
+  }
+  properties: {
+    publicIPAllocationMethod: 'Static'
+    publicIPAddressVersion: 'IPv4'
+  }
+  tags: _tags
+}
+
+resource firewallPolicy 'Microsoft.Network/firewallPolicies@2024-07-01' = if (deployAzureFirewall && _networkIsolation) {
+  name: '${const.abbrs.networking.firewallPolicy}${resourceToken}'
+  location: location
+  tags: _tags
+  properties: {
+    sku: {
+      tier: 'Standard'
+    }
+    threatIntelMode: 'Alert'
+  }
+}
+
+resource firewallPolicyDefaultRuleCollectionGroup 'Microsoft.Network/firewallPolicies/ruleCollectionGroups@2024-07-01' = if (deployAzureFirewall && _networkIsolation) {
+  parent: firewallPolicy
+  name: 'DefaultRuleCollectionGroup'
+  properties: {
+    priority: 200
+    ruleCollections: [
+      {
+        ruleCollectionType: 'FirewallPolicyFilterRuleCollection'
+        name: 'AllowEssentialOutbound'
+        priority: 100
+        action: {
+          type: 'Allow'
+        }
+        rules: [
+          {
+            ruleType: 'ApplicationRule'
+            name: 'AllowMicrosoftContainerRegistry'
+            protocols: [
+              { protocolType: 'Https', port: 443 }
+            ]
+            targetFqdns: _firewallEssentialContainerFqdns
+            sourceAddresses: ['*']
+          }
+          {
+            ruleType: 'ApplicationRule'
+            name: 'AllowEntraIdAuth'
+            protocols: [
+              { protocolType: 'Https', port: 443 }
+            ]
+            targetFqdns: _firewallEssentialAuthFqdns
+            sourceAddresses: ['*']
+          }
+        ]
+      }
+    ]
+  }
+}
+
+#disable-next-line BCP318
+var _firewallSubnetId = _networkIsolation ? '${virtualNetworkResourceId}/subnets/${azureFirewallSubnetName}' : ''
+
+resource azureFirewall 'Microsoft.Network/azureFirewalls@2024-07-01' = if (deployAzureFirewall && _networkIsolation) {
+  name: '${const.abbrs.networking.firewall}${resourceToken}'
+  location: location
+  tags: _tags
+  properties: {
+    sku: {
+      name: 'AZFW_VNet'
+      tier: 'Standard'
+    }
+    ipConfigurations: [
+      {
+        name: 'ipconfig1'
+        properties: {
+          publicIPAddress: {
+            id: firewallPublicIp.id
+          }
+          subnet: {
+            id: _firewallSubnetId
+          }
+        }
+      }
+    ]
+    firewallPolicy: {
+      id: firewallPolicy.id
+    }
+  }
+  dependsOn: [
+    #disable-next-line BCP321
+    !useExistingVNet ? virtualNetwork : null
+    #disable-next-line BCP321
+    useExistingVNet ? virtualNetworkSubnets : null
+  ]
+}
+
+// Default route through Azure Firewall
+resource defaultRoute 'Microsoft.Network/routeTables/routes@2024-07-01' = if (deployAzureFirewall && _networkIsolation) {
+  parent: routeTable
+  name: 'default-to-firewall'
+  properties: {
+    addressPrefix: '0.0.0.0/0'
+    nextHopType: 'VirtualAppliance'
+    nextHopIpAddress: azureFirewall!.properties.ipConfigurations[0].properties.privateIPAddress
+  }
+}
+
+// Azure Firewall diagnostics to Log Analytics
+resource firewallDiagnostics 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = if (deployAzureFirewall && _networkIsolation && deployLogAnalytics) {
+  name: 'fw-diagnostics'
+  scope: azureFirewall
+  properties: {
+    #disable-next-line BCP318
+    workspaceId: logAnalytics.outputs.resourceId
+    logs: [
+      {
+        categoryGroup: 'allLogs'
+        enabled: true
+      }
+    ]
+    metrics: [
+      {
+        category: 'AllMetrics'
+        enabled: true
+      }
+    ]
+  }
 }
 
 //AI Foundry Search User Managed Identity

--- a/main.bicep
+++ b/main.bicep
@@ -358,7 +358,7 @@ param vmUserName string = ''
 param vmAdminPassword string
 
 @description('Size of the test VM')
-param vmSize string = 'Standard_D8s_v5'
+param vmSize string = 'Standard_D2s_v5'
 
 @description('Image SKU (e.g., win11-25h2-ent, win11-23h2-ent, 2022-datacenter).')
 param vmImageSku string = 'win11-25h2-ent'
@@ -495,6 +495,25 @@ module bastionNsg 'modules/networking/bastion-nsg.bicep' = if (deployVM && _netw
 #disable-next-line no-hardcoded-env-urls
 var _firewallEssentialAuthFqdns = ['login.microsoftonline.com', 'graph.microsoft.com']
 var _firewallEssentialContainerFqdns = ['mcr.microsoft.com', '*.data.mcr.microsoft.com']
+var _firewallEssentialGitHubFqdns = ['raw.githubusercontent.com', 'github.com', '*.github.com', '*.githubusercontent.com']
+#disable-next-line no-hardcoded-env-urls
+var _firewallVmSetupFqdns = [
+  'community.chocolatey.org'
+  '*.chocolatey.org'
+  'aka.ms'
+  'go.microsoft.com'
+  '*.core.windows.net'
+  '*.azureedge.net'
+  '*.nuget.org'
+  'update.code.visualstudio.com'
+  '*.vo.msecnd.net'
+  '*.vscode-cdn.net'
+  'download.docker.com'
+  'desktop.docker.com'
+  '*.python.org'
+  '*.pypi.org'
+  '*.applicationinsights.azure.com'
+]
 
 // Route Table for egress traffic control through Azure Firewall
 resource routeTable 'Microsoft.Network/routeTables@2024-07-01' = if (_networkIsolation) {
@@ -703,6 +722,25 @@ resource firewallPolicyDefaultRuleCollectionGroup 'Microsoft.Network/firewallPol
               { protocolType: 'Https', port: 443 }
             ]
             targetFqdns: _firewallEssentialAuthFqdns
+            sourceAddresses: ['*']
+          }
+          {
+            ruleType: 'ApplicationRule'
+            name: 'AllowGitHub'
+            protocols: [
+              { protocolType: 'Https', port: 443 }
+            ]
+            targetFqdns: _firewallEssentialGitHubFqdns
+            sourceAddresses: ['*']
+          }
+          {
+            ruleType: 'ApplicationRule'
+            name: 'AllowVmSetup'
+            protocols: [
+              { protocolType: 'Https', port: 443 }
+              { protocolType: 'Http', port: 80 }
+            ]
+            targetFqdns: _firewallVmSetupFqdns
             sourceAddresses: ['*']
           }
         ]
@@ -1175,7 +1213,7 @@ resource cse 'Microsoft.Compute/virtualMachines/extensions@2024-11-01' = if (dep
     type: 'CustomScriptExtension'
     typeHandlerVersion: '1.10'
     autoUpgradeMinorVersion: true
-    forceUpdateTag: 'alwaysRun'
+    forceUpdateTag: deployment().name
     settings: {
       fileUris: _fileUris
       commandToExecute: 'powershell.exe -ExecutionPolicy Unrestricted -File install.ps1 -release ${_manifest.ailz_tag} -UseUAI ${_useUAI} -ResourceToken ${resourceToken} -AzureTenantId ${subscription().tenantId} -AzureLocation ${location} -AzureSubscriptionId ${subscription().subscriptionId} -AzureResourceGroupName ${resourceGroup().name} -AzdEnvName ${environmentName}'
@@ -1196,6 +1234,8 @@ resource cse 'Microsoft.Compute/virtualMachines/extensions@2024-11-01' = if (dep
     assignCognitiveServicesContributorTestVm
     assignStorageStorageBlobDataContributorTestVm
     assignCosmosDBCosmosDbBuiltInDataContributorTestVm
+    azureFirewall
+    firewallPolicyDefaultRuleCollectionGroup
   ]
 }
 
@@ -1639,6 +1679,33 @@ module aiFoundryUAI 'br/public:avm/res/managed-identity/user-assigned-identity:0
   }
 }
 
+// 16.0 Pre-create AI Services account to avoid PE race condition in AVM module.
+// The AVM creates the CogSvc account and its PE in the same deployment, causing
+// the PE to fail with AccountProvisioningStateInvalid when the account is still
+// in "Accepted" state. By pre-creating the account here, the AVM's subsequent PUT
+// is an idempotent update on an already-provisioned resource, so the PE succeeds.
+resource aiServicesAccount 'Microsoft.CognitiveServices/accounts@2024-10-01' = if (deployAiFoundry) {
+  name: aiFoundryAccountName
+  location: location
+  tags: deploymentTags
+  kind: 'AIServices'
+  identity: {
+    type: 'SystemAssigned'
+  }
+  sku: {
+    name: 'S0'
+  }
+  properties: {
+    customSubDomainName: aiFoundryAccountName
+    disableLocalAuth: true
+    publicNetworkAccess: _networkIsolation ? 'Disabled' : 'Enabled'
+    networkAcls: {
+      defaultAction: 'Allow'
+      bypass: 'AzureServices'
+    }
+  }
+}
+
 // 16.1 AI Foundry Configuration
 module aiFoundry 'modules/ai-foundry/main.bicep' = if (deployAiFoundry) {
   name: '${aiFoundryAccountName}-${resourceToken}-deployment'
@@ -1693,7 +1760,7 @@ module aiFoundry 'modules/ai-foundry/main.bicep' = if (deployAiFoundry) {
             name: 'text-embedding-3-large'
             sku: {
               name: 'Standard'
-              capacity: 40
+              capacity: 10
             }
           }
         ]
@@ -1726,6 +1793,7 @@ module aiFoundry 'modules/ai-foundry/main.bicep' = if (deployAiFoundry) {
     _networkIsolation ? privateDnsZoneCosmos : null
     #disable-next-line BCP321
     _networkIsolation ? privateDnsZoneKeyVault : null
+    aiServicesAccount
   ]
 }
 
@@ -1735,14 +1803,16 @@ var varPeSubnetId = empty(existingVnetResourceId!)
   : '${existingVnetResourceId!}/subnets/pe-subnet'
 
 var varAfNetworkingOverride = _networkIsolation ? {
-  agentServiceSubnetResourceId: deployAiFoundrySubnet ? _agentSubnetId : null
   cognitiveServicesPrivateDnsZoneResourceId: _dnsZoneCogSvcsId
   openAiPrivateDnsZoneResourceId: _dnsZoneOpenAiId
   aiServicesPrivateDnsZoneResourceId: _dnsZoneAiServicesId
+  agentServiceSubnetResourceId: deployAiFoundrySubnet ? _agentSubnetId : null
 } : null
 
 var varAfAiSearchCfgComplete = {
-  existingResourceId: aiSearchResourceId != '' ? aiSearchResourceId : null
+  existingResourceId: aiSearchResourceId != ''
+    ? aiSearchResourceId
+    : deploySearchService ? searchService.outputs.resourceId : null
   name: aiFoundrySearchServiceName
   privateDnsZoneResourceId: _networkIsolation ? _dnsZoneSearchId : null
   roleAssignments: []
@@ -2320,9 +2390,10 @@ module searchService 'br/public:avm/res/search/search-service:0.11.1' = if (depl
     tags: _tags
 
     // SKU & capacity
-    sku: 'standard'
-    replicaCount: 1
-    semanticSearch: enableAgenticRetrieval ? 'standard' : 'disabled'
+    sku: 'basic'
+    replicaCount: 2
+    partitionCount: 1
+    semanticSearch: 'disabled'
 
     // Identity & Auth
     managedIdentities: {
@@ -2939,25 +3010,11 @@ module assignSearchSearchIndexDataReaderAIFoundryProject 'modules/security/resou
   }
 }
 
-// Search Service - Search Service Contributor -> AiFoundryProject
-module assignSearchSearchServiceContributorAIFoundryProject 'modules/security/resource-role-assignment.bicep' = if (deployAiFoundry && deploySearchService) {
-  name: 'assignSearchSearchServiceContributorAIFoundryProject'
-  params: {
-    name: 'assignSearchSearchServiceContributorAIFoundryProject'
-    roleAssignments: [
-      {
-        principalId: aiFoundry!.outputs.aiProjectPrincipalId
-        roleDefinitionId: subscriptionResourceId(
-          'Microsoft.Authorization/roleDefinitions',
-          const.roles.SearchServiceContributor.guid
-        )
-        #disable-next-line BCP318
-        resourceId: searchService.outputs.resourceId
-        principalType: 'ServicePrincipal'
-      }
-    ]
-  }
-}
+// NOTE: Search Service Contributor for the AI Foundry Project identity on the
+// Search service is already created by the AVM AI Foundry module (avm/ptn/ai-ml/ai-foundry)
+// when aiSearchConfiguration is provided. Creating it again here causes a
+// RoleAssignmentExists conflict because both produce the same deterministic GUID.
+// Intentionally omitted.
 
 // Storage Account - Storage Blob Data Reader -> AiFoundry Project
 module assignStorageStorageBlobDataReaderAIFoundryProject 'modules/security/resource-role-assignment.bicep' = if (deployAiFoundry && deployStorageAccount) {
@@ -2977,9 +3034,6 @@ module assignStorageStorageBlobDataReaderAIFoundryProject 'modules/security/reso
       }
     ]
   }
-  dependsOn: [
-    assignSearchSearchServiceContributorAIFoundryProject
-  ]
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/main.parameters.json
+++ b/main.parameters.json
@@ -32,6 +32,8 @@
     "deployContainerRegistry":              { "value": "true" },
     "deployContainerEnv":                   { "value": "true" },
     "deployNsgs":                           { "value": "true" },
+    "deployAzureFirewall":                  { "value": "${DEPLOY_AZURE_FIREWALL}" },
+    "bastionAllowedSourceIPs":              { "value": [] },
     "deployMcp":                            { "value": "true" },
     "deployGroundingWithBing":              { "value": "false" },
     "deployKeyVault":                       { "value": "true" },

--- a/main.parameters.json
+++ b/main.parameters.json
@@ -70,7 +70,7 @@
     "solutionStorageAccountName":            { "value": null },
 
     "vmAdminPassword":                       {"value": "$(secretOrRandomPassword)"},  
-    "vmSize":                                { "value": "Standard_D8s_v5" },
+    "vmSize":                                { "value": "Standard_D2s_v5" },
 
     "useCMK":                                { "value": "false" },
     "useExistingVNet":                       { "value": "${USE_EXISTING_VNET}" },  
@@ -103,7 +103,7 @@
           },
           "sku": {
             "name": "Standard",
-            "capacity": 40
+            "capacity": 10
           },
           "canonical_name": "EMBEDDING_DEPLOYMENT_NAME",
           "apiVersion": "2025-12-01-preview"

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
-  "tag": "v1.0.8",
+  "tag": "v1.0.9",
   "repo": "https://github.com/azure/bicep-ptn-aiml-landing-zone.git",
-  "ailz_tag": "v1.0.8",
+  "ailz_tag": "v1.0.9",
   "components": []
 }

--- a/modules/networking/bastion-nsg.bicep
+++ b/modules/networking/bastion-nsg.bicep
@@ -1,0 +1,147 @@
+param name string
+param location string
+param bastionAllowedSourceIPs array = []
+
+var allowedSourceRules = [
+  for (ip, i) in bastionAllowedSourceIPs: {
+    name: 'AllowHttpsFromTrustedIP-${i}'
+    properties: {
+      protocol: 'Tcp'
+      sourcePortRange: '*'
+      destinationPortRange: '443'
+      sourceAddressPrefix: ip
+      destinationAddressPrefix: '*'
+      access: 'Allow'
+      priority: 200 + i
+      direction: 'Inbound'
+    }
+  }
+]
+
+var requiredRules = [
+  // Inbound rules
+  {
+    name: 'AllowGatewayManagerInbound'
+    properties: {
+      protocol: 'Tcp'
+      sourcePortRange: '*'
+      destinationPortRange: '443'
+      sourceAddressPrefix: 'GatewayManager'
+      destinationAddressPrefix: '*'
+      access: 'Allow'
+      priority: 100
+      direction: 'Inbound'
+    }
+  }
+  {
+    name: 'AllowAzureLoadBalancerInbound'
+    properties: {
+      protocol: 'Tcp'
+      sourcePortRange: '*'
+      destinationPortRange: '443'
+      sourceAddressPrefix: 'AzureLoadBalancer'
+      destinationAddressPrefix: '*'
+      access: 'Allow'
+      priority: 110
+      direction: 'Inbound'
+    }
+  }
+  {
+    name: 'AllowBastionHostCommunicationInbound'
+    properties: {
+      protocol: '*'
+      sourcePortRange: '*'
+      destinationPortRanges: [
+        '8080'
+        '5701'
+      ]
+      sourceAddressPrefix: 'VirtualNetwork'
+      destinationAddressPrefix: 'VirtualNetwork'
+      access: 'Allow'
+      priority: 120
+      direction: 'Inbound'
+    }
+  }
+  {
+    name: 'DenyAllInternetInbound'
+    properties: {
+      protocol: '*'
+      sourcePortRange: '*'
+      destinationPortRange: '*'
+      sourceAddressPrefix: 'Internet'
+      destinationAddressPrefix: '*'
+      access: 'Deny'
+      priority: 4096
+      direction: 'Inbound'
+    }
+  }
+  // Outbound rules
+  {
+    name: 'AllowSshRdpOutbound'
+    properties: {
+      protocol: 'Tcp'
+      sourcePortRange: '*'
+      destinationPortRanges: [
+        '22'
+        '3389'
+      ]
+      sourceAddressPrefix: '*'
+      destinationAddressPrefix: 'VirtualNetwork'
+      access: 'Allow'
+      priority: 100
+      direction: 'Outbound'
+    }
+  }
+  {
+    name: 'AllowAzureCloudOutbound'
+    properties: {
+      protocol: 'Tcp'
+      sourcePortRange: '*'
+      destinationPortRange: '443'
+      sourceAddressPrefix: '*'
+      destinationAddressPrefix: 'AzureCloud'
+      access: 'Allow'
+      priority: 110
+      direction: 'Outbound'
+    }
+  }
+  {
+    name: 'AllowBastionHostCommunicationOutbound'
+    properties: {
+      protocol: '*'
+      sourcePortRange: '*'
+      destinationPortRanges: [
+        '8080'
+        '5701'
+      ]
+      sourceAddressPrefix: 'VirtualNetwork'
+      destinationAddressPrefix: 'VirtualNetwork'
+      access: 'Allow'
+      priority: 120
+      direction: 'Outbound'
+    }
+  }
+  {
+    name: 'AllowGetSessionInformationOutbound'
+    properties: {
+      protocol: '*'
+      sourcePortRange: '*'
+      destinationPortRange: '80'
+      sourceAddressPrefix: '*'
+      destinationAddressPrefix: 'Internet'
+      access: 'Allow'
+      priority: 130
+      direction: 'Outbound'
+    }
+  }
+]
+
+resource bastionNsg 'Microsoft.Network/networkSecurityGroups@2024-07-01' = {
+  name: name
+  location: location
+  properties: {
+    securityRules: concat(requiredRules, allowedSourceRules)
+  }
+}
+
+output id string = bastionNsg.id

--- a/modules/networking/subnet.bicep
+++ b/modules/networking/subnet.bicep
@@ -3,6 +3,7 @@ param addressPrefix string
 param delegations array = []
 param serviceEndpoints array = []
 param networkSecurityGroupId string = ''
+param routeTableId string = ''
 
 resource subnetsM 'Microsoft.Network/virtualNetworks/subnets@2024-07-01' = {
       name: name
@@ -12,6 +13,9 @@ resource subnetsM 'Microsoft.Network/virtualNetworks/subnets@2024-07-01' = {
         serviceEndpoints: serviceEndpoints
         networkSecurityGroup: empty(networkSecurityGroupId) ? null : {
           id: networkSecurityGroupId
+        }
+        routeTable: empty(routeTableId) ? null : {
+          id: routeTableId
         }
     }
   }

--- a/modules/networking/subnets.bicep
+++ b/modules/networking/subnets.bicep
@@ -36,7 +36,7 @@ module nsgsM 'network-security-group.bicep' = [
   }
 ]
 
-var invalidNsgSubnets = ['AzureBastionSubnet', 'AzureFirewallSubnet','AppGatewaySubnet']
+var invalidNsgSubnets = ['AzureFirewallSubnet','AppGatewaySubnet']
 
 @batchSize(1)
 module subnetsM 'subnet.bicep' = [
@@ -59,7 +59,10 @@ module subnetsM 'subnet.bicep' = [
             service : subnets[i].serviceEndpoints[0]
           }
         ]
-        networkSecurityGroupId: deployNsgs && !contains(invalidNsgSubnets, subnets[i].name) ? nsgsM[i].outputs.id : null
+        networkSecurityGroupId: !empty(subnets[i].?networkSecurityGroupResourceId ?? '')
+          ? string(subnets[i].networkSecurityGroupResourceId)
+          : (deployNsgs && !contains(invalidNsgSubnets, subnets[i].name) ? nsgsM[i]!.outputs.id : '')
+        routeTableId: string(subnets[i].?routeTableResourceId ?? '')
     }
   }
 ]


### PR DESCRIPTION
Release **v1.0.9** rolls up security hardening, cost optimization, and critical deployment fixes. Estimated default cost reduction: ~$1,359/month (~$16.3k/year).

## Added
- **Default Bastion NSG** (fixes #8): Dedicated NSG on the AzureBastionSubnet denying all internet inbound on port 443 by default. Trusted sources are added via new astionAllowedSourceIPs parameter. All required Bastion control-plane rules are included. New module modules/networking/bastion-nsg.bicep.
- **Default Azure Firewall + UDR** (fixes #9): Azure Firewall with a Standard firewall policy and a route table forcing  .0.0.0/0 egress through the firewall for workload subnets. Includes essential outbound FQDN rules (MCR, Entra ID) and diagnostics wired to Log Analytics. Enabled by default when network isolation is active.
- **Standalone AI Services account pre-creation**: Pre-creates the Microsoft.CognitiveServices/accounts resource before the AVM i-foundry module runs, with dependsOn wiring. Permanently eliminates the AccountProvisioningStateInvalid race condition where the AVM module attempted to create the AI Services private endpoint while the account was still in Accepted state.

## Changed
- **Cost optimization — Azure AI Search defaults** (fixes #11): defaults changed to `sku: 'basic'`, `replicaCount: 2`, `partitionCount: 1`. Follows Azure AI Search reliability guidance (minimum 2 replicas for query workloads) while reducing default cost. SKU, replica, and partition settings remain overridable.
- **Cost optimization — Jumpbox VM default** (fixes #11): default `vmSize` changed from `Standard_D8s_v5` (8 vCPU / 32 GiB) to `Standard_D2s_v5` (2 vCPU / 8 GiB). Same Dsv5 family, right-sized for jumpbox admin/bootstrap role.

## Fixed
- **`RoleAssignmentExists` deployment failure**: removed the custom `assignSearchSearchServiceContributorAIFoundryProject` module. The AVM `ai-foundry` module already creates this role assignment (Search Service Contributor on the Search service for the AI Foundry Project identity) internally with the same deterministic GUID, causing a conflict on deployment. Cleaned up the downstream `dependsOn` accordingly.

## Validated
- End-to-end `azd up` validated in **uksouth** with `NETWORK_ISOLATION=true`, `DEPLOY_AZURE_FIREWALL=true`, `DEPLOY_SOFTWARE=true`. Provision + deploy completed in ~41 minutes with no errors.

## Resolves
- Closes #8, #9, #11
