### PR TITLE
chore: release 2.0.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
 
 ## [Unreleased]
 
+## [v2.0.13] - 2026-06-02
+
+### Fixed
+
+- **Foundry Agent Service v2 Cosmos data-plane permissions.** The AI Foundry project managed identity now receives Cosmos DB Built-in Data Contributor assignments for the capability-host containers used by declarative/versioned agents: `agent-definitions-v1` and `run-state-v1`. These containers back `AIProjectClient.agents.create_version()` / `PromptAgentDefinition` agent definitions and run state. Without these assignments, new deployments that use the Foundry Agent Service v2 agent API can fail with Cosmos DB `403` errors even though the legacy thread/entity stores are accessible.
+
 ## [v2.0.12] - 2026-06-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
 
 ## [Unreleased]
 
+## [v2.0.14] - 2026-06-04
+
+### Changed
+
+- **Dapr is now opt-in per Container App** (addresses #86): Container Apps no longer receive Dapr configuration automatically. Apps can enable Dapr explicitly through `containerAppsList[].dapr.enabled=true`, with optional per-app overrides for `appId`, `appPort`, `appProtocol`, and `enableApiLogging`. This makes external app deployments avoid unnecessary Dapr sidecars by default while allowing GPT-RAG and other Dapr-dependent workloads to preserve service invocation by declaring Dapr explicitly.
+
 ## [v2.0.13] - 2026-06-02
 
 ### Fixed

--- a/main.bicep
+++ b/main.bicep
@@ -582,7 +582,7 @@ param modelDeploymentList array
 // Container Apps params
 // ----------------------------------------------------------------------
 
-@description('List of container apps to create')
+@description('List of container apps to create. Dapr is opt-in per app through `dapr.enabled=true`; apps without a `dapr` object deploy with Dapr disabled.')
 param containerAppsList array
 
 @description('Workload profiles.')
@@ -2705,12 +2705,13 @@ module containerApps 'br/public:avm/res/app/container-app:0.18.1' = [
       ingressTransport: 'auto'
       ingressAllowInsecure: false
 
-      dapr: {
+      dapr: app.?dapr.?enabled == true ? {
         enabled: true
-        appId: app.service_name
-        appPort: int(app.?target_port ?? 8080)
-        appProtocol: 'http'
-      }
+        appId: app.?dapr.?appId ?? app.service_name
+        appPort: int(app.?dapr.?appPort ?? app.?target_port ?? 8080)
+        appProtocol: app.?dapr.?appProtocol ?? 'http'
+        enableApiLogging: app.?dapr.?enableApiLogging ?? false
+      } : null
 
       managedIdentities: {
         systemAssigned: (_useUAI) ? false : true

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
-  "tag": "v2.0.12",
+  "tag": "v2.0.13",
   "repo": "https://github.com/azure/bicep-ptn-aiml-landing-zone.git",
-  "ailz_tag": "v2.0.12",
+  "ailz_tag": "v2.0.13",
   "components": []
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
-  "tag": "v2.0.13",
+  "tag": "v2.0.14",
   "repo": "https://github.com/azure/bicep-ptn-aiml-landing-zone.git",
-  "ailz_tag": "v2.0.13",
+  "ailz_tag": "v2.0.14",
   "components": []
 }

--- a/modules/ai-foundry/foundry/modules/project/role-assignments/cosmosDbDataPlane.bicep
+++ b/modules/ai-foundry/foundry/modules/project/role-assignments/cosmosDbDataPlane.bicep
@@ -12,11 +12,17 @@ resource cosmosDb 'Microsoft.DocumentDB/databaseAccounts@2025-04-15' existing = 
   scope: resourceGroup()
 }
 
-// NOTE: these are containers that are automatically created by the capability host for the project workspace
+// NOTE: these are containers that are automatically created by the capability host for the project workspace.
+// The thread/entity stores back the legacy Assistants-style agents; ``agent-definitions-v1`` and
+// ``run-state-v1`` back the new Foundry declarative/versioned agents (AIProjectClient.agents.create_version
+// + PromptAgentDefinition). All five must be granted so create-once/versioned agents can read their
+// definition and persist run state (otherwise create_version / run_stream return a Cosmos 403).
 var cosmosContainerNameSuffixes = [
   'thread-message-store'
   'system-thread-message-store'
   'agent-entity-store'
+  'agent-definitions-v1'
+  'run-state-v1'
 ]
 
 var cosmosDefaultSqlRoleDefinitionId = resourceId(


### PR DESCRIPTION
## Summary
- Releases v2.0.14 with Container Apps Dapr opt-in support from #90.
- Carries forward the latest v2.0.13 Foundry Agent Service v2 Cosmos RBAC fix as the release base.
- Bumps \manifest.json\ tag and \ilz_tag\ to \2.0.14\.

## Validation
- Ran \z bicep build --file main.bicep\ on the release branch.
- Dapr behavior was validated in Azure from #90: an app without \containerAppsList[].dapr\ deployed with \configuration.dapr = null\; an app with \dapr.enabled=true\ deployed with Dapr enabled.

## Follow-up
After this release is published, GPT-RAG should update its landing zone pin to \2.0.14\ and explicitly enable Dapr for services that use Dapr service invocation.