### PR TITLE
fix: filter empty targetFqdns from DefaultRuleCollectionGroup (#80)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
 
 ## [Unreleased]
 
+## [v2.0.8] - 2026-05-31
+
+### Fixed
+
+- **ZTA: `DefaultRuleCollectionGroup` deployment rejected with `BadRequest: "The request is invalid."`** ([#80](https://github.com/Azure/bicep-ptn-aiml-landing-zone/issues/80)). Azure Firewall validates `ApplicationRule.targetFqdns` at ARM request-validation time and rejects any rule whose `targetFqdns` array is empty — the entire rule collection group creation fails in ~0.3s with no operation logged, leaving the firewall with zero rules. This regression hit any consumer that disabled one of the optional egress extensions, including the most common GPT-RAG ZTA path where `deployAcrTaskAgentPool=false` (default) made `AllowAcrTasks`, `AllowAcrTaskDevRuntimes`, and `AllowAcrTaskOsPackages` ship with `targetFqdns: []`. The same shape also failed when `extendFirewallForJumpboxBootstrap=false` (all four jumpbox rules empty). With the firewall empty, the `aca-environment-subnet` UDR (`0.0.0.0/0 → AzFW`) silently blocked MCR, which then surfaced as the `azd provision` "Container App creation failed: GET mcr.microsoft.com: EOF" symptom that v2.0.7's `dependsOn` ordering fix tried to address. Wrapped the rule list in `filter(..., rule => !empty(rule.targetFqdns))` so the ARM payload only ever contains application rules with at least one FQDN target. Each rule definition is preserved verbatim — the only behavioural change is that rules whose feature flag resolved to "no targets" are omitted from the payload instead of being submitted as empty. Basic mode (`networkIsolation=false`) and topologies that do not deploy a local firewall are unaffected because the rule collection group is conditional on `deployAzureFirewall && _networkIsolation`. The `dependsOn` fix from v2.0.7 is retained as defence-in-depth: even with a valid RCG payload, container apps must still wait for the rules to land before MCR is reachable.
+
 ## [v2.0.7] - 2026-05-30
 
 ### Fixed

--- a/main.bicep
+++ b/main.bicep
@@ -1365,7 +1365,15 @@ resource firewallPolicyDefaultRuleCollectionGroup 'Microsoft.Network/firewallPol
         action: {
           type: 'Allow'
         }
-        rules: [
+        // Azure Firewall rejects ApplicationRules whose targetFqdns is an empty
+        // array with `BadRequest: "The request is invalid."` at the ARM
+        // request-validation layer (no rule-collection-group operation is even
+        // created). Build the full set of rules below, then filter out any
+        // whose targetFqdns ended up empty due to disabled feature flags
+        // (e.g. deployJumpbox=false, deployAcrTaskAgentPool=false). This keeps
+        // every rule definition co-located while ensuring the ARM payload only
+        // ever contains rules with at least one FQDN target.
+        rules: filter([
           {
             ruleType: 'ApplicationRule'
             name: 'AllowMicrosoftContainerRegistry'
@@ -1467,7 +1475,7 @@ resource firewallPolicyDefaultRuleCollectionGroup 'Microsoft.Network/firewallPol
             targetFqdns: (_deployAcrTaskAgentPool && extendFirewallForAcrTaskBuilds) ? _firewallAcrTaskOsPackageFqdns : []
             sourceAddresses: [devopsBuildAgentsSubnetPrefix]
           }
-        ]
+        ], rule => !empty(rule.targetFqdns))
       }
     ]
   }


### PR DESCRIPTION
## Summary

Closes #80.

Wraps `firewallPolicyDefaultRuleCollectionGroup`'s rules array in `filter(..., rule => !empty(rule.targetFqdns))` so the ARM payload only contains application rules with at least one FQDN target. Each rule definition is preserved verbatim — the only behavioural change is that rules whose feature flag resolved to "no targets" (e.g. `AllowAcrTasks` when `_deployAcrTaskAgentPool=false`, jumpbox rules when `extendFirewallForJumpboxBootstrap=false`) are omitted from the payload instead of being submitted as empty.

## Why

Azure Firewall rejects any `ApplicationRule` whose `targetFqdns` array is empty at the ARM request-validation layer (`BadRequest: "The request is invalid."`, ~0.3s, no operation logged). With the default GPT-RAG ZTA params (`DEPLOY_ACR_TASK_AGENT_POOL=false`), three rules — `AllowAcrTasks`, `AllowAcrTaskDevRuntimes`, `AllowAcrTaskOsPackages` — fall back to `[]`, invalidating the whole RCG. The firewall is then left with zero rules; the `aca-environment-subnet` UDR (`0.0.0.0/0 → AzFW`) silently blocks MCR; container apps fail to pull the placeholder image; `azd provision` aborts.

v2.0.7 (#78) added a `dependsOn` between Container Apps and the RCG to fix what looked like a race. That ordering fix is still correct — it ensures container apps wait for the firewall to be configured before pulling MCR — but it cannot help when the RCG never succeeds. v2.0.8 fixes the underlying RCG payload validity; the v2.0.7 `dependsOn` is retained as defence-in-depth.

## Scope

- Affects: any v2.0.4+ consumer with `networkIsolation=true` + `deployAzureFirewall=true` and any of `deployAcrTaskAgentPool=false`, `extendFirewallForJumpboxBootstrap=false`.
- Not affected: `networkIsolation=false`, or topologies that do not deploy a local firewall.

## Validation

- `az bicep build` succeeds (pre-existing warnings only).
- Will be e2e validated by the GPT-RAG umbrella consumer (`Azure/GPT-RAG` release/2.7.13) in a fresh ZTA env right after this release tags.

## Changelog

- `[v2.0.8] - 2026-05-31 / Fixed`: full traceability paragraph in `CHANGELOG.md`.
