### PR TITLE
fix: ACA depends on firewall RCG so MCR pull doesn't race (#78)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
 
 ## [Unreleased]
 
+## [v2.0.7] - 2026-05-30
+
+### Fixed
+
+- **ZTA: Container App creation no longer races the firewall MCR allow rule** ([#78](https://github.com/Azure/bicep-ptn-aiml-landing-zone/issues/78)). Under `networkIsolation=true` + `deployAzureFirewall=true`, the `aca-environment-subnet` UDR forces all egress through the firewall, and the ACA control plane validates the placeholder image (`mcr.microsoft.com/dotnet/samples:aspnetapp-9.0`) at create time. The Container Apps module previously did not depend on `firewallPolicyDefaultRuleCollectionGroup`, so Bicep created the apps in parallel with the rule collection group; the MCR pull was denied (`GET https://mcr.microsoft.com/v2/: EOF`) and the whole `azd provision` aborted before the firewall rules ever landed. Added the missing dependency so the `AllowMicrosoftContainerRegistry` application rule is in place before any container app is created. Basic mode (`networkIsolation=false`) and AI-LZ-integrated topologies that do not deploy a local firewall are unaffected because the referenced resource is conditional.
+
 ## [v2.0.6] - 2026-05-30
 
 ### Changed

--- a/main.bicep
+++ b/main.bicep
@@ -2748,6 +2748,16 @@ module containerApps 'br/public:avm/res/app/container-app:0.18.1' = [
       containerEnv!                   
       privateDnsZones
       privateEndpoints
+      // Issue #78 — under network isolation the aca-environment-subnet UDR
+      // routes 0.0.0.0/0 to Azure Firewall. The ACA control plane validates
+      // the placeholder image (`_containerDummyImageName`, MCR) at create
+      // time. Without this dependency the container apps race the firewall
+      // rule collection group and the MCR pull is denied (EOF), which
+      // aborts the whole provision before the firewall rules ever land.
+      // The reference is to a conditional resource; in Basic mode
+      // (`deployAzureFirewall=false` or `networkIsolation=false`) the
+      // dependency is simply absent.
+      firewallPolicyDefaultRuleCollectionGroup
     ]
   }
 ]


### PR DESCRIPTION
## Summary

Fixes #78 — under ZTA (`networkIsolation=true` + `deployAzureFirewall=true`), Container App creation fails with `GET https://mcr.microsoft.com/v2/: EOF` because the placeholder image pull runs in parallel with the firewall rule collection group that allows MCR egress. Once any of the 3 container apps fails, the whole `azd provision` aborts and the firewall policy stays empty (zero rule collection groups).

## Change

Add `firewallPolicyDefaultRuleCollectionGroup` to the `containerApps` module `dependsOn`. The referenced resource is conditional (`if (deployAzureFirewall && _networkIsolation)`), so Bicep emits no dependency in Basic or hub-shared-firewall topologies.

## Validation

In a previously-failed ZTA env (`rg-gptrag-0530261602`, uksouth), manually applying the `AllowMicrosoftContainerRegistry` application rule on the empty firewall policy and re-running `azd provision` let all 3 container apps deploy on the first attempt (orchestrator 17s, frontend 32s, dataingest 32s). The dependency added here guarantees that ordering at provision time.

Full e2e ZTA validation will run from the GPT-RAG release/2.7.13 branch once v2.0.7 is tagged.

## Scope

- ZTA mode (`networkIsolation=true` + local Azure Firewall).
- No effect on Basic (`networkIsolation=false`) or AI-LZ-integrated topologies using a hub firewall (`hubIntegrationEgressNextHopIp`).

Closes #78

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
