### PR TITLE
fix: finalize policy-managed Private DNS handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.  
 This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres to [Semantic Versioning](https://semver.org/).
 
+## [v1.1.7] - 2026-05-10
+
+### Fixed
+- **Hub & Spoke with policy-managed Private DNS no longer emits `privateDnsZoneGroup: null` to AVM private-endpoint modules** (PR #51 follow-up): `modules/networking/private-endpoint.bicep` now routes through two explicit AVM module paths — one with `privateDnsZoneGroup` and one without that property — so policy-managed DNS scenarios omit the property entirely instead of sending a literal null.
+- **AI Foundry account DNS-zone gating now requires the full 3-zone set before emitting DNS configs** (PR #51 follow-up): `modules/ai-foundry/foundry/main.bicep` now guards `privateDnsZoneResourceIds` and the Foundry account private-endpoint DNS zone group with the same complete check (`cognitiveServices`, `openAi`, `aiServices`) to prevent partial-input non-null assertions from breaking deployment.
+- **AI Foundry associated-resource modules now omit PE DNS-zone groups when IDs are not provided** (PR #51 follow-up): `modules/ai-foundry/storage-account.bicep` and the Foundry submodules for Search, Cosmos DB, Key Vault, and Storage now build private endpoint objects without `privateDnsZoneGroup` unless a DNS zone ID is present, aligning runtime behavior with the policy-managed DNS model.
+
 ## [v1.1.6] - 2026-05-06
 
 ### Fixed

--- a/main.bicep
+++ b/main.bicep
@@ -1604,49 +1604,49 @@ module privateDnsZones 'modules/networking/private-dns-zones.bicep' = if (_deplo
 // Private Endpoints (consolidated into a single for-loop module with @batchSize(1) to keep compiled ARM template under 4 MB while preserving serialized PE creation).
 ///////////////////////////////////////////////////////////////////////////
 
-var _peDnsZoneGroupBlob = policyManagedPrivateDns ? {} : {
+var _peDnsZoneGroupBlob = policyManagedPrivateDns ? null : {
   name: 'blobDnsZoneGroup'
   privateDnsZoneGroupConfigs: [
     { name: 'blobARecord', privateDnsZoneResourceId: _dnsZoneBlobId }
   ]
 }
-var _peDnsZoneGroupCosmos = policyManagedPrivateDns ? {} : {
+var _peDnsZoneGroupCosmos = policyManagedPrivateDns ? null : {
   name: 'cosmosDnsZoneGroup'
   privateDnsZoneGroupConfigs: [
     { name: 'cosmosARecord', privateDnsZoneResourceId: _dnsZoneCosmosId }
   ]
 }
-var _peDnsZoneGroupSearch = policyManagedPrivateDns ? {} : {
+var _peDnsZoneGroupSearch = policyManagedPrivateDns ? null : {
   name: 'searchDnsZoneGroup'
   privateDnsZoneGroupConfigs: [
     { name: 'searchARecord', privateDnsZoneResourceId: _dnsZoneSearchId }
   ]
 }
-var _peDnsZoneGroupKeyVault = policyManagedPrivateDns ? {} : {
+var _peDnsZoneGroupKeyVault = policyManagedPrivateDns ? null : {
   name: 'kvDnsZoneGroup'
   privateDnsZoneGroupConfigs: [
     { name: 'kvARecord', privateDnsZoneResourceId: _dnsZoneKeyVaultId }
   ]
 }
-var _peDnsZoneGroupAppConfig = policyManagedPrivateDns ? {} : {
+var _peDnsZoneGroupAppConfig = policyManagedPrivateDns ? null : {
   name: 'appConfigDnsZoneGroup'
   privateDnsZoneGroupConfigs: [
     { name: 'appConfigARecord', privateDnsZoneResourceId: _dnsZoneAppConfigId }
   ]
 }
-var _peDnsZoneGroupContainerApps = policyManagedPrivateDns ? {} : {
+var _peDnsZoneGroupContainerApps = policyManagedPrivateDns ? null : {
   name: 'ccaDnsZoneGroup'
   privateDnsZoneGroupConfigs: [
     { name: 'ccaARecord', privateDnsZoneResourceId: _dnsZoneContainerAppsId }
   ]
 }
-var _peDnsZoneGroupAcr = policyManagedPrivateDns ? {} : {
+var _peDnsZoneGroupAcr = policyManagedPrivateDns ? null : {
   name: 'acrDnsZoneGroup'
   privateDnsZoneGroupConfigs: [
     { name: 'acr', privateDnsZoneResourceId: _dnsZoneAcrId }
   ]
 }
-var _peDnsZoneGroupCogSvcs = policyManagedPrivateDns ? {} : {
+var _peDnsZoneGroupCogSvcs = policyManagedPrivateDns ? null : {
   name: 'cogSvcsDnsZoneGroup'
   privateDnsZoneGroupConfigs: [
     { name: 'cogSvcsARecord', privateDnsZoneResourceId: _dnsZoneCogSvcsId }
@@ -1855,7 +1855,7 @@ module aiFoundryStorageAccount 'modules/ai-foundry/storage-account.bicep' = if (
     skuName: aiFoundryStorageSku
     disablePublicNetworkAccess: _networkIsolation
     privateEndpointSubnetResourceId: _networkIsolation ? _peSubnetId : ''
-    blobPrivateDnsZoneResourceId: _networkIsolation ? _dnsZoneBlobId : ''
+    blobPrivateDnsZoneResourceId: (_networkIsolation && !policyManagedPrivateDns) ? _dnsZoneBlobId : ''
   }
   dependsOn: [
     #disable-next-line BCP321
@@ -1863,8 +1863,7 @@ module aiFoundryStorageAccount 'modules/ai-foundry/storage-account.bicep' = if (
     #disable-next-line BCP321
     (_networkIsolation && useExistingVNet && deploySubnets) ? virtualNetworkSubnets : null
     #disable-next-line BCP321
-    _networkIsolation ? privateDnsZones : null
-    // Serialize PE creation against the shared `pe-subnet` (fixes #41). The aggregator
+    (_networkIsolation && !policyManagedPrivateDns) ? privateDnsZones : null
     // `privateEndpoints` module creates ~10 PEs against `pe-subnet` (already serialized
     // internally via @batchSize(1)). This module also creates an inline blob PE on the
     // same subnet via the AVM storage-account module's `privateEndpoints` parameter.
@@ -1970,33 +1969,39 @@ var varPeSubnetId = empty(existingVnetResourceId!)
   ? '${virtualNetworkResourceId}/subnets/pe-subnet'
   : '${existingVnetResourceId!}/subnets/pe-subnet'
 
-var varAfNetworkingOverride = _networkIsolation ? {
-  cognitiveServicesPrivateDnsZoneResourceId: _dnsZoneCogSvcsId
-  openAiPrivateDnsZoneResourceId: _dnsZoneOpenAiId
-  aiServicesPrivateDnsZoneResourceId: _dnsZoneAiServicesId
-  agentServiceSubnetResourceId: deployAiFoundrySubnet ? _agentSubnetId : null
-} : null
+var varAfNetworkingOverride = _networkIsolation
+  ? (policyManagedPrivateDns
+    ? {
+        agentServiceSubnetResourceId: deployAiFoundrySubnet ? _agentSubnetId : null
+      }
+    : {
+        cognitiveServicesPrivateDnsZoneResourceId: _dnsZoneCogSvcsId
+        openAiPrivateDnsZoneResourceId: _dnsZoneOpenAiId
+        aiServicesPrivateDnsZoneResourceId: _dnsZoneAiServicesId
+        agentServiceSubnetResourceId: deployAiFoundrySubnet ? _agentSubnetId : null
+      })
+  : null
 
 var varAfAiSearchCfgComplete = {
   existingResourceId: aiSearchResourceId != ''
     ? aiSearchResourceId
     : deployAiFoundry ? searchServiceAIFoundry.outputs.resourceId : null
   name: aiFoundrySearchServiceName
-  privateDnsZoneResourceId: _networkIsolation ? _dnsZoneSearchId : null
+  privateDnsZoneResourceId: (_networkIsolation && !policyManagedPrivateDns) ? _dnsZoneSearchId : null
   roleAssignments: []
 }
 
 var varAfCosmosCfgComplete = {
   existingResourceId: aiFoundryCosmosDBAccountResourceId != '' ? aiFoundryCosmosDBAccountResourceId : null
   name: aiFoundryCosmosDbName
-  privateDnsZoneResourceId: _networkIsolation ? _dnsZoneCosmosId : null
+  privateDnsZoneResourceId: (_networkIsolation && !policyManagedPrivateDns) ? _dnsZoneCosmosId : null
   roleAssignments: []
 }
 
 var varAfKVCfgComplete = {
   existingResourceId: keyVaultResourceId != '' ? keyVaultResourceId : null
   name: '${const.abbrs.security.keyVault}ai-${resourceToken}'
-  privateDnsZoneResourceId: _networkIsolation ? _dnsZoneKeyVaultId : null
+  privateDnsZoneResourceId: (_networkIsolation && !policyManagedPrivateDns) ? _dnsZoneKeyVaultId : null
   roleAssignments: []
 }
 
@@ -2010,7 +2015,7 @@ var varAfStorageCfgComplete = {
     ? aiFoundryStorageAccountResourceId
     : (deployAiFoundry ? aiFoundryStorageAccount.outputs.resourceId : null)
   name: aiFoundryStorageAccountName
-  blobPrivateDnsZoneResourceId: _networkIsolation ? _dnsZoneBlobId : null
+  blobPrivateDnsZoneResourceId: (_networkIsolation && !policyManagedPrivateDns) ? _dnsZoneBlobId : null
   roleAssignments: []
 }
 
@@ -2145,7 +2150,7 @@ module privateEndpointPrivateLinkScope 'modules/networking/private-endpoint.bice
         }
       }
     ]
-    privateDnsZoneGroup: policyManagedPrivateDns ? {} : {
+    privateDnsZoneGroup: policyManagedPrivateDns ? null : {
       name: 'privateLinkDnsZoneGroup'
       privateDnsZoneGroupConfigs: [
         { name: 'azuremonitorARecord', privateDnsZoneResourceId: _dnsZoneAzureMonitorId }

--- a/main.parameters.json
+++ b/main.parameters.json
@@ -34,7 +34,8 @@
     "deployContainerRegistry":              { "value": "true" },
     "deployContainerEnv":                   { "value": "true" },
     "deployNsgs":                           { "value": "true" },
-    "deployAzureFirewall":                  { "value": "${DEPLOY_AZURE_FIREWALL}" },
+    "deployAzureFirewall":                  { "value": "${DEPLOY_AZURE_FIREWALL=false}" },
+    "deployAcrTaskAgentPool":               { "value": "${DEPLOY_ACR_TASK_AGENT_POOL=false}" },
     "bastionAllowedSourceIPs":              { "value": [] },
     "bastionSkuName":                       { "value": "${BASTION_SKU_NAME=Standard}" },
     "bastionEnableTunneling":               { "value": "${BASTION_ENABLE_TUNNELING=false}" },
@@ -87,7 +88,8 @@
     "useExistingVNet":                       { "value": "${USE_EXISTING_VNET}" },  
     "deploySubnets":                         { "value": "${DEPLOY_SUBNETS}" },  
     "sideBySideDeploy":                      { "value": "${SIDE_BY_SIDE}" }, 
-    "existingVnetResourceId":                { "value": "${EXISTING_VNET_RESOURCE_ID}" },     
+    "existingVnetResourceId":                { "value": "${EXISTING_VNET_RESOURCE_ID}" },
+    "policyManagedPrivateDns":               { "value": "${POLICY_MANAGED_PRIVATE_DNS}" },     
 
     "modelDeploymentList":{
       "value": [

--- a/main.parameters.json
+++ b/main.parameters.json
@@ -34,7 +34,7 @@
     "deployContainerRegistry":              { "value": "true" },
     "deployContainerEnv":                   { "value": "true" },
     "deployNsgs":                           { "value": "true" },
-    "deployAzureFirewall":                  { "value": "${DEPLOY_AZURE_FIREWALL=false}" },
+    "deployAzureFirewall":                  { "value": "${DEPLOY_AZURE_FIREWALL}" },
     "deployAcrTaskAgentPool":               { "value": "${DEPLOY_ACR_TASK_AGENT_POOL=false}" },
     "bastionAllowedSourceIPs":              { "value": [] },
     "bastionSkuName":                       { "value": "${BASTION_SKU_NAME=Standard}" },
@@ -89,7 +89,7 @@
     "deploySubnets":                         { "value": "${DEPLOY_SUBNETS}" },  
     "sideBySideDeploy":                      { "value": "${SIDE_BY_SIDE}" }, 
     "existingVnetResourceId":                { "value": "${EXISTING_VNET_RESOURCE_ID}" },
-    "policyManagedPrivateDns":               { "value": "${POLICY_MANAGED_PRIVATE_DNS}" },     
+    "policyManagedPrivateDns":               { "value": "${POLICY_MANAGED_PRIVATE_DNS=false}" },     
 
     "modelDeploymentList":{
       "value": [

--- a/modules/ai-foundry/foundry/main.bicep
+++ b/modules/ai-foundry/foundry/main.bicep
@@ -93,7 +93,7 @@ module foundryAccount 'modules/account.bicep' = {
     aiModelDeployments: aiModelDeployments
     privateEndpointSubnetResourceId: privateEndpointSubnetResourceId
     agentSubnetResourceId: aiFoundryConfiguration.?networking.?agentServiceSubnetResourceId
-    privateDnsZoneResourceIds: !empty(privateEndpointSubnetResourceId) && !empty(aiFoundryConfiguration.?networking.?cognitiveServicesPrivateDnsZoneResourceId)
+    privateDnsZoneResourceIds: !empty(privateEndpointSubnetResourceId) && !empty(aiFoundryConfiguration.?networking.?cognitiveServicesPrivateDnsZoneResourceId) && !empty(aiFoundryConfiguration.?networking.?openAiPrivateDnsZoneResourceId) && !empty(aiFoundryConfiguration.?networking.?aiServicesPrivateDnsZoneResourceId)
       ? [
           aiFoundryConfiguration!.networking!.cognitiveServicesPrivateDnsZoneResourceId!
           aiFoundryConfiguration!.networking!.openAiPrivateDnsZoneResourceId!
@@ -251,7 +251,9 @@ module foundryProject 'modules/project/main.bicep' = {
 // cannot raise `AccountProvisioningStateInvalid`. Fully declarative,
 // policy-neutral (no deploymentScripts, no shared-key storage required).
 // =============================================================================
-module foundryAccountPrivateEndpoint 'br/public:avm/res/network/private-endpoint:0.11.0' = if (!empty(privateEndpointSubnetResourceId) && !empty(aiFoundryConfiguration.?networking)) {
+var hasAllFoundryPrivateDnsZoneIds = !empty(aiFoundryConfiguration.?networking.?cognitiveServicesPrivateDnsZoneResourceId) && !empty(aiFoundryConfiguration.?networking.?openAiPrivateDnsZoneResourceId) && !empty(aiFoundryConfiguration.?networking.?aiServicesPrivateDnsZoneResourceId)
+
+module foundryAccountPrivateEndpoint 'br/public:avm/res/network/private-endpoint:0.11.0' = if (!empty(privateEndpointSubnetResourceId) && !empty(aiFoundryConfiguration.?networking) && hasAllFoundryPrivateDnsZoneIds) {
   name: take('module.account.pe.${resourcesName}', 64)
   params: {
     name: 'pep-${foundryAccount.outputs.name}-account'
@@ -269,7 +271,7 @@ module foundryAccountPrivateEndpoint 'br/public:avm/res/network/private-endpoint
         }
       }
     ]
-    privateDnsZoneGroup: (!empty(aiFoundryConfiguration.?networking.?cognitiveServicesPrivateDnsZoneResourceId) && !empty(aiFoundryConfiguration.?networking.?openAiPrivateDnsZoneResourceId) && !empty(aiFoundryConfiguration.?networking.?aiServicesPrivateDnsZoneResourceId)) ? {
+    privateDnsZoneGroup: {
       privateDnsZoneGroupConfigs: [
         {
           privateDnsZoneResourceId: aiFoundryConfiguration!.networking!.cognitiveServicesPrivateDnsZoneResourceId!
@@ -281,7 +283,31 @@ module foundryAccountPrivateEndpoint 'br/public:avm/res/network/private-endpoint
           privateDnsZoneResourceId: aiFoundryConfiguration!.networking!.aiServicesPrivateDnsZoneResourceId!
         }
       ]
-    } : null
+    }
+  }
+  dependsOn: [
+    foundryProject
+  ]
+}
+
+module foundryAccountPrivateEndpointWithoutDns 'br/public:avm/res/network/private-endpoint:0.11.0' = if (!empty(privateEndpointSubnetResourceId) && !empty(aiFoundryConfiguration.?networking) && !hasAllFoundryPrivateDnsZoneIds) {
+  name: take('module.account.pe.${resourcesName}', 64)
+  params: {
+    name: 'pep-${foundryAccount.outputs.name}-account'
+    location: location
+    tags: tags
+    subnetResourceId: privateEndpointSubnetResourceId!
+    privateLinkServiceConnections: [
+      {
+        name: 'pep-${foundryAccount.outputs.name}-account'
+        properties: {
+          privateLinkServiceId: foundryAccount.outputs.resourceId
+          groupIds: [
+            'account'
+          ]
+        }
+      }
+    ]
   }
   dependsOn: [
     foundryProject

--- a/modules/ai-foundry/foundry/main.bicep
+++ b/modules/ai-foundry/foundry/main.bicep
@@ -93,7 +93,7 @@ module foundryAccount 'modules/account.bicep' = {
     aiModelDeployments: aiModelDeployments
     privateEndpointSubnetResourceId: privateEndpointSubnetResourceId
     agentSubnetResourceId: aiFoundryConfiguration.?networking.?agentServiceSubnetResourceId
-    privateDnsZoneResourceIds: !empty(privateEndpointSubnetResourceId) && !empty(aiFoundryConfiguration.?networking)
+    privateDnsZoneResourceIds: !empty(privateEndpointSubnetResourceId) && !empty(aiFoundryConfiguration.?networking.?cognitiveServicesPrivateDnsZoneResourceId)
       ? [
           aiFoundryConfiguration!.networking!.cognitiveServicesPrivateDnsZoneResourceId!
           aiFoundryConfiguration!.networking!.openAiPrivateDnsZoneResourceId!
@@ -269,7 +269,7 @@ module foundryAccountPrivateEndpoint 'br/public:avm/res/network/private-endpoint
         }
       }
     ]
-    privateDnsZoneGroup: {
+    privateDnsZoneGroup: !empty(aiFoundryConfiguration.?networking.?cognitiveServicesPrivateDnsZoneResourceId) ? {
       privateDnsZoneGroupConfigs: [
         {
           privateDnsZoneResourceId: aiFoundryConfiguration!.networking!.cognitiveServicesPrivateDnsZoneResourceId!
@@ -281,7 +281,7 @@ module foundryAccountPrivateEndpoint 'br/public:avm/res/network/private-endpoint
           privateDnsZoneResourceId: aiFoundryConfiguration!.networking!.aiServicesPrivateDnsZoneResourceId!
         }
       ]
-    }
+    } : null
   }
   dependsOn: [
     foundryProject
@@ -399,14 +399,14 @@ type foundryNetworkConfigurationType = {
   @description('Optional. The Resource ID of the subnet for the Azure AI Services account. This is required if \'createAIAgentService\' is true.')
   agentServiceSubnetResourceId: string?
 
-  @description('Required. The Resource ID of the Private DNS Zone for the Azure AI Services account.')
-  cognitiveServicesPrivateDnsZoneResourceId: string
+  @description('Optional. The Resource ID of the Private DNS Zone for the Azure AI Services account. Required unless DNS is policy-managed.')
+  cognitiveServicesPrivateDnsZoneResourceId: string?
 
-  @description('Required. The Resource ID of the Private DNS Zone for the OpenAI account.')
-  openAiPrivateDnsZoneResourceId: string
+  @description('Optional. The Resource ID of the Private DNS Zone for the OpenAI account. Required unless DNS is policy-managed.')
+  openAiPrivateDnsZoneResourceId: string?
 
-  @description('Required. The Resource ID of the Private DNS Zone for the Azure AI Services account.')
-  aiServicesPrivateDnsZoneResourceId: string
+  @description('Optional. The Resource ID of the Private DNS Zone for the Azure AI Services account. Required unless DNS is policy-managed.')
+  aiServicesPrivateDnsZoneResourceId: string?
 }
 
 @export()

--- a/modules/ai-foundry/foundry/main.bicep
+++ b/modules/ai-foundry/foundry/main.bicep
@@ -269,7 +269,7 @@ module foundryAccountPrivateEndpoint 'br/public:avm/res/network/private-endpoint
         }
       }
     ]
-    privateDnsZoneGroup: !empty(aiFoundryConfiguration.?networking.?cognitiveServicesPrivateDnsZoneResourceId) ? {
+    privateDnsZoneGroup: (!empty(aiFoundryConfiguration.?networking.?cognitiveServicesPrivateDnsZoneResourceId) && !empty(aiFoundryConfiguration.?networking.?openAiPrivateDnsZoneResourceId) && !empty(aiFoundryConfiguration.?networking.?aiServicesPrivateDnsZoneResourceId)) ? {
       privateDnsZoneGroupConfigs: [
         {
           privateDnsZoneResourceId: aiFoundryConfiguration!.networking!.cognitiveServicesPrivateDnsZoneResourceId!

--- a/modules/ai-foundry/foundry/modules/aiSearch.bicep
+++ b/modules/ai-foundry/foundry/modules/aiSearch.bicep
@@ -63,16 +63,17 @@ module aiSearch 'br/public:avm/res/search/search-service:0.11.1' = if (empty(exi
     roleAssignments: roleAssignments
     privateEndpoints: privateNetworkingEnabled
       ? [
-          {
-            privateDnsZoneGroup: !empty(privateDnsZoneResourceId) ? {
+          union({
+            subnetResourceId: privateEndpointSubnetResourceId!
+          }, !empty(privateDnsZoneResourceId) ? {
+            privateDnsZoneGroup: {
               privateDnsZoneGroupConfigs: [
                 {
                   privateDnsZoneResourceId: privateDnsZoneResourceId!
                 }
               ]
-            } : null
-            subnetResourceId: privateEndpointSubnetResourceId!
-          }
+            }
+          } : {})
         ]
       : []
     tags: tags

--- a/modules/ai-foundry/foundry/modules/aiSearch.bicep
+++ b/modules/ai-foundry/foundry/modules/aiSearch.bicep
@@ -36,7 +36,7 @@ resource existingSearchService 'Microsoft.Search/searchServices@2025-05-01' exis
   scope: resourceGroup(existingSubscriptionId, existingResourceGroupName)
 }
 
-var privateNetworkingEnabled = !empty(privateDnsZoneResourceId) && !empty(privateEndpointSubnetResourceId)
+var privateNetworkingEnabled = !empty(privateEndpointSubnetResourceId)
 
 module aiSearch 'br/public:avm/res/search/search-service:0.11.1' = if (empty(existingResourceId)) {
   name: take('avm.res.search.search-service.${name}', 64)
@@ -64,13 +64,13 @@ module aiSearch 'br/public:avm/res/search/search-service:0.11.1' = if (empty(exi
     privateEndpoints: privateNetworkingEnabled
       ? [
           {
-            privateDnsZoneGroup: {
+            privateDnsZoneGroup: !empty(privateDnsZoneResourceId) ? {
               privateDnsZoneGroupConfigs: [
                 {
                   privateDnsZoneResourceId: privateDnsZoneResourceId!
                 }
               ]
-            }
+            } : null
             subnetResourceId: privateEndpointSubnetResourceId!
           }
         ]

--- a/modules/ai-foundry/foundry/modules/cosmosDb.bicep
+++ b/modules/ai-foundry/foundry/modules/cosmosDb.bicep
@@ -55,17 +55,18 @@ module cosmosDb 'br/public:avm/res/document-db/database-account:0.18.0' = if (em
     }
     privateEndpoints: privateNetworkingEnabled
       ? [
-          {
-            privateDnsZoneGroup: !empty(privateDnsZoneResourceId) ? {
+          union({
+            service: 'Sql'
+            subnetResourceId: privateEndpointSubnetResourceId!
+          }, !empty(privateDnsZoneResourceId) ? {
+            privateDnsZoneGroup: {
               privateDnsZoneGroupConfigs: [
                 {
                   privateDnsZoneResourceId: privateDnsZoneResourceId!
                 }
               ]
-            } : null
-            service: 'Sql'
-            subnetResourceId: privateEndpointSubnetResourceId!
-          }
+            }
+          } : {})
         ]
       : []
     roleAssignments: roleAssignments

--- a/modules/ai-foundry/foundry/modules/cosmosDb.bicep
+++ b/modules/ai-foundry/foundry/modules/cosmosDb.bicep
@@ -36,7 +36,7 @@ resource existingCosmosDb 'Microsoft.DocumentDB/databaseAccounts@2025-04-15' exi
   scope: resourceGroup(existingSubscriptionId, existingResourceGroupName)
 }
 
-var privateNetworkingEnabled = !empty(privateDnsZoneResourceId) && !empty(privateEndpointSubnetResourceId)
+var privateNetworkingEnabled = !empty(privateEndpointSubnetResourceId)
 
 module cosmosDb 'br/public:avm/res/document-db/database-account:0.18.0' = if (empty(existingResourceId)) {
   name: take('avm.res.document-db.database-account.${name}', 64)
@@ -56,13 +56,13 @@ module cosmosDb 'br/public:avm/res/document-db/database-account:0.18.0' = if (em
     privateEndpoints: privateNetworkingEnabled
       ? [
           {
-            privateDnsZoneGroup: {
+            privateDnsZoneGroup: !empty(privateDnsZoneResourceId) ? {
               privateDnsZoneGroupConfigs: [
                 {
                   privateDnsZoneResourceId: privateDnsZoneResourceId!
                 }
               ]
-            }
+            } : null
             service: 'Sql'
             subnetResourceId: privateEndpointSubnetResourceId!
           }

--- a/modules/ai-foundry/foundry/modules/keyVault.bicep
+++ b/modules/ai-foundry/foundry/modules/keyVault.bicep
@@ -58,17 +58,18 @@ module keyVault 'br/public:avm/res/key-vault/vault:0.13.3' = if (empty(existingR
     softDeleteRetentionInDays: 7
     privateEndpoints: privateNetworkingEnabled
       ? [
-          {
-            privateDnsZoneGroup: !empty(privateDnsZoneResourceId) ? {
+          union({
+            service: 'vault'
+            subnetResourceId: privateEndpointSubnetResourceId!
+          }, !empty(privateDnsZoneResourceId) ? {
+            privateDnsZoneGroup: {
               privateDnsZoneGroupConfigs: [
                 {
                   privateDnsZoneResourceId: privateDnsZoneResourceId!
                 }
               ]
-            } : null
-            service: 'vault'
-            subnetResourceId: privateEndpointSubnetResourceId!
-          }
+            }
+          } : {})
         ]
       : []
     roleAssignments: roleAssignments

--- a/modules/ai-foundry/foundry/modules/keyVault.bicep
+++ b/modules/ai-foundry/foundry/modules/keyVault.bicep
@@ -36,7 +36,7 @@ resource existingKeyVault 'Microsoft.KeyVault/vaults@2024-11-01' existing = if (
   scope: resourceGroup(existingSubscriptionId, existingResourceGroupName)
 }
 
-var privateNetworkingEnabled = !empty(privateDnsZoneResourceId) && !empty(privateEndpointSubnetResourceId)
+var privateNetworkingEnabled = !empty(privateEndpointSubnetResourceId)
 
 module keyVault 'br/public:avm/res/key-vault/vault:0.13.3' = if (empty(existingResourceId)) {
   name: take('avm.res.key-vault.vault.${name}', 64)
@@ -59,13 +59,13 @@ module keyVault 'br/public:avm/res/key-vault/vault:0.13.3' = if (empty(existingR
     privateEndpoints: privateNetworkingEnabled
       ? [
           {
-            privateDnsZoneGroup: {
+            privateDnsZoneGroup: !empty(privateDnsZoneResourceId) ? {
               privateDnsZoneGroupConfigs: [
                 {
                   privateDnsZoneResourceId: privateDnsZoneResourceId!
                 }
               ]
-            }
+            } : null
             service: 'vault'
             subnetResourceId: privateEndpointSubnetResourceId!
           }

--- a/modules/ai-foundry/foundry/modules/storageAccount.bicep
+++ b/modules/ai-foundry/foundry/modules/storageAccount.bicep
@@ -64,17 +64,18 @@ module storageAccount 'br/public:avm/res/storage/storage-account:0.28.0' = if (e
     supportsHttpsTrafficOnly: true
     privateEndpoints: privateNetworkingEnabled
       ? [
-          {
-            privateDnsZoneGroup: !empty(blobPrivateDnsZoneResourceId) ? {
+          union({
+            service: 'blob'
+            subnetResourceId: privateEndpointSubnetResourceId!
+          }, !empty(blobPrivateDnsZoneResourceId) ? {
+            privateDnsZoneGroup: {
               privateDnsZoneGroupConfigs: [
                 {
                   privateDnsZoneResourceId: blobPrivateDnsZoneResourceId!
                 }
               ]
-            } : null
-            service: 'blob'
-            subnetResourceId: privateEndpointSubnetResourceId!
-          }
+            }
+          } : {})
         ]
       : []
     roleAssignments: roleAssignments

--- a/modules/ai-foundry/foundry/modules/storageAccount.bicep
+++ b/modules/ai-foundry/foundry/modules/storageAccount.bicep
@@ -36,7 +36,7 @@ resource existingStorageAccount 'Microsoft.Storage/storageAccounts@2025-01-01' e
   scope: resourceGroup(existingSubscriptionId, existingResourceGroupName)
 }
 
-var privateNetworkingEnabled = !empty(blobPrivateDnsZoneResourceId) && !empty(privateEndpointSubnetResourceId)
+var privateNetworkingEnabled = !empty(privateEndpointSubnetResourceId)
 
 module storageAccount 'br/public:avm/res/storage/storage-account:0.28.0' = if (empty(existingResourceId)) {
   name: take('avm.res.storage.storage-account.${name}', 64)
@@ -65,13 +65,13 @@ module storageAccount 'br/public:avm/res/storage/storage-account:0.28.0' = if (e
     privateEndpoints: privateNetworkingEnabled
       ? [
           {
-            privateDnsZoneGroup: {
+            privateDnsZoneGroup: !empty(blobPrivateDnsZoneResourceId) ? {
               privateDnsZoneGroupConfigs: [
                 {
                   privateDnsZoneResourceId: blobPrivateDnsZoneResourceId!
                 }
               ]
-            }
+            } : null
             service: 'blob'
             subnetResourceId: privateEndpointSubnetResourceId!
           }

--- a/modules/ai-foundry/storage-account.bicep
+++ b/modules/ai-foundry/storage-account.bicep
@@ -74,19 +74,19 @@ module storageAccount 'br/public:avm/res/storage/storage-account:0.26.2' = {
       virtualNetworkRules: []
       defaultAction: disablePublicNetworkAccess ? 'Deny' : 'Allow'
     }
-    privateEndpoints: (!empty(privateEndpointSubnetResourceId) && !empty(blobPrivateDnsZoneResourceId))
+    privateEndpoints: !empty(privateEndpointSubnetResourceId)
       ? [
           {
             name: 'pe-${name}-blob'
             service: 'blob'
             subnetResourceId: privateEndpointSubnetResourceId
-            privateDnsZoneGroup: {
+            privateDnsZoneGroup: !empty(blobPrivateDnsZoneResourceId) ? {
               privateDnsZoneGroupConfigs: [
                 {
                   privateDnsZoneResourceId: blobPrivateDnsZoneResourceId
                 }
               ]
-            }
+            } : null
           }
         ]
       : []

--- a/modules/ai-foundry/storage-account.bicep
+++ b/modules/ai-foundry/storage-account.bicep
@@ -76,18 +76,19 @@ module storageAccount 'br/public:avm/res/storage/storage-account:0.26.2' = {
     }
     privateEndpoints: !empty(privateEndpointSubnetResourceId)
       ? [
-          {
+          union({
             name: 'pe-${name}-blob'
             service: 'blob'
             subnetResourceId: privateEndpointSubnetResourceId
-            privateDnsZoneGroup: !empty(blobPrivateDnsZoneResourceId) ? {
+          }, !empty(blobPrivateDnsZoneResourceId) ? {
+            privateDnsZoneGroup: {
               privateDnsZoneGroupConfigs: [
                 {
                   privateDnsZoneResourceId: blobPrivateDnsZoneResourceId
                 }
               ]
-            } : null
-          }
+            }
+          } : {})
         ]
       : []
     enableTelemetry: enableTelemetry

--- a/modules/networking/private-endpoint.bicep
+++ b/modules/networking/private-endpoint.bicep
@@ -6,7 +6,7 @@ param resourceGroupName string
 param tags object
 param subnetResourceId string
 param privateLinkServiceConnections array = []
-param privateDnsZoneGroup object = {}
+param privateDnsZoneGroup object?
 param prefix string = 'nic-'
 
 module privateEndpoint 'br/public:avm/res/network/private-endpoint:0.11.0' = {

--- a/modules/networking/private-endpoint.bicep
+++ b/modules/networking/private-endpoint.bicep
@@ -9,7 +9,7 @@ param privateLinkServiceConnections array = []
 param privateDnsZoneGroup object?
 param prefix string = 'nic-'
 
-module privateEndpoint 'br/public:avm/res/network/private-endpoint:0.11.0' = {
+module privateEndpoint 'br/public:avm/res/network/private-endpoint:0.11.0' = if (privateDnsZoneGroup != null) {
   scope: resourceGroup(resourceGroupName)
   params: {
     name: name
@@ -17,9 +17,22 @@ module privateEndpoint 'br/public:avm/res/network/private-endpoint:0.11.0' = {
     tags: tags
     subnetResourceId: subnetResourceId
     privateLinkServiceConnections: privateLinkServiceConnections
-    privateDnsZoneGroup: privateDnsZoneGroup
+    privateDnsZoneGroup: privateDnsZoneGroup!
     customNetworkInterfaceName: '${prefix}${name}'
   }
 }
 
-output resourceId string = privateEndpoint.outputs.resourceId
+module privateEndpointWithoutDns 'br/public:avm/res/network/private-endpoint:0.11.0' = if (privateDnsZoneGroup == null) {
+  scope: resourceGroup(resourceGroupName)
+  params: {
+    name: name
+    location: location
+    tags: tags
+    subnetResourceId: subnetResourceId
+    privateLinkServiceConnections: privateLinkServiceConnections
+    customNetworkInterfaceName: '${prefix}${name}'
+  }
+}
+
+#disable-next-line BCP318
+output resourceId string = privateDnsZoneGroup == null ? privateEndpointWithoutDns!.outputs.resourceId : privateEndpoint!.outputs.resourceId

--- a/modules/networking/private-endpoints.bicep
+++ b/modules/networking/private-endpoints.bicep
@@ -4,7 +4,7 @@ targetScope = 'resourceGroup'
 type endpointInfo = {
   name: string
   privateLinkServiceConnections: array
-  privateDnsZoneGroup: object
+  privateDnsZoneGroup: object?
   customNetworkInterfaceName: string?
 }
 
@@ -25,7 +25,7 @@ module privateEndpoints 'br/public:avm/res/network/private-endpoint:0.11.0' = [f
     tags: tags
     subnetResourceId: subnetResourceId
     privateLinkServiceConnections: ep.privateLinkServiceConnections
-    privateDnsZoneGroup: ep.privateDnsZoneGroup
+    privateDnsZoneGroup: ep.?privateDnsZoneGroup
     customNetworkInterfaceName: ep.?customNetworkInterfaceName ?? '${prefix}${ep.name}'
   }
 }]


### PR DESCRIPTION
This PR supersedes the pending implementation gaps from #51 and includes the final fixes needed for release v1.1.7.\n\n## Included\n- Omit privateDnsZoneGroup when DNS is policy-managed (no explicit null sent to AVM PE module).\n- Keep privateDnsZoneGroup parameter nullable in PE wrapper and preserve call-site compatibility.\n- Require all 3 Foundry DNS zone IDs before emitting DNS config/group.\n- Update AI Foundry associated modules to omit DNS group when zone IDs are absent.\n- Update CHANGELOG.md for v1.1.7.\n\nRelated context: #51