### PR TITLE
docs: soften v2 framing in README, CHANGELOG, and migration guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
 
 ## [v2.0.0] - 2026-05-18
 
-> v2.0.0 is a **breaking release** that introduces hub-and-spoke composability, granular reuse of platform resources, IP allow-lists, and a deployment-mode preset, while keeping the Zero Trust topology that v1.x operators already use. See [docs/v2-migration.md](docs/v2-migration.md) for the full upgrade path, [docs/runbook-hub-spoke.md](docs/runbook-hub-spoke.md) for the hub-and-spoke walkthrough, and [docs/runbook-standalone.md](docs/runbook-standalone.md) for the simpler single-subscription scenario. Tracking issue: [#58](https://github.com/Azure/bicep-ptn-aiml-landing-zone/issues/58).
+> v2.0.0 is a **major release** that introduces hub-and-spoke composability, granular reuse of platform resources, IP allow-lists, and a deployment-mode preset. The Zero Trust topology that v1.x operators already use keeps working. See [docs/v2-migration.md](docs/v2-migration.md) for the upgrade path, [docs/runbook-hub-spoke.md](docs/runbook-hub-spoke.md) for the hub-and-spoke walkthrough, and [docs/runbook-standalone.md](docs/runbook-standalone.md) for the simpler single-subscription scenario. Tracking issue: [#58](https://github.com/Azure/bicep-ptn-aiml-landing-zone/issues/58).
 
 ### Breaking Changes
 

--- a/README.md
+++ b/README.md
@@ -6,26 +6,28 @@ The Azure AI Landing Zone is an enterprise-scale, production-ready reference arc
 
 ![Architecture Diagram](media/Architecture%20Diagram.png)
 
-## What's new in v2.0.0
+## What's new in v2
 
-v2.0.0 is a **breaking release** that introduces hub-and-spoke composability and granular reuse of platform resources for Application Landing Zone (ALZ) integrated topologies, while keeping the v1.x Zero Trust standalone experience unchanged. Highlights:
+The v2 line adds two things that matter most for everyday use:
 
-- **Topology preset** — new `deploymentMode` parameter (`standalone` \| `ailz-integrated`) tags the deployment with operator intent
-- **IP allow-lists** — new `allowedIpRanges` parameter for "Zero Trust + named developer IPs" hybrid scenarios, applied uniformly to 7 PaaS services
-- **Decoupled jumpbox / Bastion / NAT Gateway** — split from the old monolithic `deployVM` flag, each independently controllable, each with a BYO `existingResourceId` variant
-- **Observability reuse** — bring your own Log Analytics workspace and Application Insights, including cross-subscription scenarios
-- **Granular BYO Private DNS** — 15 per-zone override parameters, plus `dnsZoneLinkSuffix` for multi-spoke shared-zone topologies
-- **Hub integration** — new spoke→hub VNet peering (created by `main.bicep`) and external-egress UDR via hub firewall/NVA, with helper script for the reverse-peering direction
-- **Pre-flight validation** — new `scripts/Invoke-PreflightChecks.ps1` runs automatically as a `preprovision` hook to catch parameter mistakes (BYO resource missing, CIDR overlap, conflicting flags) before they reach ARM. Bypass with `PREFLIGHT_SKIP=true`.
+1. **A topology switch** — set `deploymentMode` to one of:
+    - **`standalone`** — the AI Landing Zone provisions everything it needs (VNet, private endpoints, Bastion, jumpbox, NAT Gateway, observability). Best for sandboxes, evaluations, and teams without a corporate hub.
+    - **`ailz-integrated`** — the AI Landing Zone deploys only the **spoke** (VNet + private endpoints + AI services) and peers into a hub VNet you already operate, **reusing** the hub's Firewall, Bastion, Private DNS zones, and Log Analytics workspace. Best for production inside an existing Azure Landing Zone.
+2. **Granular reuse of existing resources** — every platform service can be brought from the outside via an `existing*ResourceId` parameter (cross-subscription IDs are accepted): Log Analytics, Application Insights, Private DNS zones (per zone, 15 available), hub VNet, jumpbox, Bastion, NAT Gateway, route table.
 
-If you're **upgrading from v1.x**, read the **[v2.0.0 migration guide](docs/v2-migration.md)** — every breaking change is mapped to the new parameter(s) you need to set.
+A handful of other quality-of-life additions:
 
-If you're **deploying for the first time**, pick a runbook:
+- **`allowedIpRanges`** — let named CIDRs reach the data plane of Storage, Key Vault, Cosmos DB, AI Search, ACR, AI Foundry, and App Configuration without disabling private endpoints. Use this when developers need to query the workload from their laptops without routing through Bastion.
+- **Decoupled hub components** — `deployJumpbox`, `deployBastion`, and `deployNatGateway` are now independent flags. No more all-or-nothing `deployVM`.
+- **Hub integration helpers** — `hubIntegration.hubVnetResourceId` creates the spoke→hub peering for you; `hubIntegration.egressNextHopIp` routes spoke egress through your hub firewall / NVA.
+- **Pre-flight validation** — `scripts/Invoke-PreflightChecks.ps1` runs automatically as an `azd preprovision` hook and catches the usual mistakes (CIDR overlap, undersized subnets, missing BYO resource IDs, conflicting flags) before they reach ARM. Bypass with `PREFLIGHT_SKIP=true`.
 
-- **[Runbook — Standalone deployment](docs/runbook-standalone.md)** — single subscription, AI LZ owns all networking and platform resources. Use this if you don't already have an ALZ.
-- **[Runbook — Hub-and-Spoke deployment](docs/runbook-hub-spoke.md)** — spoke in an existing ALZ, with hub-owned Firewall / Bastion / Log Analytics. Use this if your organization already operates an Azure Landing Zone.
+**Pick a runbook to deploy:**
 
-The "How to Deploy" section below remains accurate for the standalone case and the basic Zero Trust setup.
+- **[Standalone deployment](docs/runbook-standalone.md)** — single subscription, AI LZ owns all networking and platform resources.
+- **[Hub-and-spoke deployment](docs/runbook-hub-spoke.md)** — spoke inside an existing Landing Zone, hub provides the platform.
+
+If you're upgrading from v1.x, see the **[migration guide](docs/v2-migration.md)** — it shows what changed in v2 and the parameters you may need to update.
 
 ## How to Deploy
 

--- a/docs/v2-migration.md
+++ b/docs/v2-migration.md
@@ -1,14 +1,14 @@
-# Migrating from v1.x to v2.0.0
+# Migrating from v1.x to v2
 
-This document walks you through upgrading an existing AI Landing Zone deployment, or a downstream accelerator that consumes this repo as a submodule, from the v1.x line to **v2.0.0**.
+This document walks you through upgrading an existing AI Landing Zone deployment, or a downstream accelerator that consumes this repo as a submodule, from the v1.x line to **v2**.
 
-v2.0.0 is a **breaking release** (see [issue #58](https://github.com/Azure/bicep-ptn-aiml-landing-zone/issues/58)) that introduces hub-and-spoke composability, granular reuse of platform resources, IP allow-lists, and a deployment-mode preset, while keeping the Zero Trust topology that v1.x operators already use.
+v2 is a **major release** (see [issue #58](https://github.com/Azure/bicep-ptn-aiml-landing-zone/issues/58)) that introduces hub-and-spoke composability, granular reuse of platform resources, IP allow-lists, and a deployment-mode preset. The Zero Trust topology that v1.x operators already use keeps working.
 
 > If you are deploying for the first time, you do **not** need this document — go straight to the [Standalone runbook](./runbook-standalone.md) or the [Hub-and-Spoke runbook](./runbook-hub-spoke.md).
 
 ---
 
-## 1. Why v2.0.0?
+## 1. Why v2?
 
 v1.x was designed for the **standalone** scenario: a customer points `azd provision` at an empty subscription, the template builds everything — VNet, Firewall, DNS zones, jumpbox, Bastion, App Insights, Log Analytics, the application stack — and the customer accesses the result.
 
@@ -49,7 +49,7 @@ Internally, every v2.0.0 parameter has either a sensible default that reproduces
 
 ---
 
-## 3. Breaking changes that need operator action
+## 3. Things that need attention when upgrading
 
 ### 3.1. `deployVM` is split into three flags
 


### PR DESCRIPTION
Documentation-only cleanup of the v2 framing across README, CHANGELOG, and the migration guide.

## Motivation

The original v2 wording leaned on "breaking release" and "every breaking change" — accurate in a semver sense, but unnecessarily alarming for users who just want to deploy or upgrade. This PR keeps every technical detail intact further down in the migration guide while moving the user-facing surface to a calm, task-focused tone.

## What changes

**README**

- The `What's new in v2.0.0` section is rewritten as `What's new in v2` with a user-task-focused structure: the two-mode topology switch (`deploymentMode`), a BYO matrix of useful knobs, and a clean runbook picker. The v1-vs-v2 comparison vocabulary is dropped.
- `v2` instead of `v2.0.0` so the section stays accurate across patch releases (v2.0.1, v2.0.2, ...).
- Closing line drops "every breaking change" and uses softer "what changed in v2 and the parameters you may need to update".

**CHANGELOG**

- v2.0.0 banner reads "major release" instead of "breaking release". No change to the Fixed / Added lists.

**docs/v2-migration.md**

- Title becomes `Migrating from v1.x to v2`.
- Opening paragraph uses "major release" and references "the v2 line" rather than pinning everything to "v2.0.0".
- Section heading `Breaking changes that need operator action` becomes `Things that need attention when upgrading`.

## What does **not** change

- No technical content removed. The migration guide still walks through every parameter rename, removed flag, and behavior change.
- No code changes. `main.bicep`, modules, and scripts are untouched.
- Release notes for v2.0.0 and v2.0.1 already published on GitHub are unaffected (they live outside the repo).

## Validation

Documentation-only — no build or test changes.