### PR TITLE
fix(ai-foundry): default Foundry AI Search to 1 replica (was 3) to reduce baseline cost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
 
 - **ACR Task build egress extension point**: new `additionalAcrTaskBuildFqdns` array parameter appends solution-specific HTTPS FQDNs to the ACR Tasks build-agent runtime rule, scoped to `devops-build-agents-subnet` and gated by `networkIsolation`, `deployAzureFirewall`, `deployAcrTaskAgentPool`, and `extendFirewallForAcrTaskBuilds`.
 
+### Changed
+
+- **Foundry-bundled AI Search default `replicaCount` lowered from `3` to `1`** in `modules/ai-foundry/foundry/modules/aiSearch.bicep`. The 3-replica default was inherited from the AVM Foundry reference and is the threshold for Azure AI Search's read/write SLA, but is overkill for the typical landing-zone bootstrap workload and roughly triples the Search bill (Standard SKU ~$245/mo per replica × partition, i.e. ~$735/mo for 3r×1p vs ~$245/mo for 1r×1p — a recurring ~$490/mo savings on every deployment that includes the Agent Service). The new default matches the workload AI Search service (`main.bicep` already used `replicaCount: 1` / `partitionCount: 1` for the workload Search). Operators who need the read/write SLA can scale the Search service back up to 3 replicas in-place from the portal/CLI with no data loss; bringing existing v2.0.x deployments in line with the new default is a non-destructive in-place scale-down. No template parameter contract is changed.
+
 ### Fixed
 
 - **ACR Task builds needing Microsoft Linux package feeds** ([#68](https://github.com/Azure/bicep-ptn-aiml-landing-zone/issues/68)): `packages.microsoft.com` is now part of the default ACR Tasks OS package allow-list so Dockerfiles can install Microsoft-supported packages such as `msodbcsql18` under network isolation without manual firewall edits.

--- a/modules/ai-foundry/foundry/modules/aiSearch.bicep
+++ b/modules/ai-foundry/foundry/modules/aiSearch.bicep
@@ -59,7 +59,7 @@ module aiSearch 'br/public:avm/res/search/search-service:0.11.1' = if (empty(exi
         }
     sku: 'standard'
     partitionCount: 1
-    replicaCount: 3
+    replicaCount: 1
     roleAssignments: roleAssignments
     privateEndpoints: privateNetworkingEnabled
       ? [


### PR DESCRIPTION
## Summary

Lowers the hardcoded eplicaCount in `modules/ai-foundry/foundry/modules/aiSearch.bicep` from **3 → 1**.

## Why

The 3-replica default was inherited from the AVM Foundry reference and is the threshold for Azure AI Search's read/write SLA, but is overkill for the typical landing-zone bootstrap workload and roughly **triples the Search bill**:

| Configuration | Search Units | Approx. monthly cost |
|---|---|---|
| 1 partition × 3 replicas (current default) | 3 SU | ~$735/mo |
| 1 partition × 1 replica (new default) | 1 SU | ~$245/mo |

That is a recurring **~$490/mo savings** on every deployment that includes the Foundry Agent Service (which always bundles its own AI Search alongside the workload AI Search).

The new default matches the workload AI Search instance — `main.bicep` already used `replicaCount: 1` / `partitionCount: 1` for the workload Search service.

## Migration / impact

- **No template parameter contract is changed.** Existing `main.parameters.json` files do not need edits.
- **Existing v2.0.x deployments**: re-running `azd provision` against an existing RG will scale the Foundry Search service from 3 → 1 replicas. This is a **non-destructive in-place scale-down** — Azure AI Search supports it with no data loss and no index rebuild.
- **Operators who need the read/write SLA** (3+ replicas) can scale the Search service back up in-place from the portal / Az CLI / ARM at any time.

## Related

- Follow-up to the cost discussion in the Bicep `deployed-resources.md` docs page (Azure/AI-Landing-Zones, `mkdocs` branch), which will be updated to reflect the new floor.
- Targets next patch release **v2.0.5**.