### PR TITLE
v2.0.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
 
 ## [Unreleased]
 
+### Fixed
+
+- **Regional preflight no longer emits non-actionable transient capacity warnings.** Removed the `SEARCH_CAPACITY`, `COSMOS_CAPACITY`, and `ACA_WORKLOAD_PROFILE_CAPACITY` warnings because Azure does not expose reliable pre-create APIs for those transient capacity pools. The preflight now stays focused on checks it can actually validate, such as provider/location support, VM SKU availability, and AI model quota.
+
 ## [v2.0.17] - 2026-06-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.  
 This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [v2.0.18] - 2026-06-16
 
 ### Fixed
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
-  "tag": "v2.0.14",
+  "tag": "v2.0.18",
   "repo": "https://github.com/azure/bicep-ptn-aiml-landing-zone.git",
-  "ailz_tag": "v2.0.14",
+  "ailz_tag": "v2.0.18",
   "components": []
 }

--- a/scripts/Invoke-PreflightChecks.ps1
+++ b/scripts/Invoke-PreflightChecks.ps1
@@ -733,9 +733,6 @@ function Test-AzureResources {
 #     `preprovision` hook (i.e. an azd env is present).
 #   * Provider/location support — for each resource type the landing zone
 #     provisions, confirm the provider lists the chosen region as supported.
-#   * Transient regional capacity — known to fail at provision time with
-#     `InsufficientResourcesAvailable` (Search) or `ServiceUnavailable`
-#     (Cosmos DB) even when the region is listed as supported; raised as WARN.
 #   * Jumpbox VM SKU availability — when a jumpbox is requested, confirm the
 #     requested VM size is offered (and not restricted) in the region for the
 #     current subscription.
@@ -1005,23 +1002,14 @@ function Test-RegionalReadiness {
     if ($deploySearch) {
         Test-ProviderLocation -ProviderNamespace 'Microsoft.Search' -ResourceType 'searchServices' `
             -Location $location -DisplayName 'Azure AI Search' -CodePrefix 'SEARCH'
-        Add-Finding -Severity WARN -Code 'SEARCH_CAPACITY' `
-            -Message "Azure AI Search transient regional capacity (InsufficientResourcesAvailable) is not exposed by any pre-create quota API; this preflight validates provider/location support only." `
-            -Hint "If provisioning fails with InsufficientResourcesAvailable, retry in a different region — see https://azure.github.io/AI-Landing-Zones/bicep/regional-considerations/."
     }
     if ($deployCosmos) {
         Test-ProviderLocation -ProviderNamespace 'Microsoft.DocumentDB' -ResourceType 'databaseAccounts' `
             -Location $cosmosLocation -DisplayName 'Azure Cosmos DB' -CodePrefix 'COSMOS'
-        Add-Finding -Severity WARN -Code 'COSMOS_CAPACITY' `
-            -Message "Cosmos DB transient regional capacity (ServiceUnavailable on high-demand regions) is not exposed by a pre-create quota API; this preflight validates provider/location support only." `
-            -Hint "If provisioning fails with ServiceUnavailable, retry in a different region — see https://azure.github.io/AI-Landing-Zones/bicep/regional-considerations/."
     }
     if ($deployContainerApps -or $deployContainerEnv) {
         Test-ProviderLocation -ProviderNamespace 'Microsoft.App' -ResourceType 'managedEnvironments' `
             -Location $location -DisplayName 'Azure Container Apps Environment' -CodePrefix 'ACA'
-        Add-Finding -Severity WARN -Code 'ACA_WORKLOAD_PROFILE_CAPACITY' `
-            -Message "Container Apps workload profiles (D-series/E-series) occasionally hit transient capacity limits in popular regions; this preflight validates provider/location support only." `
-            -Hint "If environment creation fails on workload-profile capacity, retry or fall back to the Consumption profile."
     }
     if ($deployAiFoundry) {
         Test-ProviderLocation -ProviderNamespace 'Microsoft.CognitiveServices' -ResourceType 'accounts' `


### PR DESCRIPTION
## Summary
- Promote the non-actionable capacity preflight warning removal to v2.0.18.
- Update manifest release metadata to v2.0.18.
- Move the changelog entry from Unreleased to v2.0.18.

## Validation
- Parsed scripts/Invoke-PreflightChecks.ps1 with the PowerShell parser.
- Ran `az bicep build --file main.bicep`.