### PR TITLE
fix: support policy-managed Private DNS in Hub & Spoke deployments

### DIFF
--- a/main.bicep
+++ b/main.bicep
@@ -1604,49 +1604,49 @@ module privateDnsZones 'modules/networking/private-dns-zones.bicep' = if (_deplo
 // Private Endpoints (consolidated into a single for-loop module with @batchSize(1) to keep compiled ARM template under 4 MB while preserving serialized PE creation).
 ///////////////////////////////////////////////////////////////////////////
 
-var _peDnsZoneGroupBlob = policyManagedPrivateDns ? {} : {
+var _peDnsZoneGroupBlob = policyManagedPrivateDns ? null : {
   name: 'blobDnsZoneGroup'
   privateDnsZoneGroupConfigs: [
     { name: 'blobARecord', privateDnsZoneResourceId: _dnsZoneBlobId }
   ]
 }
-var _peDnsZoneGroupCosmos = policyManagedPrivateDns ? {} : {
+var _peDnsZoneGroupCosmos = policyManagedPrivateDns ? null : {
   name: 'cosmosDnsZoneGroup'
   privateDnsZoneGroupConfigs: [
     { name: 'cosmosARecord', privateDnsZoneResourceId: _dnsZoneCosmosId }
   ]
 }
-var _peDnsZoneGroupSearch = policyManagedPrivateDns ? {} : {
+var _peDnsZoneGroupSearch = policyManagedPrivateDns ? null : {
   name: 'searchDnsZoneGroup'
   privateDnsZoneGroupConfigs: [
     { name: 'searchARecord', privateDnsZoneResourceId: _dnsZoneSearchId }
   ]
 }
-var _peDnsZoneGroupKeyVault = policyManagedPrivateDns ? {} : {
+var _peDnsZoneGroupKeyVault = policyManagedPrivateDns ? null : {
   name: 'kvDnsZoneGroup'
   privateDnsZoneGroupConfigs: [
     { name: 'kvARecord', privateDnsZoneResourceId: _dnsZoneKeyVaultId }
   ]
 }
-var _peDnsZoneGroupAppConfig = policyManagedPrivateDns ? {} : {
+var _peDnsZoneGroupAppConfig = policyManagedPrivateDns ? null : {
   name: 'appConfigDnsZoneGroup'
   privateDnsZoneGroupConfigs: [
     { name: 'appConfigARecord', privateDnsZoneResourceId: _dnsZoneAppConfigId }
   ]
 }
-var _peDnsZoneGroupContainerApps = policyManagedPrivateDns ? {} : {
+var _peDnsZoneGroupContainerApps = policyManagedPrivateDns ? null : {
   name: 'ccaDnsZoneGroup'
   privateDnsZoneGroupConfigs: [
     { name: 'ccaARecord', privateDnsZoneResourceId: _dnsZoneContainerAppsId }
   ]
 }
-var _peDnsZoneGroupAcr = policyManagedPrivateDns ? {} : {
+var _peDnsZoneGroupAcr = policyManagedPrivateDns ? null : {
   name: 'acrDnsZoneGroup'
   privateDnsZoneGroupConfigs: [
     { name: 'acr', privateDnsZoneResourceId: _dnsZoneAcrId }
   ]
 }
-var _peDnsZoneGroupCogSvcs = policyManagedPrivateDns ? {} : {
+var _peDnsZoneGroupCogSvcs = policyManagedPrivateDns ? null : {
   name: 'cogSvcsDnsZoneGroup'
   privateDnsZoneGroupConfigs: [
     { name: 'cogSvcsARecord', privateDnsZoneResourceId: _dnsZoneCogSvcsId }
@@ -1855,7 +1855,7 @@ module aiFoundryStorageAccount 'modules/ai-foundry/storage-account.bicep' = if (
     skuName: aiFoundryStorageSku
     disablePublicNetworkAccess: _networkIsolation
     privateEndpointSubnetResourceId: _networkIsolation ? _peSubnetId : ''
-    blobPrivateDnsZoneResourceId: _networkIsolation ? _dnsZoneBlobId : ''
+    blobPrivateDnsZoneResourceId: (_networkIsolation && !policyManagedPrivateDns) ? _dnsZoneBlobId : ''
   }
   dependsOn: [
     #disable-next-line BCP321
@@ -1863,8 +1863,7 @@ module aiFoundryStorageAccount 'modules/ai-foundry/storage-account.bicep' = if (
     #disable-next-line BCP321
     (_networkIsolation && useExistingVNet && deploySubnets) ? virtualNetworkSubnets : null
     #disable-next-line BCP321
-    _networkIsolation ? privateDnsZones : null
-    // Serialize PE creation against the shared `pe-subnet` (fixes #41). The aggregator
+    (_networkIsolation && !policyManagedPrivateDns) ? privateDnsZones : null
     // `privateEndpoints` module creates ~10 PEs against `pe-subnet` (already serialized
     // internally via @batchSize(1)). This module also creates an inline blob PE on the
     // same subnet via the AVM storage-account module's `privateEndpoints` parameter.
@@ -1970,33 +1969,39 @@ var varPeSubnetId = empty(existingVnetResourceId!)
   ? '${virtualNetworkResourceId}/subnets/pe-subnet'
   : '${existingVnetResourceId!}/subnets/pe-subnet'
 
-var varAfNetworkingOverride = _networkIsolation ? {
-  cognitiveServicesPrivateDnsZoneResourceId: _dnsZoneCogSvcsId
-  openAiPrivateDnsZoneResourceId: _dnsZoneOpenAiId
-  aiServicesPrivateDnsZoneResourceId: _dnsZoneAiServicesId
-  agentServiceSubnetResourceId: deployAiFoundrySubnet ? _agentSubnetId : null
-} : null
+var varAfNetworkingOverride = _networkIsolation
+  ? (policyManagedPrivateDns
+    ? {
+        agentServiceSubnetResourceId: deployAiFoundrySubnet ? _agentSubnetId : null
+      }
+    : {
+        cognitiveServicesPrivateDnsZoneResourceId: _dnsZoneCogSvcsId
+        openAiPrivateDnsZoneResourceId: _dnsZoneOpenAiId
+        aiServicesPrivateDnsZoneResourceId: _dnsZoneAiServicesId
+        agentServiceSubnetResourceId: deployAiFoundrySubnet ? _agentSubnetId : null
+      })
+  : null
 
 var varAfAiSearchCfgComplete = {
   existingResourceId: aiSearchResourceId != ''
     ? aiSearchResourceId
     : deployAiFoundry ? searchServiceAIFoundry.outputs.resourceId : null
   name: aiFoundrySearchServiceName
-  privateDnsZoneResourceId: _networkIsolation ? _dnsZoneSearchId : null
+  privateDnsZoneResourceId: (_networkIsolation && !policyManagedPrivateDns) ? _dnsZoneSearchId : null
   roleAssignments: []
 }
 
 var varAfCosmosCfgComplete = {
   existingResourceId: aiFoundryCosmosDBAccountResourceId != '' ? aiFoundryCosmosDBAccountResourceId : null
   name: aiFoundryCosmosDbName
-  privateDnsZoneResourceId: _networkIsolation ? _dnsZoneCosmosId : null
+  privateDnsZoneResourceId: (_networkIsolation && !policyManagedPrivateDns) ? _dnsZoneCosmosId : null
   roleAssignments: []
 }
 
 var varAfKVCfgComplete = {
   existingResourceId: keyVaultResourceId != '' ? keyVaultResourceId : null
   name: '${const.abbrs.security.keyVault}ai-${resourceToken}'
-  privateDnsZoneResourceId: _networkIsolation ? _dnsZoneKeyVaultId : null
+  privateDnsZoneResourceId: (_networkIsolation && !policyManagedPrivateDns) ? _dnsZoneKeyVaultId : null
   roleAssignments: []
 }
 
@@ -2010,7 +2015,7 @@ var varAfStorageCfgComplete = {
     ? aiFoundryStorageAccountResourceId
     : (deployAiFoundry ? aiFoundryStorageAccount.outputs.resourceId : null)
   name: aiFoundryStorageAccountName
-  blobPrivateDnsZoneResourceId: _networkIsolation ? _dnsZoneBlobId : null
+  blobPrivateDnsZoneResourceId: (_networkIsolation && !policyManagedPrivateDns) ? _dnsZoneBlobId : null
   roleAssignments: []
 }
 
@@ -2145,7 +2150,7 @@ module privateEndpointPrivateLinkScope 'modules/networking/private-endpoint.bice
         }
       }
     ]
-    privateDnsZoneGroup: policyManagedPrivateDns ? {} : {
+    privateDnsZoneGroup: policyManagedPrivateDns ? null : {
       name: 'privateLinkDnsZoneGroup'
       privateDnsZoneGroupConfigs: [
         { name: 'azuremonitorARecord', privateDnsZoneResourceId: _dnsZoneAzureMonitorId }

--- a/main.parameters.json
+++ b/main.parameters.json
@@ -34,7 +34,8 @@
     "deployContainerRegistry":              { "value": "true" },
     "deployContainerEnv":                   { "value": "true" },
     "deployNsgs":                           { "value": "true" },
-    "deployAzureFirewall":                  { "value": "${DEPLOY_AZURE_FIREWALL}" },
+    "deployAzureFirewall":                  { "value": "${DEPLOY_AZURE_FIREWALL=false}" },
+    "deployAcrTaskAgentPool":               { "value": "${DEPLOY_ACR_TASK_AGENT_POOL=false}" },
     "bastionAllowedSourceIPs":              { "value": [] },
     "bastionSkuName":                       { "value": "${BASTION_SKU_NAME=Standard}" },
     "bastionEnableTunneling":               { "value": "${BASTION_ENABLE_TUNNELING=false}" },
@@ -87,7 +88,8 @@
     "useExistingVNet":                       { "value": "${USE_EXISTING_VNET}" },  
     "deploySubnets":                         { "value": "${DEPLOY_SUBNETS}" },  
     "sideBySideDeploy":                      { "value": "${SIDE_BY_SIDE}" }, 
-    "existingVnetResourceId":                { "value": "${EXISTING_VNET_RESOURCE_ID}" },     
+    "existingVnetResourceId":                { "value": "${EXISTING_VNET_RESOURCE_ID}" },
+    "policyManagedPrivateDns":               { "value": "${POLICY_MANAGED_PRIVATE_DNS}" },     
 
     "modelDeploymentList":{
       "value": [

--- a/main.parameters.json
+++ b/main.parameters.json
@@ -34,7 +34,7 @@
     "deployContainerRegistry":              { "value": "true" },
     "deployContainerEnv":                   { "value": "true" },
     "deployNsgs":                           { "value": "true" },
-    "deployAzureFirewall":                  { "value": "${DEPLOY_AZURE_FIREWALL=false}" },
+    "deployAzureFirewall":                  { "value": "${DEPLOY_AZURE_FIREWALL}" },
     "deployAcrTaskAgentPool":               { "value": "${DEPLOY_ACR_TASK_AGENT_POOL=false}" },
     "bastionAllowedSourceIPs":              { "value": [] },
     "bastionSkuName":                       { "value": "${BASTION_SKU_NAME=Standard}" },
@@ -89,7 +89,7 @@
     "deploySubnets":                         { "value": "${DEPLOY_SUBNETS}" },  
     "sideBySideDeploy":                      { "value": "${SIDE_BY_SIDE}" }, 
     "existingVnetResourceId":                { "value": "${EXISTING_VNET_RESOURCE_ID}" },
-    "policyManagedPrivateDns":               { "value": "${POLICY_MANAGED_PRIVATE_DNS}" },     
+    "policyManagedPrivateDns":               { "value": "${POLICY_MANAGED_PRIVATE_DNS=false}" },     
 
     "modelDeploymentList":{
       "value": [

--- a/modules/ai-foundry/foundry/main.bicep
+++ b/modules/ai-foundry/foundry/main.bicep
@@ -93,7 +93,7 @@ module foundryAccount 'modules/account.bicep' = {
     aiModelDeployments: aiModelDeployments
     privateEndpointSubnetResourceId: privateEndpointSubnetResourceId
     agentSubnetResourceId: aiFoundryConfiguration.?networking.?agentServiceSubnetResourceId
-    privateDnsZoneResourceIds: !empty(privateEndpointSubnetResourceId) && !empty(aiFoundryConfiguration.?networking)
+    privateDnsZoneResourceIds: !empty(privateEndpointSubnetResourceId) && !empty(aiFoundryConfiguration.?networking.?cognitiveServicesPrivateDnsZoneResourceId)
       ? [
           aiFoundryConfiguration!.networking!.cognitiveServicesPrivateDnsZoneResourceId!
           aiFoundryConfiguration!.networking!.openAiPrivateDnsZoneResourceId!
@@ -269,7 +269,7 @@ module foundryAccountPrivateEndpoint 'br/public:avm/res/network/private-endpoint
         }
       }
     ]
-    privateDnsZoneGroup: {
+    privateDnsZoneGroup: !empty(aiFoundryConfiguration.?networking.?cognitiveServicesPrivateDnsZoneResourceId) ? {
       privateDnsZoneGroupConfigs: [
         {
           privateDnsZoneResourceId: aiFoundryConfiguration!.networking!.cognitiveServicesPrivateDnsZoneResourceId!
@@ -281,7 +281,7 @@ module foundryAccountPrivateEndpoint 'br/public:avm/res/network/private-endpoint
           privateDnsZoneResourceId: aiFoundryConfiguration!.networking!.aiServicesPrivateDnsZoneResourceId!
         }
       ]
-    }
+    } : null
   }
   dependsOn: [
     foundryProject
@@ -399,14 +399,14 @@ type foundryNetworkConfigurationType = {
   @description('Optional. The Resource ID of the subnet for the Azure AI Services account. This is required if \'createAIAgentService\' is true.')
   agentServiceSubnetResourceId: string?
 
-  @description('Required. The Resource ID of the Private DNS Zone for the Azure AI Services account.')
-  cognitiveServicesPrivateDnsZoneResourceId: string
+  @description('Optional. The Resource ID of the Private DNS Zone for the Azure AI Services account. Required unless DNS is policy-managed.')
+  cognitiveServicesPrivateDnsZoneResourceId: string?
 
-  @description('Required. The Resource ID of the Private DNS Zone for the OpenAI account.')
-  openAiPrivateDnsZoneResourceId: string
+  @description('Optional. The Resource ID of the Private DNS Zone for the OpenAI account. Required unless DNS is policy-managed.')
+  openAiPrivateDnsZoneResourceId: string?
 
-  @description('Required. The Resource ID of the Private DNS Zone for the Azure AI Services account.')
-  aiServicesPrivateDnsZoneResourceId: string
+  @description('Optional. The Resource ID of the Private DNS Zone for the Azure AI Services account. Required unless DNS is policy-managed.')
+  aiServicesPrivateDnsZoneResourceId: string?
 }
 
 @export()

--- a/modules/ai-foundry/foundry/main.bicep
+++ b/modules/ai-foundry/foundry/main.bicep
@@ -269,7 +269,7 @@ module foundryAccountPrivateEndpoint 'br/public:avm/res/network/private-endpoint
         }
       }
     ]
-    privateDnsZoneGroup: !empty(aiFoundryConfiguration.?networking.?cognitiveServicesPrivateDnsZoneResourceId) ? {
+    privateDnsZoneGroup: (!empty(aiFoundryConfiguration.?networking.?cognitiveServicesPrivateDnsZoneResourceId) && !empty(aiFoundryConfiguration.?networking.?openAiPrivateDnsZoneResourceId) && !empty(aiFoundryConfiguration.?networking.?aiServicesPrivateDnsZoneResourceId)) ? {
       privateDnsZoneGroupConfigs: [
         {
           privateDnsZoneResourceId: aiFoundryConfiguration!.networking!.cognitiveServicesPrivateDnsZoneResourceId!

--- a/modules/ai-foundry/foundry/modules/aiSearch.bicep
+++ b/modules/ai-foundry/foundry/modules/aiSearch.bicep
@@ -36,7 +36,7 @@ resource existingSearchService 'Microsoft.Search/searchServices@2025-05-01' exis
   scope: resourceGroup(existingSubscriptionId, existingResourceGroupName)
 }
 
-var privateNetworkingEnabled = !empty(privateDnsZoneResourceId) && !empty(privateEndpointSubnetResourceId)
+var privateNetworkingEnabled = !empty(privateEndpointSubnetResourceId)
 
 module aiSearch 'br/public:avm/res/search/search-service:0.11.1' = if (empty(existingResourceId)) {
   name: take('avm.res.search.search-service.${name}', 64)
@@ -64,13 +64,13 @@ module aiSearch 'br/public:avm/res/search/search-service:0.11.1' = if (empty(exi
     privateEndpoints: privateNetworkingEnabled
       ? [
           {
-            privateDnsZoneGroup: {
+            privateDnsZoneGroup: !empty(privateDnsZoneResourceId) ? {
               privateDnsZoneGroupConfigs: [
                 {
                   privateDnsZoneResourceId: privateDnsZoneResourceId!
                 }
               ]
-            }
+            } : null
             subnetResourceId: privateEndpointSubnetResourceId!
           }
         ]

--- a/modules/ai-foundry/foundry/modules/cosmosDb.bicep
+++ b/modules/ai-foundry/foundry/modules/cosmosDb.bicep
@@ -36,7 +36,7 @@ resource existingCosmosDb 'Microsoft.DocumentDB/databaseAccounts@2025-04-15' exi
   scope: resourceGroup(existingSubscriptionId, existingResourceGroupName)
 }
 
-var privateNetworkingEnabled = !empty(privateDnsZoneResourceId) && !empty(privateEndpointSubnetResourceId)
+var privateNetworkingEnabled = !empty(privateEndpointSubnetResourceId)
 
 module cosmosDb 'br/public:avm/res/document-db/database-account:0.18.0' = if (empty(existingResourceId)) {
   name: take('avm.res.document-db.database-account.${name}', 64)
@@ -56,13 +56,13 @@ module cosmosDb 'br/public:avm/res/document-db/database-account:0.18.0' = if (em
     privateEndpoints: privateNetworkingEnabled
       ? [
           {
-            privateDnsZoneGroup: {
+            privateDnsZoneGroup: !empty(privateDnsZoneResourceId) ? {
               privateDnsZoneGroupConfigs: [
                 {
                   privateDnsZoneResourceId: privateDnsZoneResourceId!
                 }
               ]
-            }
+            } : null
             service: 'Sql'
             subnetResourceId: privateEndpointSubnetResourceId!
           }

--- a/modules/ai-foundry/foundry/modules/keyVault.bicep
+++ b/modules/ai-foundry/foundry/modules/keyVault.bicep
@@ -36,7 +36,7 @@ resource existingKeyVault 'Microsoft.KeyVault/vaults@2024-11-01' existing = if (
   scope: resourceGroup(existingSubscriptionId, existingResourceGroupName)
 }
 
-var privateNetworkingEnabled = !empty(privateDnsZoneResourceId) && !empty(privateEndpointSubnetResourceId)
+var privateNetworkingEnabled = !empty(privateEndpointSubnetResourceId)
 
 module keyVault 'br/public:avm/res/key-vault/vault:0.13.3' = if (empty(existingResourceId)) {
   name: take('avm.res.key-vault.vault.${name}', 64)
@@ -59,13 +59,13 @@ module keyVault 'br/public:avm/res/key-vault/vault:0.13.3' = if (empty(existingR
     privateEndpoints: privateNetworkingEnabled
       ? [
           {
-            privateDnsZoneGroup: {
+            privateDnsZoneGroup: !empty(privateDnsZoneResourceId) ? {
               privateDnsZoneGroupConfigs: [
                 {
                   privateDnsZoneResourceId: privateDnsZoneResourceId!
                 }
               ]
-            }
+            } : null
             service: 'vault'
             subnetResourceId: privateEndpointSubnetResourceId!
           }

--- a/modules/ai-foundry/foundry/modules/storageAccount.bicep
+++ b/modules/ai-foundry/foundry/modules/storageAccount.bicep
@@ -36,7 +36,7 @@ resource existingStorageAccount 'Microsoft.Storage/storageAccounts@2025-01-01' e
   scope: resourceGroup(existingSubscriptionId, existingResourceGroupName)
 }
 
-var privateNetworkingEnabled = !empty(blobPrivateDnsZoneResourceId) && !empty(privateEndpointSubnetResourceId)
+var privateNetworkingEnabled = !empty(privateEndpointSubnetResourceId)
 
 module storageAccount 'br/public:avm/res/storage/storage-account:0.28.0' = if (empty(existingResourceId)) {
   name: take('avm.res.storage.storage-account.${name}', 64)
@@ -65,13 +65,13 @@ module storageAccount 'br/public:avm/res/storage/storage-account:0.28.0' = if (e
     privateEndpoints: privateNetworkingEnabled
       ? [
           {
-            privateDnsZoneGroup: {
+            privateDnsZoneGroup: !empty(blobPrivateDnsZoneResourceId) ? {
               privateDnsZoneGroupConfigs: [
                 {
                   privateDnsZoneResourceId: blobPrivateDnsZoneResourceId!
                 }
               ]
-            }
+            } : null
             service: 'blob'
             subnetResourceId: privateEndpointSubnetResourceId!
           }

--- a/modules/ai-foundry/storage-account.bicep
+++ b/modules/ai-foundry/storage-account.bicep
@@ -74,19 +74,19 @@ module storageAccount 'br/public:avm/res/storage/storage-account:0.26.2' = {
       virtualNetworkRules: []
       defaultAction: disablePublicNetworkAccess ? 'Deny' : 'Allow'
     }
-    privateEndpoints: (!empty(privateEndpointSubnetResourceId) && !empty(blobPrivateDnsZoneResourceId))
+    privateEndpoints: !empty(privateEndpointSubnetResourceId)
       ? [
           {
             name: 'pe-${name}-blob'
             service: 'blob'
             subnetResourceId: privateEndpointSubnetResourceId
-            privateDnsZoneGroup: {
+            privateDnsZoneGroup: !empty(blobPrivateDnsZoneResourceId) ? {
               privateDnsZoneGroupConfigs: [
                 {
                   privateDnsZoneResourceId: blobPrivateDnsZoneResourceId
                 }
               ]
-            }
+            } : null
           }
         ]
       : []

--- a/modules/networking/private-endpoint.bicep
+++ b/modules/networking/private-endpoint.bicep
@@ -6,7 +6,7 @@ param resourceGroupName string
 param tags object
 param subnetResourceId string
 param privateLinkServiceConnections array = []
-param privateDnsZoneGroup object = {}
+param privateDnsZoneGroup object?
 param prefix string = 'nic-'
 
 module privateEndpoint 'br/public:avm/res/network/private-endpoint:0.11.0' = {

--- a/modules/networking/private-endpoints.bicep
+++ b/modules/networking/private-endpoints.bicep
@@ -4,7 +4,7 @@ targetScope = 'resourceGroup'
 type endpointInfo = {
   name: string
   privateLinkServiceConnections: array
-  privateDnsZoneGroup: object
+  privateDnsZoneGroup: object?
   customNetworkInterfaceName: string?
 }
 
@@ -25,7 +25,7 @@ module privateEndpoints 'br/public:avm/res/network/private-endpoint:0.11.0' = [f
     tags: tags
     subnetResourceId: subnetResourceId
     privateLinkServiceConnections: ep.privateLinkServiceConnections
-    privateDnsZoneGroup: ep.privateDnsZoneGroup
+    privateDnsZoneGroup: ep.?privateDnsZoneGroup
     customNetworkInterfaceName: ep.?customNetworkInterfaceName ?? '${prefix}${ep.name}'
   }
 }]


### PR DESCRIPTION

[PR-Details.md](https://github.com/user-attachments/files/27527865/PR-Details.md)

Enable azd provision in Zero Trust / Hub & Spoke mode with policyManagedPrivateDns=true, where Private DNS Zones are managed centrally in the Hub (not deployed in the spoke).

Changes:
- PE DNS zone group: pass null instead of {} when DNS is policy-managed
- Make privateDnsZoneGroup nullable (object?) in PE modules
- AI Foundry networking: omit DNS properties instead of null to avoid ARM template validation errors
- Decouple privateNetworkingEnabled from DNS zone existence in all AI Foundry sub-modules (PEs still created, only DNS zone group skipped)
- Make DNS zone fields nullable in foundryNetworkConfigurationType
- Add deployAcrTaskAgentPool and policyManagedPrivateDns parameter mappings
- Add default=false for deployAzureFirewall parameter

## Purpose

Describe the intention of the proposed changes. What problem does it solve or what functionality does it add?

## Type of change 

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Backlog Item or Issue

If applicable, provide a link to the relevant backlog item or issue.

## Documentation Link

If this change adds new functionality, provide a link to its documentation. Documentation should be updated in the `mkdocs` branch.

## Code quality checklist

- [x] I verified the changes locally to ensure they work as expected
- [x] I tested the new functionality and ensured existing features still work
- [ ] I added at least one reviewer to this Pull Request