### PR TITLE
Feat/storage

### DIFF
--- a/main.bicep
+++ b/main.bicep
@@ -262,6 +262,19 @@ param aiSearchResourceId string = ''
 @description('The AI Storage Account full ARM resource ID. Optional; if not provided, a new resource will be created.')
 param aiFoundryStorageAccountResourceId string = ''
 
+@description('The SKU name for the AI Foundry Storage Account. Only used when a new account is created (aiFoundryStorageAccountResourceId is empty). The AVM ai-foundry module does not expose this, so we pre-create the storage account with the requested SKU. Defaults to Standard_LRS for broad regional availability (some regions, e.g. Poland Central, do not support the AVM default Standard_GRS).')
+@allowed([
+  'Standard_LRS'
+  'Standard_GRS'
+  'Standard_RAGRS'
+  'Standard_ZRS'
+  'Standard_GZRS'
+  'Standard_RAGZRS'
+  'Premium_LRS'
+  'Premium_ZRS'
+])
+param aiFoundryStorageSku string = 'Standard_LRS'
+
 @description('The Cosmos DB account full ARM resource ID. Optional; if not provided, a new resource will be created.')
 param aiFoundryCosmosDBAccountResourceId string = ''
 
@@ -1461,6 +1474,33 @@ resource aiServicesAccount 'Microsoft.CognitiveServices/accounts@2024-10-01' = i
   }
 }
 
+// Pre-create AI Foundry Storage Account with a region-safe SKU.
+// The AVM ai-foundry module (<= 0.6.0) creates its Storage Account with the
+// provider default `Standard_GRS`, which is not offered in every region
+// (e.g. Poland Central -> RedundancyConfigurationNotAvailableInRegion).
+// Creating it ourselves and passing the resource ID as `existingResourceId`
+// lets us honor an explicit SKU (default `Standard_LRS`).
+module aiFoundryStorageAccount 'modules/ai-foundry/storage-account.bicep' = if (deployAiFoundry && aiFoundryStorageAccountResourceId == '') {
+  name: 'aiFoundryStorage-${resourceToken}-deployment'
+  params: {
+    name: aiFoundryStorageAccountName
+    location: location
+    tags: _tags
+    skuName: aiFoundryStorageSku
+    disablePublicNetworkAccess: _networkIsolation
+    privateEndpointSubnetResourceId: _networkIsolation ? _peSubnetId : ''
+    blobPrivateDnsZoneResourceId: _networkIsolation ? _dnsZoneBlobId : ''
+  }
+  dependsOn: [
+    #disable-next-line BCP321
+    (_networkIsolation && !useExistingVNet) ? virtualNetwork : null
+    #disable-next-line BCP321
+    (_networkIsolation && useExistingVNet && deploySubnets) ? virtualNetworkSubnets : null
+    #disable-next-line BCP321
+    _networkIsolation ? privateDnsZones : null
+  ]
+}
+
 // 16.1 AI Foundry Configuration
 module aiFoundry 'modules/ai-foundry/main.bicep' = if (deployAiFoundry) {
   name: '${aiFoundryAccountName}-${resourceToken}-deployment'
@@ -1537,6 +1577,8 @@ module aiFoundry 'modules/ai-foundry/main.bicep' = if (deployAiFoundry) {
     #disable-next-line BCP321
     _networkIsolation ? privateDnsZones : null
     aiServicesAccount
+    #disable-next-line BCP321
+    (aiFoundryStorageAccountResourceId == '') ? aiFoundryStorageAccount : null
   ]
 }
 
@@ -1575,8 +1617,15 @@ var varAfKVCfgComplete = {
   roleAssignments: []
 }
 
+// NOTE: The AVM ai-foundry `storageAccountConfigurationType` does not expose
+// a `skuName` field. We instead pre-create the Storage Account in
+// `aiFoundryStorageAccount` above with the requested SKU and pass its
+// resource ID here as `existingResourceId`, which causes the AVM to skip
+// internal storage creation (and its default `Standard_GRS`).
 var varAfStorageCfgComplete = {
-  existingResourceId: aiFoundryStorageAccountResourceId != '' ? aiFoundryStorageAccountResourceId : null
+  existingResourceId: aiFoundryStorageAccountResourceId != ''
+    ? aiFoundryStorageAccountResourceId
+    : (deployAiFoundry ? aiFoundryStorageAccount.outputs.resourceId : null)
   name: aiFoundryStorageAccountName
   blobPrivateDnsZoneResourceId: _networkIsolation ? _dnsZoneBlobId : null
   roleAssignments: []

--- a/main.parameters.json
+++ b/main.parameters.json
@@ -52,6 +52,7 @@
     "aiFoundryProjectDisplayName":           { "value": null },
     "aiFoundryProjectDescription":           { "value": null },    
     "aiFoundryStorageAccountName":           { "value": null },
+    "aiFoundryStorageSku":                 { "value": "Standard_LRS" },
     "aiFoundrySearchServiceName":            { "value": null },
     "aiFoundryCosmosDbName":                 { "value": null },
     "bingSearchName":                        { "value": null },  

--- a/modules/ai-foundry/storage-account.bicep
+++ b/modules/ai-foundry/storage-account.bicep
@@ -1,0 +1,104 @@
+// ============================================================================
+// AI Foundry Storage Account Helper Module
+// ----------------------------------------------------------------------------
+// Creates a Standard_LRS (or caller-chosen SKU) Storage Account that can be
+// fed back into the AVM `avm/ptn/ai-ml/ai-foundry` module via its
+// `storageAccountConfiguration.existingResourceId` input.
+//
+// Why this exists:
+//   The AVM ai-foundry pattern (<= v0.6.0) does NOT expose a `skuName` on its
+//   `storageAccountConfiguration` and internally creates the Storage Account
+//   with the provider default (`Standard_GRS`). That fails in regions where
+//   GRS is not offered (e.g. Poland Central) with
+//   `RedundancyConfigurationNotAvailableInRegion`.
+//
+//   By pre-creating the account here with `Standard_LRS` and handing its
+//   resource ID to the AVM as an existing resource, we honor the requested
+//   SKU and unblock deployments in GRS-restricted regions.
+// ============================================================================
+
+targetScope = 'resourceGroup'
+
+@description('Required. Name of the Storage Account. Must be globally unique, 3-24 lowercase alphanumeric characters.')
+@minLength(3)
+@maxLength(24)
+param name string
+
+@description('Optional. Location for the Storage Account.')
+param location string = resourceGroup().location
+
+@description('Optional. Tags to apply to the Storage Account.')
+param tags object = {}
+
+@description('Optional. Storage Account SKU. Defaults to Standard_LRS for broad regional availability.')
+@allowed([
+  'Standard_LRS'
+  'Standard_GRS'
+  'Standard_RAGRS'
+  'Standard_ZRS'
+  'Standard_GZRS'
+  'Standard_RAGZRS'
+  'Premium_LRS'
+  'Premium_ZRS'
+])
+param skuName string = 'Standard_LRS'
+
+@description('Optional. Disable public network access on the Storage Account.')
+param disablePublicNetworkAccess bool = false
+
+@description('Optional. Subnet resource ID for the blob private endpoint. When empty, no private endpoint is created.')
+param privateEndpointSubnetResourceId string = ''
+
+@description('Optional. Private DNS zone resource ID for the blob private endpoint (privatelink.blob.<suffix>).')
+param blobPrivateDnsZoneResourceId string = ''
+
+@description('Optional. Enable telemetry via the Customer Usage Attribution ID.')
+param enableTelemetry bool = true
+
+// ---------------------------------------------------------------------
+// Storage Account
+// ---------------------------------------------------------------------
+module storageAccount 'br/public:avm/res/storage/storage-account:0.26.2' = {
+  name: 'aiFoundryStorage-${name}'
+  params: {
+    name: name
+    location: location
+    tags: tags
+    skuName: skuName
+    kind: 'StorageV2'
+    allowBlobPublicAccess: false
+    supportsHttpsTrafficOnly: true
+    publicNetworkAccess: disablePublicNetworkAccess ? 'Disabled' : 'Enabled'
+    networkAcls: {
+      bypass: 'AzureServices'
+      virtualNetworkRules: []
+      defaultAction: disablePublicNetworkAccess ? 'Deny' : 'Allow'
+    }
+    privateEndpoints: (!empty(privateEndpointSubnetResourceId) && !empty(blobPrivateDnsZoneResourceId))
+      ? [
+          {
+            name: 'pe-${name}-blob'
+            service: 'blob'
+            subnetResourceId: privateEndpointSubnetResourceId
+            privateDnsZoneGroup: {
+              privateDnsZoneGroupConfigs: [
+                {
+                  privateDnsZoneResourceId: blobPrivateDnsZoneResourceId
+                }
+              ]
+            }
+          }
+        ]
+      : []
+    enableTelemetry: enableTelemetry
+  }
+}
+
+// ---------------------------------------------------------------------
+// Outputs
+// ---------------------------------------------------------------------
+@description('The full ARM resource ID of the Storage Account.')
+output resourceId string = storageAccount.outputs.resourceId
+
+@description('The name of the Storage Account.')
+output name string = storageAccount.outputs.name


### PR DESCRIPTION
## Purpose

What
Adds a new aiFoundryStorageSku parameter (default Standard_LRS) that controls the SKU of the Storage Account associated with the AI Foundry account. Implemented by:

New helper module [storage-account.bicep](vscode-file://vscode-app/c:/Users/remcobrosky/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/f2b51f3f64/resources/app/out/vs/code/electron-browser/workbench/workbench.html) that pre-creates the Storage Account (via AVM avm/res/storage/storage-account) with the chosen SKU, plus an optional blob private endpoint when networkIsolation = true.
New conditional aiFoundryStorageAccount module instantiation in [main.bicep](vscode-file://vscode-app/c:/Users/remcobrosky/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/f2b51f3f64/resources/app/out/vs/code/electron-browser/workbench/workbench.html), gated on deployAiFoundry && aiFoundryStorageAccountResourceId == ''.
varAfStorageCfgComplete.existingResourceId falls back to the pre-created account so the AVM ai-foundry module skips its internal storage creation.
aiFoundryStorageSku added to [main.parameters.json](vscode-file://vscode-app/c:/Users/remcobrosky/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/f2b51f3f64/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
[main.json](vscode-file://vscode-app/c:/Users/remcobrosky/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/f2b51f3f64/resources/app/out/vs/code/electron-browser/workbench/workbench.html) recompiled.
Why
The AVM avm/ptn/ai-ml/ai-foundry pattern (≤ v0.6.0) does not expose skuName on its storageAccountConfiguration and hardcodes Standard_GRS for the Storage Account it creates. GRS is not offered in every region — most notably Poland Central — causing the entire deployment to fail with RedundancyConfigurationNotAvailableInRegion.

Pre-creating the account ourselves with a region-safe default (Standard_LRS) and handing its resource ID to AVM as existingResourceId unblocks deployments in GRS-restricted regions, while still letting operators pick any other supported SKU (Standard_ZRS, Premium_LRS, etc.) when needed.

Backward compatibility
Existing deployments that pass aiFoundryStorageAccountResourceId are unaffected.
For new accounts, the default SKU changes from Standard_GRS (AVM default) to Standard_LRS. This trades cross-region redundancy for guaranteed regional availability — appropriate for a workload-scoped AI Foundry storage account. Operators wanting GRS can set aiFoundryStorageSku: 'Standard_GRS'.
## Type of change 

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Documentation Link

If this change adds new functionality, provide a link to its documentation. Documentation should be updated in the `mkdocs` branch. NO SUCH BRANCHE EXISTS

## Code quality checklist

- [X] I verified the changes locally to ensure they work as expected
- [X] I tested the new functionality and ensured existing features still work
- [X] I added at least one reviewer to this Pull Request