### PR TITLE
Fix ACR Task egress for Microsoft package feeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.  
 This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- **ACR Task build egress extension point**: new `additionalAcrTaskBuildFqdns` array parameter appends solution-specific HTTPS FQDNs to the ACR Tasks build-agent runtime rule, scoped to `devops-build-agents-subnet` and gated by `networkIsolation`, `deployAzureFirewall`, `deployAcrTaskAgentPool`, and `extendFirewallForAcrTaskBuilds`.
+
+### Fixed
+
+- **ACR Task builds needing Microsoft Linux package feeds** ([#68](https://github.com/Azure/bicep-ptn-aiml-landing-zone/issues/68)): `packages.microsoft.com` is now part of the default ACR Tasks OS package allow-list so Dockerfiles can install Microsoft-supported packages such as `msodbcsql18` under network isolation without manual firewall edits.
+
 ## [v2.0.2] - 2026-05-19
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -168,6 +168,12 @@ The agent pool can be disabled entirely with `deployAcrTaskAgentPool=false` if b
 
 When `networkIsolation=true`, egress from the jumpbox and workload subnets is forced through the default Azure Firewall. The landing zone codifies the FQDNs required by the default `install.ps1` bootstrap and by the ACR Tasks agent pool. The set is split by purpose so you can audit or trim it:
 
+- ACR Tasks control plane and registry: `*.azurecr.io`, `*.data.azurecr.io`, and Azure Storage queue/blob/table FQDNs.
+- Language/runtime feeds: Python.org, PyPI, npm.
+- OS package feeds: Debian, Ubuntu, Yarn, and `packages.microsoft.com` for Microsoft-supported Linux packages such as `msodbcsql18`.
+
+If your application build needs additional HTTPS endpoints, add them to the `additionalAcrTaskBuildFqdns` array parameter. The values are appended to the ACR Tasks HTTPS runtime rule only when `networkIsolation`, `deployAzureFirewall`, `deployAcrTaskAgentPool`, and `extendFirewallForAcrTaskBuilds` are all enabled, and are scoped to the `devops-build-agents-subnet`.
+
 | Rule | Source subnet | FQDN group | Used by |
 | --- | --- | --- | --- |
 | `AllowMicrosoftContainerRegistry` | `*` | `mcr.microsoft.com`, `*.data.mcr.microsoft.com` | ACA/agents/ACR Tasks pulling Microsoft base images |

--- a/main.bicep
+++ b/main.bicep
@@ -393,6 +393,9 @@ param extendFirewallForJumpboxBootstrap bool = true
 @description('When true, extends the Azure Firewall Policy with the FQDN allow-list required for ACR Tasks builds running inside the build-agents subnet to fetch language packages (npm, PyPI) and OS packages (Debian/Ubuntu apt repos, yarn). Only effective when networkIsolation, deployAzureFirewall and deployAcrTaskAgentPool are all enabled. Disable if you manage egress centrally or pre-bake all dependencies into the builder base image.')
 param extendFirewallForAcrTaskBuilds bool = true
 
+@description('Additional FQDNs to allow from the ACR Tasks build-agent subnet when extendFirewallForAcrTaskBuilds is true. Use this for application-specific build dependencies that are not part of the landing-zone default allow-list.')
+param additionalAcrTaskBuildFqdns array = []
+
 @description('List of trusted source IP CIDRs allowed to connect to the Bastion public IP on port 443. When empty, all internet inbound to port 443 is denied by default.')
 param bastionAllowedSourceIPs array = []
 
@@ -1098,9 +1101,11 @@ var _firewallAcrTaskFqdns = _deployAcrTaskAgentPool ? [
 
 // OS package repositories used by Debian/Ubuntu-based builder images during
 // `apt-get` steps in ACR Tasks runs. Scoped to devopsBuildAgentsSubnetPrefix
-// via `AllowAcrTaskOsPackages`. Language registries (npm/PyPI/python.org) are
-// reused from `_firewallDevRuntimeFqdns` via `AllowAcrTaskDevRuntimes`.
-// See issue #20.
+// via `AllowAcrTaskOsPackages`. Includes packages.microsoft.com because
+// Microsoft-supported Linux packages such as msodbcsql18 are common build-time
+// dependencies for solution accelerators. Language registries (npm/PyPI/python.org)
+// are reused from `_firewallDevRuntimeFqdns` via `AllowAcrTaskDevRuntimes`.
+// See issues #20 and #68.
 #disable-next-line no-hardcoded-env-urls
 var _firewallAcrTaskOsPackageFqdns = [
   'deb.debian.org'
@@ -1108,6 +1113,7 @@ var _firewallAcrTaskOsPackageFqdns = [
   'archive.ubuntu.com'
   'security.ubuntu.com'
   'dl.yarnpkg.com'
+  'packages.microsoft.com'
 ]
 
 // Route Table for egress traffic control through Azure Firewall (or external NVA, Gap 6).
@@ -1448,7 +1454,7 @@ resource firewallPolicyDefaultRuleCollectionGroup 'Microsoft.Network/firewallPol
             protocols: [
               { protocolType: 'Https', port: 443 }
             ]
-            targetFqdns: (_deployAcrTaskAgentPool && extendFirewallForAcrTaskBuilds) ? _firewallDevRuntimeFqdns : []
+            targetFqdns: (_deployAcrTaskAgentPool && extendFirewallForAcrTaskBuilds) ? union(_firewallDevRuntimeFqdns, additionalAcrTaskBuildFqdns) : []
             sourceAddresses: [devopsBuildAgentsSubnetPrefix]
           }
           {

--- a/main.parameters.json
+++ b/main.parameters.json
@@ -38,6 +38,7 @@
     "deployNsgs":                           { "value": "true" },
     "deployAzureFirewall":                  { "value": "${DEPLOY_AZURE_FIREWALL}" },
     "deployAcrTaskAgentPool":               { "value": "${DEPLOY_ACR_TASK_AGENT_POOL=false}" },
+    "additionalAcrTaskBuildFqdns":           { "value": [] },
     "bastionAllowedSourceIPs":              { "value": [] },
     "bastionSkuName":                       { "value": "${BASTION_SKU_NAME=Standard}" },
     "bastionEnableTunneling":               { "value": "${BASTION_ENABLE_TUNNELING=false}" },


### PR DESCRIPTION
## Summary
- add packages.microsoft.com to the default ACR Tasks OS package allow-list
- add additionalAcrTaskBuildFqdns for solution-specific HTTPS build dependencies
- document the ACR Tasks build egress behavior

Fixes #68.

## Validation
- az bicep build --file main.bicep