### PR TITLE
feat: make Container Apps Dapr opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.  
 This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+- **Dapr is now opt-in per Container App** (addresses #86): Container Apps no longer receive Dapr configuration automatically. Apps can enable Dapr explicitly through `containerAppsList[].dapr.enabled=true`, with optional per-app overrides for `appId`, `appPort`, `appProtocol`, and `enableApiLogging`. This makes external app deployments avoid unnecessary Dapr sidecars by default while allowing GPT-RAG and other Dapr-dependent workloads to preserve service invocation by declaring Dapr explicitly.
+
 ## [v1.1.6] - 2026-05-06
 
 ### Fixed

--- a/main.bicep
+++ b/main.bicep
@@ -435,7 +435,7 @@ param modelDeploymentList array
 // Container Apps params
 // ----------------------------------------------------------------------
 
-@description('List of container apps to create')
+@description('List of container apps to create. Dapr is opt-in per app through `dapr.enabled=true`; apps without a `dapr` object deploy with Dapr disabled.')
 param containerAppsList array
 
 @description('Workload profiles.')
@@ -2296,12 +2296,13 @@ module containerApps 'br/public:avm/res/app/container-app:0.18.1' = [
       ingressTransport: 'auto'
       ingressAllowInsecure: false
 
-      dapr: {
+      dapr: app.?dapr.?enabled == true ? {
         enabled: true
-        appId: app.service_name
-        appPort: int(app.?target_port ?? 8080)
-        appProtocol: 'http'
-      }
+        appId: app.?dapr.?appId ?? app.service_name
+        appPort: int(app.?dapr.?appPort ?? app.?target_port ?? 8080)
+        appProtocol: app.?dapr.?appProtocol ?? 'http'
+        enableApiLogging: app.?dapr.?enableApiLogging ?? false
+      } : null
 
       managedIdentities: {
         systemAssigned: (_useUAI) ? false : true


### PR DESCRIPTION
## Summary
- Makes Container Apps Dapr configuration opt-in per app via \containerAppsList[].dapr.enabled=true\.
- Preserves per-app defaults for \ppId\, \ppPort\, \ppProtocol\, and \nableApiLogging\ when Dapr is explicitly enabled.
- Updates CHANGELOG with the behavior change and migration note for Dapr-dependent workloads such as GPT-RAG.

Fixes #86.

## Validation
- Ran \z bicep build --file main.bicep\.
- Deployed a minimal validation environment in Azure with two Container Apps: one without \dapr\ and one with \dapr.enabled=true\.
- Confirmed deployed state: the first app had \configuration.dapr = null\; the second app had Dapr enabled with the configured values.

## Follow-up
After this lands and is released, GPT-RAG should update its landing zone pin and explicitly set \dapr.enabled=true\ for services that use Dapr service invocation.