### PR TITLE
fix(foundry): scope Cosmos data-plane RBAC at database level for Agent Service v2 lazy containers (#94)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
 
 ## [Unreleased]
 
+### Fixed
+
+- **Foundry Agent Service v2 Cosmos data-plane assignments now cover lazily-created containers** ([#94](https://github.com/Azure/bicep-ptn-aiml-landing-zone/issues/94)). The `cosmosDbDataPlane.bicep` module previously created five per-collection `Cosmos DB Built-in Data Contributor` assignments scoped to a fixed list of capability-host containers (`thread-message-store`, `system-thread-message-store`, `agent-entity-store`, `agent-definitions-v1`, `run-state-v1`). The Foundry Agent Service v2 runtime creates additional containers on demand (for example `<workspaceId>-aoaiv2-vector-store-store`), and the data-plane RBAC check against any not-yet-created collection scope returns `403`, breaking `AIProjectClient.agents.create_version` and `run_stream` in regions such as `swedencentral`. The module now creates a single role assignment scoped at the database level (`dbs/enterprise_memory`) so the project identity is authorized over every container the capability host owns, including ones materialized at runtime. The assignment name uses `guid(roleDefinitionId, principalId, dbScope, projectWorkspaceId)` so redeploys are idempotent. The database is dedicated to the Foundry capability host, so this is not a privilege widening in practice.
+  - Operator note for upgrades from v2.0.13 / v2.0.14: the previous five per-collection assignments remain on the account as orphans. They are informational only, not blocking, and are not removed by Bicep. If you want to clean them up, use `az cosmosdb sql role assignment delete` against the `dbs/enterprise_memory/colls/<workspaceId>-<suffix>` scopes.
+
 ## [v2.0.15] - 2026-06-11
 
 ### Fixed

--- a/modules/ai-foundry/foundry/modules/project/role-assignments/cosmosDbDataPlane.bicep
+++ b/modules/ai-foundry/foundry/modules/project/role-assignments/cosmosDbDataPlane.bicep
@@ -7,23 +7,14 @@ param projectIdentityPrincipalId string
 @description('Required. The project workspace ID.')
 param projectWorkspaceId string
 
+// Name of the database that the Foundry capability host owns. Isolated as a
+// variable so the Foundry contract is named once and reused.
+var foundryCapabilityHostDbName = 'enterprise_memory'
+
 resource cosmosDb 'Microsoft.DocumentDB/databaseAccounts@2025-04-15' existing = {
   name: cosmosDbName
   scope: resourceGroup()
 }
-
-// NOTE: these are containers that are automatically created by the capability host for the project workspace.
-// The thread/entity stores back the legacy Assistants-style agents; ``agent-definitions-v1`` and
-// ``run-state-v1`` back the new Foundry declarative/versioned agents (AIProjectClient.agents.create_version
-// + PromptAgentDefinition). All five must be granted so create-once/versioned agents can read their
-// definition and persist run state (otherwise create_version / run_stream return a Cosmos 403).
-var cosmosContainerNameSuffixes = [
-  'thread-message-store'
-  'system-thread-message-store'
-  'agent-entity-store'
-  'agent-definitions-v1'
-  'run-state-v1'
-]
 
 var cosmosDefaultSqlRoleDefinitionId = resourceId(
   'Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions',
@@ -31,15 +22,31 @@ var cosmosDefaultSqlRoleDefinitionId = resourceId(
   '00000000-0000-0000-0000-000000000002'
 )
 
-@batchSize(1)
-resource cosmosDataRoleAssigment 'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments@2025-04-15' = [
-  for (containerSuffix, i) in cosmosContainerNameSuffixes: {
-    parent: cosmosDb
-    name: guid(cosmosDefaultSqlRoleDefinitionId, cosmosDbName, containerSuffix, projectIdentityPrincipalId)
-    properties: {
-      principalId: projectIdentityPrincipalId
-      roleDefinitionId: cosmosDefaultSqlRoleDefinitionId
-      scope: '${cosmosDb.id}/dbs/enterprise_memory/colls/${projectWorkspaceId}-${containerSuffix}'
-    }
+var foundryCapabilityHostDbScope = '${cosmosDb.id}/dbs/${foundryCapabilityHostDbName}'
+
+// The Foundry Agent Service v2 capability host owns every collection under the
+// `enterprise_memory` database and creates additional containers lazily at
+// runtime (for example `<workspaceId>-aoaiv2-vector-store-store`). A
+// per-collection role assignment cannot cover containers that do not exist
+// yet, which causes `AIProjectClient.agents.create_version` / `run_stream` to
+// fail with Cosmos 403 in regions such as `swedencentral`. We assign Built-in
+// Data Contributor at database scope so the project identity is authorized
+// over the whole capability-host DB. See issue #94.
+// projectWorkspaceId is included in the role assignment name so that
+// redeploys remain deterministic and so the calling module's contract stays
+// stable (the parameter was previously used to interpolate per-collection
+// scopes).
+resource cosmosDataRoleAssignment 'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments@2025-04-15' = {
+  parent: cosmosDb
+  name: guid(
+    cosmosDefaultSqlRoleDefinitionId,
+    projectIdentityPrincipalId,
+    foundryCapabilityHostDbScope,
+    projectWorkspaceId
+  )
+  properties: {
+    principalId: projectIdentityPrincipalId
+    roleDefinitionId: cosmosDefaultSqlRoleDefinitionId
+    scope: foundryCapabilityHostDbScope
   }
-]
+}


### PR DESCRIPTION
## Purpose

Foundry Agent Service v2 lazily creates Cosmos containers at runtime (for example `<workspaceId>-aoaiv2-vector-store-store`). The current `cosmosDbDataPlane.bicep` module pre-creates `Cosmos DB Built-in Data Contributor` role assignments only for a fixed set of five capability-host containers, scoped per-collection. Any data-plane call that touches a not-yet-created container fails the RBAC check with `403`, breaking `AIProjectClient.agents.create_version` and `run_stream` in regions such as `swedencentral`.

This PR moves the assignment up to the database scope so the project identity is authorized for every container the capability host owns, including the ones that only exist after the first run.

## Type of change
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## Root cause

Cosmos DB SQL data-plane RBAC matches the assignment `scope` against the request URI. An assignment scoped to `dbs/enterprise_memory/colls/<workspaceId>-thread-message-store` does not authorize a request against `dbs/enterprise_memory/colls/<workspaceId>-aoaiv2-vector-store-store`. Because v2 of the Agent Service creates the second container lazily, no preexisting assignment can cover it. The check returns `403` and the SDK call fails.

The previous five-container list was specific to the legacy Assistants stores and the first-generation declarative agent stores. It was never going to track the runtime container set as Foundry evolves it.

## Fix

In `modules/ai-foundry/foundry/modules/project/role-assignments/cosmosDbDataPlane.bicep`:

- Replace the five per-collection `sqlRoleAssignments` with a single assignment scoped at the database level: `/dbs/enterprise_memory`.
- Introduce `var foundryCapabilityHostDbName = 'enterprise_memory'` so the Foundry capability host contract is named once and reused.
- Use `guid(roleDefinitionId, principalId, dbScope, projectWorkspaceId)` for the assignment name so redeploys are deterministic.

The database `enterprise_memory` is dedicated to the Foundry capability host, so granting Built-in Data Contributor at database scope is not a meaningful privilege widening compared to the previous five-container intent.

## Validation

### Static
- [x] `az bicep build --file main.bicep` clean (only pre-existing warnings).

### Azure end-to-end (Standard mode, `swedencentral`)
- [x] `azd provision` against this branch — **SUCCESS in 21m 1s**. Cosmos DB, Foundry account/project, capability host, and role assignments all deployed cleanly.
- [x] Cosmos role assignments inspected post-deploy — single new assignment at `dbs/enterprise_memory` (DB scope, no `colls/...`) is present, owned by the project identity. ✓
- [x] Smoke test: `AIProjectClient.agents.create_version` followed by streaming `responses.create` (the `run_stream` equivalent on Foundry v2):
  - `agents.create_version(...)` returned cleanly. This is the call that materializes the lazy `<workspaceId>-aoaiv2-vector-store-store` container.
  - Streaming response completed (`response.completed` event received, 12 events streamed, final text `'pong.'`).
  - **No Cosmos 403** anywhere in the flow.
- [x] Redeploy idempotency confirmed by the deterministic `guid(roleDefinitionId, principalId, dbScope, projectWorkspaceId)` name — incremental redeploy does not duplicate the assignment.

## Related issues

- Closes #94.
- Builds on the v2.0.13 fix that added `agent-definitions-v1` and `run-state-v1` to the per-collection list. That fix is superseded by this one.

## Operator-facing notes

- Customers upgrading from `v2.0.13` or `v2.0.14` will keep up to five pre-existing per-collection assignments on the Cosmos account. They are orphaned but harmless. Bicep does not remove them. Confirmed in this validation env: 3 orphan per-collection assignments remain alongside the new DB-scoped one. Optional cleanup: `az cosmosdb sql role assignment delete` against the `dbs/enterprise_memory/colls/<workspaceId>-<suffix>` scopes.
- No parameter contract changes. No `main.parameters.json` update required.

## Code quality checklist
- [x] Verified the changes locally; `az bicep build` is clean.
- [x] Azure smoke test (`AIProjectClient.agents.create_version` + streaming `responses.create`) passed in `swedencentral`.