### PR TITLE
fix(defaults): set deployVmKeyVault default to false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
 
 ## [Unreleased]
 
+### Changed
+
+- **`deployVmKeyVault` default flipped from `true` to `false`** in `main.bicep` and `main.parameters.json` (`${DEPLOY_VM_KEY_VAULT=false}`). The parameter is declared and surfaced as the `DEPLOY_VM_KEY_VAULT` output but does not currently gate any resource in the template — so the previous `true` default never actually produced a VM-side Key Vault and only created a misleading signal for downstream tooling. The output is preserved so existing consumers reading `azd env get-values` continue to receive a value; only the default changes.
+
 ## [v2.0.5] - 2026-05-30
 
 ### Added

--- a/main.bicep
+++ b/main.bicep
@@ -252,7 +252,7 @@ param deployAppConfig bool = true
 param deployKeyVault bool = true
 
 @description('Deploy an Azure Key Vault to securely store VM secrets, keys, and certificates.')
-param deployVmKeyVault bool = true
+param deployVmKeyVault bool = false
 
 @description('Deploy an Azure Log Analytics workspace for centralized log collection and query.')
 param deployLogAnalytics bool = true

--- a/main.parameters.json
+++ b/main.parameters.json
@@ -47,7 +47,7 @@
     "deployMcp":                            { "value": "${DEPLOY_MCP=true}" },
     "deployGroundingWithBing":              { "value": "${DEPLOY_GROUNDING_WITH_BING=false}" },
     "deployKeyVault":                       { "value": "${DEPLOY_KEY_VAULT=true}" },
-    "deployVmKeyVault":                     { "value": "${DEPLOY_VM_KEY_VAULT}" },
+    "deployVmKeyVault":                     { "value": "${DEPLOY_VM_KEY_VAULT=false}" },
     "deployLogAnalytics":                   { "value": "${DEPLOY_LOG_ANALYTICS=true}" },
     "enablePrivateLogAnalytics":            { "value": "${ENABLE_PRIVATE_LOG_ANALYTICS=true}" },
     "deploySearchService":                  { "value": "${DEPLOY_SEARCH_SERVICE=true}" },


### PR DESCRIPTION
## Summary

Flips the default of `deployVmKeyVault` from `true` to `false` in `main.bicep` and `main.parameters.json` (`\${DEPLOY_VM_KEY_VAULT=false}\`).

## Why

The parameter is declared and surfaced as the `DEPLOY_VM_KEY_VAULT` output, but **does not currently gate any resource in the template** — so the previous `true` default never actually produced a VM-side Key Vault and only created a misleading signal for downstream tooling consuming `azd env get-values`.

## Compatibility

- **Output preserved**: `DEPLOY_VM_KEY_VAULT` is still emitted, so consumers reading the azd outputs continue to receive a value (just `false` now by default).
- **No parameter removed**: the `deployVmKeyVault` parameter stays in place for future use / explicit opt-in.
- **No infrastructure change**: since the param is currently unused for resource gating, no resource is created or destroyed by this change.

## Release target

Next patch — **v2.0.6**.