### PR TITLE
Fix jumpbox win-acme bootstrap asset discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.  
 This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres to [Semantic Versioning](https://semver.org/).
 
+## [v1.1.9] - 2026-05-10
+
+### Fixed
+- **Jumpbox win-acme bootstrap no longer depends on GitHub release discovery** (fixes #55): `install.ps1` now downloads a pinned `win-acme.v2.2.9.1701.x64.trimmed.zip` release asset directly instead of querying `https://api.github.com/repos/win-acme/win-acme/releases/latest` and searching the returned asset list. This avoids Custom Script Extension failures where the GitHub API response is missing or does not expose the expected asset shape in locked-down / rate-limited bootstrap contexts, while keeping the install deterministic and non-interactive.
+
 ## [v1.1.8] - 2026-05-10
 
 ### Fixed

--- a/install.ps1
+++ b/install.ps1
@@ -254,13 +254,16 @@ try {
 # - Avoids winget dependency (unreliable on this VM image/CSE context).
 #
 # Behavior:
-# - Non-interactive and deterministic: re-installs from latest x64 trimmed zip
-#   on each run so state does not drift.
-# - Fails loudly if release discovery/download/extract/version check fails.
+# - Non-interactive and deterministic: re-installs a pinned x64 trimmed zip
+#   on each run so state does not drift and CSE does not depend on GitHub API
+#   release discovery/rate limits.
+# - Fails loudly if download/extract/version check fails.
 # ---------------------------------------------------------------------------
 $wacsDir             = 'C:\tools\win-acme'
 $wacsExe             = Join-Path $wacsDir 'wacs.exe'
-$winAcmeReleaseApi   = 'https://api.github.com/repos/win-acme/win-acme/releases/latest'
+$winAcmeVersion      = '2.2.9.1701'
+$winAcmeAssetName    = "win-acme.v$winAcmeVersion.x64.trimmed.zip"
+$winAcmeDownloadUrl  = "https://github.com/win-acme/win-acme/releases/download/v$winAcmeVersion/$winAcmeAssetName"
 
 Write-Host "`n--- Installing win-acme (ACME client) ---"
 try {
@@ -270,21 +273,11 @@ try {
     }
     New-Item -ItemType Directory -Path $wacsDir -Force | Out-Null
 
-    Write-Host "Discovering latest win-acme release from $winAcmeReleaseApi"
-    $release = Invoke-RestMethod -Uri $winAcmeReleaseApi -UseBasicParsing
-    $asset = $release.assets |
-        Where-Object { $_.name -like 'win-acme.*.x64.trimmed.zip' } |
-        Select-Object -First 1
+    $wacsZip = Join-Path $env:TEMP $winAcmeAssetName
+    Write-Host "Downloading $winAcmeAssetName"
+    Invoke-WebRequest -Uri $winAcmeDownloadUrl -OutFile $wacsZip -UseBasicParsing
 
-    if (-not $asset) {
-        throw 'Could not find the latest win-acme x64 trimmed release asset.'
-    }
-
-    $wacsZip = Join-Path $env:TEMP $asset.name
-    Write-Host "Downloading $($asset.name)"
-    Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $wacsZip -UseBasicParsing
-
-    Write-Host "Extracting $($asset.name) to $wacsDir"
+    Write-Host "Extracting $winAcmeAssetName to $wacsDir"
     Expand-Archive -Path $wacsZip -DestinationPath $wacsDir -Force
     Remove-Item -Path $wacsZip -Force -ErrorAction SilentlyContinue
 

--- a/main.bicep
+++ b/main.bicep
@@ -757,7 +757,7 @@ var _firewallDevRuntimeFqdns = [
 ]
 // Jumpbox ACME workflow egress (issue #53): scoped only to the jumpbox subnet
 // and only when `extendFirewallForJumpboxBootstrap=true`.
-// - api.github.com: discover latest win-acme release asset during bootstrap.
+// - api.github.com: reserved for ACME-client release discovery / plugin checks.
 // - acme-v02.api.letsencrypt.org: Let's Encrypt ACME v2 directory endpoint
 //   used during certificate issuance/renewal.
 var _firewallJumpboxAcmeFqdns = [


### PR DESCRIPTION
Fixes #55.

Pins the win-acme x64 trimmed ZIP URL so Custom Script Extension bootstrap no longer depends on GitHub release API asset discovery.