### PR TITLE
fix(ai-foundry): gate bundled-resource PE subnet on networkIsolation (v2.0.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.  
 This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres to [Semantic Versioning](https://semver.org/).
 
+## [v2.0.2] - 2026-05-19
+
+### Fixed
+
+- **AI Foundry-bundled sub-modules emit invalid Private Endpoints under `networkIsolation=false`** (regression introduced in v2.0.0): `main.bicep` passed `varPeSubnetId` unconditionally as `privateEndpointSubnetResourceId` to the top-level `aiFoundry` module. `varPeSubnetId` is derived as `'${virtualNetworkResourceId}/subnets/pe-subnet'` regardless of `_networkIsolation`; when `_networkIsolation=false` the spoke VNet is not deployed, `virtualNetworkResourceId` resolves to `''`, and `varPeSubnetId` collapses to the bogus literal string `'/subnets/pe-subnet'`. The four AI Foundry-bundled sub-modules (`modules/ai-foundry/foundry/modules/{keyVault,aiSearch,storageAccount,cosmosDb}.bicep`) each derive `var privateNetworkingEnabled = !empty(privateEndpointSubnetResourceId)` (truthy on the garbage string) and emit invalid `privateEndpoints` iterators whose `subnetResourceId` is the malformed string. ARM template validation fails with `InvalidTemplate: 'databaseAccount_privateEndpoints[0]' / 'keyVault_privateEndpoints[0]' ... 'reference' is not valid: all function arguments should be string literals.`. The failure is deterministic and surfaces **after** the AI Foundry account, all model deployments, the AI Foundry-bundled Search and Storage, all workload Container Apps, and the workload AI Search have already been created, leaving the resource group in a half-deployed state. **Fix**: `main.bicep` now mirrors the existing sibling pattern at the `aiFoundryStorageAccount` call site — `privateEndpointSubnetResourceId: _networkIsolation ? varPeSubnetId : ''`. When network isolation is off, all four bundled sub-modules see an empty subnet ID, `privateNetworkingEnabled` evaluates `false`, and no PE iterators are emitted. No behavior change for the `_networkIsolation=true` topology. Tracking issue: [#63](https://github.com/Azure/bicep-ptn-aiml-landing-zone/issues/63).
+
 ## [v2.0.1] - 2026-05-19
 
 ### Fixed

--- a/main.bicep
+++ b/main.bicep
@@ -2250,7 +2250,17 @@ module aiFoundry 'modules/ai-foundry/main.bicep' = if (deployAiFoundry) {
     location: location
     tags: deploymentTags
 
-    privateEndpointSubnetResourceId: varPeSubnetId
+    // Gate this on `_networkIsolation` to mirror the sibling `aiFoundryStorageAccount`
+    // module at L2220. When network isolation is off, the spoke VNet is not deployed,
+    // `virtualNetworkResourceId` resolves to '', and `varPeSubnetId` collapses to the
+    // bogus literal '/subnets/pe-subnet'. Passing that down to the four AI Foundry-
+    // bundled sub-modules (Cosmos, Key Vault, AI Search, Storage) makes each one's
+    // `privateNetworkingEnabled = !empty(privateEndpointSubnetResourceId)` evaluate
+    // true (the string is non-empty but invalid), and ARM template validation fails
+    // with `databaseAccount_privateEndpoints[0]` / `keyVault_privateEndpoints[0]` ...
+    // `'reference' is not valid: all function arguments should be string literals.`.
+    // See issue #63 for the full diagnosis.
+    privateEndpointSubnetResourceId: _networkIsolation ? varPeSubnetId : ''
 
     aiFoundryConfiguration: {
       accountName: aiFoundryAccountName


### PR DESCRIPTION
# v2.0.2 — Foundry-bundled PE subnet gated on `networkIsolation`

Resolves #63.

## Summary

When `networkIsolation=false` and `deployAiFoundry=true`, `azd provision` fails mid-deployment with two ARM template-validation errors:

```
InvalidTemplate: 'databaseAccount_privateEndpoints[0]' ... 'reference' is not valid:
    all function arguments should be string literals.
InvalidTemplate: 'keyVault_privateEndpoints[0]'         ... 'reference' is not valid:
    all function arguments should be string literals.
```

…**after** the AI Foundry account, all model deployments, the AI Foundry-bundled Search and Storage, all workload Container Apps, and the workload AI Search are already created. The resource group is left in a half-deployed state.

The failure is deterministic across cold runs in `swedencentral` and is specific to the `networkIsolation=false` topology — `networkIsolation=true` deploys correctly.

## Root cause

`main.bicep` L2253 passed `varPeSubnetId` unconditionally as the `privateEndpointSubnetResourceId` parameter of the top-level `aiFoundry` module:

```bicep
privateEndpointSubnetResourceId: varPeSubnetId   // L2253 — unconditional
```

`varPeSubnetId` (L2331-2333) is derived with no `_networkIsolation` guard:

```bicep
var varPeSubnetId = empty(existingVnetResourceId!)
  ? '${virtualNetworkResourceId}/subnets/pe-subnet'
  : '${existingVnetResourceId!}/subnets/pe-subnet'
```

When `_networkIsolation=false`:
- The `virtualNetwork` module is gated on `_networkIsolation && !useExistingVNet` and is **not emitted**.
- `virtualNetworkResourceId` (the AVM output reference) resolves to `''`.
- `varPeSubnetId` becomes the literal string `'/subnets/pe-subnet'` — non-empty but syntactically invalid (no `/subscriptions/.../virtualNetworks/...` prefix).

Inside `modules/ai-foundry/foundry/main.bicep`, that value is propagated to four child sub-modules — `keyVault.bicep`, `aiSearch.bicep`, `storageAccount.bicep`, `cosmosDb.bicep`. Each one derives:

```bicep
var privateNetworkingEnabled = !empty(privateEndpointSubnetResourceId)
```

`!empty('/subnets/pe-subnet')` evaluates **true**, so each sub-module unconditionally passes a 1-element `privateEndpoints` array to its underlying AVM module with the malformed `subnetResourceId`. The AVM `database-account:0.18.0` and `key-vault` modules emit `Microsoft.Network/privateEndpoints` JSON whose iterator's `reference()` cannot derive a literal resource ID from the malformed input — hence the validation failure.

## Inconsistency that points at the right fix

The parallel `aiFoundryStorageAccount` call at **L2220** already has the correct gate:

```bicep
privateEndpointSubnetResourceId: _networkIsolation ? _peSubnetId : ''
```

So the gate is the documented intent at the sibling call. L2253 was simply missed.

## Fix

One-line surgical change at `main.bicep` L2253, mirroring the sibling pattern:

```diff
-    privateEndpointSubnetResourceId: varPeSubnetId
+    privateEndpointSubnetResourceId: _networkIsolation ? varPeSubnetId : ''
```

(Plus an extended comment block explaining the gate to future readers and pointing at issue #63.)

When `_networkIsolation=false`, all four AI Foundry-bundled sub-modules see an empty `privateEndpointSubnetResourceId`, `privateNetworkingEnabled` evaluates to `false`, and no PE iterators are emitted.

**No behavior change** under `_networkIsolation=true` — `varPeSubnetId` continues to resolve to the spoke/BYO VNet's `pe-subnet` exactly as today.

## Why fix upstream and not in the sub-modules

The four sub-modules in `modules/ai-foundry/foundry/modules/*` correctly express *"if you pass me a subnet ID, I will create a PE on it"* — that contract is fine and consistent with the AVM PE module pattern. The bug is **upstream** in `main.bicep`: it conjures up a non-empty but invalid subnet ID when there is no VNet. Fixing it at the source (gate on `_networkIsolation`) keeps the downstream contract clean and avoids heuristic resource-ID validation in the sub-modules.

## Validation

- `az bicep build --file main.bicep` → succeeds (only pre-existing warnings).
- `scripts/Measure-MainJsonSize.ps1` → **4.615 MB** (unchanged from v2.0.1; well under the 4.7 MB CI fail threshold and the 5.0 MB ARM hard ceiling).
- Code path inspection of all four bundled sub-modules confirms `privateNetworkingEnabled = !empty(privateEndpointSubnetResourceId)` now evaluates `false` when network isolation is off, so the PE iterators are not emitted.
- `networkIsolation=true` topologies are untouched — `_networkIsolation ? varPeSubnetId : ''` resolves to exactly `varPeSubnetId` in that branch.

## Release

- Cut as **v2.0.2** (patch bump on the v2.0 line).
- Pairs with v2.0.1 (#60) — both are template-validation regressions in the AI Foundry emission code path that surface only after a successful first half of the deployment.
- `CHANGELOG.md` updated with a `## [v2.0.2] - 2026-05-19` entry capturing the symptom, root cause, and fix.
