### PR TITLE
fix: jumpbox ACME bootstrap, firewall allow-list and KV cert RBAC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.  
 This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres to [Semantic Versioning](https://semver.org/).
 
+## [v1.1.8] - 2026-05-10
+
+### Fixed
+- **Jumpbox certificate workflow now has first-class ACME support under network isolation** (fixes #53): `install.ps1` now installs win-acme non-interactively from the latest `win-acme.*.x64.trimmed.zip` release asset, validates installation with `wacs.exe --version`, and fails loudly on bootstrap errors instead of silently continuing.
+- **Firewall least-privilege allow-list now explicitly covers ACME issuance path for jumpbox** (fixes #53): `main.bicep` adds a dedicated jumpbox-scoped ACME FQDN group (`api.github.com`, `acme-v02.api.letsencrypt.org`) and a dedicated `AllowJumpboxAcme` application rule gated by `extendFirewallForJumpboxBootstrap`.
+- **Jumpbox MI now has certificate import RBAC by default** (fixes #53): `main.bicep` adds `Key Vault Certificates Officer` to jumpbox Key Vault role assignments so certificate import and certificate lifecycle operations no longer require manual RBAC patching.
+
+### Changed
+- **README runbook is now provider-agnostic and explicitly split by operational boundary** (fixes #53): DNS operations stay on workstation/provider side, while ACME issuance/import and Azure-side steps are documented on the jumpbox side using built-in win-acme tooling.
+
 ## [v1.1.7] - 2026-05-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -153,9 +153,10 @@ When `networkIsolation=true`, egress from the jumpbox and workload subnets is fo
 | `AllowJumpboxBootstrap` | `jumpboxSubnetPrefix` | Chocolatey, NuGet, VS Installer, `download.microsoft.com`, `aka.ms`, `go.microsoft.com`, `*.core.windows.net`, `*.azureedge.net` | `choco install`, VS Code/PowerShell Core/Azure CLI/AZD MSIs (Python is installed from python.org embeddable zip — see `AllowJumpboxDevRuntimes`) |
 | `AllowJumpboxDevRuntimes` | `jumpboxSubnetPrefix` | `*.python.org`, `*.pypi.org`, `*.pythonhosted.org`, `*.pypa.io`, `*.npmjs.org` | `pip install`, `npm install`, jumpbox Python embeddable-zip install + `get-pip.py` bootstrap |
 | `AllowJumpboxEditors` | `jumpboxSubnetPrefix` | `update.code.visualstudio.com`, `*.vo.msecnd.net`, `*.vscode-cdn.net` | VS Code updates |
+| `AllowJumpboxAcme` | `jumpboxSubnetPrefix` | `api.github.com`, `acme-v02.api.letsencrypt.org` | win-acme release discovery + ACME v2 issuance/renewal from jumpbox |
 | `AllowAcrTasks` | `devopsBuildAgentsSubnetPrefix` | `*.azurecr.io`, `*.data.azurecr.io` | ACR Tasks agent pool talking to its registry |
 
-Set `extendFirewallForJumpboxBootstrap=false` to skip the three jumpbox-scoped rules when egress is managed centrally by another policy.
+Set `extendFirewallForJumpboxBootstrap=false` to skip the jumpbox-scoped rules when egress is managed centrally by another policy.
 
 ### Permissions
 
@@ -217,6 +218,7 @@ Current default configuration provisions a single Hello World container app (`or
 | GenAI App Configuration Store | App Configuration Data Owner | Jumpbox VM | Full control over configuration settings |
 | GenAI App Key Vault | Key Vault Contributor | Jumpbox VM | Manage Key Vault settings |
 | GenAI App Key Vault | Key Vault Secrets Officer | Jumpbox VM | Create Key Vault secrets |
+| GenAI App Key Vault | Key Vault Certificates Officer | Jumpbox VM | Import/manage Key Vault certificates for public ingress TLS |
 | GenAI App Search Service | Search Service Contributor | Jumpbox VM | Create/update search service elements |
 | GenAI App Search Service | Search Index Data Contributor | Jumpbox VM | Read/write search index data |
 | GenAI App Storage Account | Storage Blob Data Contributor | Jumpbox VM | Read/write blob data |
@@ -272,23 +274,24 @@ publicIngress: {
    - HTTP:80 becomes a permanent HTTP→HTTPS redirect.
    - NSG allows TCP/443 from the supplied source CIDRs only.
 
-**Post-deploy runbook (BYO cert + DNS):**
+**Post-deploy runbook (provider-agnostic DNS + jumpbox ACME):**
 
-1. Provision (or import) a TLS certificate for your custom hostname (e.g., `app.contoso.com`) into the landing-zone Key Vault as a **secret** (PFX without passphrase, base64-encoded — App Gateway requires this exact shape) and capture the **versionless** secret URI (`https://<kv>.vault.azure.net/secrets/<name>`).
-2. Create a public DNS A record for the hostname pointing at `PUBLIC_INGRESS_PUBLIC_IP` (surfaced as a deployment output).
-3. Set the operator parameters in `main.parameters.json` (or via `azd env set` followed by an edit since `publicIngress` is an aggregate object):
+1. **Workstation (DNS provider side):** choose your DNS provider/registrar and prepare your hostname (example: `app.contoso.com`). No provider-specific integration is required in this landing zone.
+2. **Jumpbox (certificate issuance/import side):** use the built-in ACME client installed by `install.ps1` at `C:\tools\win-acme\wacs.exe` (DNS-01 flow), then import the resulting certificate into the landing-zone Key Vault. The jumpbox MI has `Key Vault Certificates Officer` for this workflow.
+3. **Workstation (DNS provider side):** create/update the public DNS A record for the hostname pointing at `PUBLIC_INGRESS_PUBLIC_IP` (deployment output).
+4. Capture the **versionless** Key Vault secret URI for the certificate (`https://<kv>.vault.azure.net/secrets/<name>`), then set operator parameters in `main.parameters.json` (or via `azd env set` followed by an edit since `publicIngress` is an aggregate object):
    ```jsonc
    "publicIngress": {
-     "value": {
+      "value": {
        "enabled": true,
        "frontendHostName": "app.contoso.com",
        "sslCertSecretId": "https://<kv>.vault.azure.net/secrets/<name>",
-       "allowedSourceAddressPrefixes": ["203.0.113.0/24"]
-     }
-   }
-   ```
-4. Run `azd provision` again. The HTTPS listener, redirect rule, and NSG allow rule are now in place.
-5. Validate end-to-end: `curl -v https://app.contoso.com/` should return the Container App's response; `curl -v http://app.contoso.com/` should redirect to HTTPS.
+        "allowedSourceAddressPrefixes": ["203.0.113.0/24"]
+      }
+    }
+    ```
+5. Run `azd provision` again. The HTTPS listener, redirect rule, and NSG allow rule are now in place.
+6. Validate end-to-end: `curl -v https://app.contoso.com/` should return the Container App's response; `curl -v http://app.contoso.com/` should redirect to HTTPS.
 
 **Teardown:** run `azd down` to remove the entire deployment, or delete the gateway/PIP/WAF policy/NSG/UAI manually. As stated above, flipping `enabled` back to `false` and re-provisioning will **not** delete the resources due to ARM incremental deployment semantics.
 

--- a/install.ps1
+++ b/install.ps1
@@ -244,6 +244,65 @@ try {
     Write-Warning "Python install failed: $_. Consumer postProvision scripts that require Python on the jumpbox may need to install it manually."
 }
 
+# ---------------------------------------------------------------------------
+# win-acme (ACME client) — default jumpbox installation for provider-agnostic
+# certificate workflows under network isolation (issue #53).
+#
+# Why built-in:
+# - Workstation path handles DNS provider updates (TXT / A records).
+# - Jumpbox path handles issuance + Azure-side import from inside the VNet.
+# - Avoids winget dependency (unreliable on this VM image/CSE context).
+#
+# Behavior:
+# - Non-interactive and deterministic: re-installs from latest x64 trimmed zip
+#   on each run so state does not drift.
+# - Fails loudly if release discovery/download/extract/version check fails.
+# ---------------------------------------------------------------------------
+$wacsDir             = 'C:\tools\win-acme'
+$wacsExe             = Join-Path $wacsDir 'wacs.exe'
+$winAcmeReleaseApi   = 'https://api.github.com/repos/win-acme/win-acme/releases/latest'
+
+Write-Host "`n--- Installing win-acme (ACME client) ---"
+try {
+    if (Test-Path $wacsDir) {
+        Write-Host "Removing pre-existing $wacsDir to guarantee a deterministic install"
+        Remove-Item -Path $wacsDir -Recurse -Force -ErrorAction Stop
+    }
+    New-Item -ItemType Directory -Path $wacsDir -Force | Out-Null
+
+    Write-Host "Discovering latest win-acme release from $winAcmeReleaseApi"
+    $release = Invoke-RestMethod -Uri $winAcmeReleaseApi -UseBasicParsing
+    $asset = $release.assets |
+        Where-Object { $_.name -like 'win-acme.*.x64.trimmed.zip' } |
+        Select-Object -First 1
+
+    if (-not $asset) {
+        throw 'Could not find the latest win-acme x64 trimmed release asset.'
+    }
+
+    $wacsZip = Join-Path $env:TEMP $asset.name
+    Write-Host "Downloading $($asset.name)"
+    Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $wacsZip -UseBasicParsing
+
+    Write-Host "Extracting $($asset.name) to $wacsDir"
+    Expand-Archive -Path $wacsZip -DestinationPath $wacsDir -Force
+    Remove-Item -Path $wacsZip -Force -ErrorAction SilentlyContinue
+
+    if (-not (Test-Path $wacsExe)) {
+        throw "win-acme install failed: expected executable not found at $wacsExe"
+    }
+
+    & $wacsExe --version
+    if ($LASTEXITCODE -ne 0) {
+        throw "win-acme version check failed (exit=$LASTEXITCODE)"
+    }
+
+    Write-Host "win-acme successfully installed at $wacsExe" -ForegroundColor Green
+} catch {
+    Write-Error "win-acme installation failed: $_"
+    throw
+}
+
 # Refresh PATH for the rest of this CSE run so the tools above are resolvable
 # without waiting for the post-CSE reboot.
 $env:PATH = "C:\Program Files\Microsoft SDKs\Azure\CLI2\wbin;C:\Program Files\Git\cmd;C:\Program Files\Git\bin;C:\ProgramData\chocolatey\bin;$env:PATH"

--- a/main.bicep
+++ b/main.bicep
@@ -755,6 +755,15 @@ var _firewallDevRuntimeFqdns = [
   'registry.npmjs.org'
   '*.npmjs.org'
 ]
+// Jumpbox ACME workflow egress (issue #53): scoped only to the jumpbox subnet
+// and only when `extendFirewallForJumpboxBootstrap=true`.
+// - api.github.com: discover latest win-acme release asset during bootstrap.
+// - acme-v02.api.letsencrypt.org: Let's Encrypt ACME v2 directory endpoint
+//   used during certificate issuance/renewal.
+var _firewallJumpboxAcmeFqdns = [
+  'api.github.com'
+  'acme-v02.api.letsencrypt.org'
+]
 #disable-next-line no-hardcoded-env-urls
 var _firewallEditorFqdns = [
   'update.code.visualstudio.com'
@@ -1092,6 +1101,15 @@ resource firewallPolicyDefaultRuleCollectionGroup 'Microsoft.Network/firewallPol
               { protocolType: 'Https', port: 443 }
             ]
             targetFqdns: extendFirewallForJumpboxBootstrap ? _firewallEditorFqdns : []
+            sourceAddresses: [jumpboxSubnetPrefix]
+          }
+          {
+            ruleType: 'ApplicationRule'
+            name: 'AllowJumpboxAcme'
+            protocols: [
+              { protocolType: 'Https', port: 443 }
+            ]
+            targetFqdns: extendFirewallForJumpboxBootstrap ? _firewallJumpboxAcmeFqdns : []
             sourceAddresses: [jumpboxSubnetPrefix]
           }
           {
@@ -1442,6 +1460,13 @@ var _testVmRoles = (deployVM && _networkIsolation) ? concat(
     {
       principalId: _testVmPrincipalId
       roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', const.roles.KeyVaultSecretsOfficer.guid)
+      #disable-next-line BCP318
+      resourceId: keyVault.id
+      principalType: 'ServicePrincipal'
+    }
+    {
+      principalId: _testVmPrincipalId
+      roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', const.roles.KeyVaultCertificatesOfficer.guid)
       #disable-next-line BCP318
       resourceId: keyVault.id
       principalType: 'ServicePrincipal'


### PR DESCRIPTION
Fixes #53\n\n## Summary\n- Install win-acme during jumpbox bootstrap (install.ps1) using latest win-acme.*.x64.trimmed.zip release asset from GitHub API.\n- Validate installation with wacs.exe --version and fail loudly if install/validation fails.\n- Add least-privilege jumpbox ACME firewall egress coverage in main.bicep via dedicated AllowJumpboxAcme rule (pi.github.com, cme-v02.api.letsencrypt.org) gated by xtendFirewallForJumpboxBootstrap.\n- Add Key Vault Certificates Officer to jumpbox Key Vault role assignments.\n- Update README runbook to provider-agnostic DNS workflow (workstation DNS tasks + jumpbox ACME/import tasks).\n- Update CHANGELOG with v1.1.8 entry.\n\n## Notes\n- Kept existing feature-flag behavior intact.\n- Followed least-privilege by scoping new firewall rule to jumpboxSubnetPrefix only.