### PR TITLE
Parameterize AI Foundry project name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.  
 This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres to [Semantic Versioning](https://semver.org/).
 
+## [v2.0.19] - 2026-06-17
+
+### Fixed
+
+- **AI Foundry project deployments now honor `aiFoundryProjectName`** ([#101](https://github.com/Azure/bicep-ptn-aiml-landing-zone/issues/101)). The template already exposed `aiFoundryProjectName` and published it to App Configuration as `AI_FOUNDRY_PROJECT_NAME`, but the AI Foundry project resource still used the hardcoded name `aifoundry-default-project`. The deployed project name now follows the parameterized naming pattern, and the project display name and description can be customized with `aiFoundryProjectDisplayName` and `aiFoundryProjectDescription` while preserving the previous defaults when omitted.
+
 ## [v2.0.18] - 2026-06-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
 
 ### Fixed
 
-- **AI Foundry project deployments now honor `aiFoundryProjectName`** ([#101](https://github.com/Azure/bicep-ptn-aiml-landing-zone/issues/101)). The template already exposed `aiFoundryProjectName` and published it to App Configuration as `AI_FOUNDRY_PROJECT_NAME`, but the AI Foundry project resource still used the hardcoded name `aifoundry-default-project`. The deployed project name now follows the parameterized naming pattern, and the project display name and description can be customized with `aiFoundryProjectDisplayName` and `aiFoundryProjectDescription` while preserving the previous defaults when omitted.
+- **AI Foundry project deployments now honor `aiFoundryProjectName`** ([#101](https://github.com/Azure/bicep-ptn-aiml-landing-zone/issues/101)). The template already exposed `aiFoundryProjectName` and published it to App Configuration as `AI_FOUNDRY_PROJECT_NAME`, but the AI Foundry project resource still used the hardcoded name `aifoundry-default-project`. The deployed project name now follows the parameterized naming pattern, the display name defaults to that same generated project name, and both display name and description can still be customized with `aiFoundryProjectDisplayName` and `aiFoundryProjectDescription`.
 
 ## [v2.0.18] - 2026-06-16
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A handful of other quality-of-life additions:
 - **Decoupled hub components** — `deployJumpbox`, `deployBastion`, and `deployNatGateway` are now independent flags. No more all-or-nothing `deployVM`.
 - **Hub integration helpers** — `hubIntegration.hubVnetResourceId` creates the spoke→hub peering for you; `hubIntegration.egressNextHopIp` routes spoke egress through your hub firewall / NVA.
 - **Pre-flight validation** — `scripts/Invoke-PreflightChecks.ps1` runs automatically as an `azd preprovision` hook and catches the usual mistakes (CIDR overlap, undersized subnets, missing BYO resource IDs, conflicting flags) before they reach ARM. Bypass with `PREFLIGHT_SKIP=true`.
+- **AI Foundry project naming** — `aiFoundryProjectName`, `aiFoundryProjectDisplayName`, and `aiFoundryProjectDescription` let consumers customize the deployed AI Foundry project instead of using a hardcoded default.
 
 **Pick a runbook to deploy:**
 

--- a/main.bicep
+++ b/main.bicep
@@ -531,6 +531,12 @@ param aiFoundryAccountName string = '${const.abbrs.ai.aiFoundry}${resourceToken}
 @description('Name of the AI Foundry project resource.')
 param aiFoundryProjectName string = '${const.abbrs.ai.aiFoundryProject}${resourceToken}'
 
+@description('Optional display name for the AI Foundry project. When omitted, the default display name is used.')
+param aiFoundryProjectDisplayName string?
+
+@description('Optional description for the AI Foundry project. When omitted, the default description is used.')
+param aiFoundryProjectDescription string?
+
 @description('Name of the Storage Account used by AI Foundry for blobs, queues, tables, and files.')
 param aiFoundryStorageAccountName string = replace('${const.abbrs.storage.storageAccount}${const.abbrs.ai.aiFoundry}${resourceToken}', '-', '')
 
@@ -2333,9 +2339,9 @@ module aiFoundry 'modules/ai-foundry/main.bicep' = if (deployAiFoundry) {
 
       project: deployAfProject
         ? {
-            name: 'aifoundry-default-project'
-            displayName: 'Default AI Foundry Project.'
-            description: 'This is the default project for AI Foundry.'
+            name: aiFoundryProjectName
+            displayName: empty(aiFoundryProjectDisplayName) ? 'Default AI Foundry Project.' : aiFoundryProjectDisplayName!
+            description: empty(aiFoundryProjectDescription) ? 'This is the default project for AI Foundry.' : aiFoundryProjectDescription!
           }
         : null
     }

--- a/main.bicep
+++ b/main.bicep
@@ -2340,7 +2340,7 @@ module aiFoundry 'modules/ai-foundry/main.bicep' = if (deployAiFoundry) {
       project: deployAfProject
         ? {
             name: aiFoundryProjectName
-            displayName: empty(aiFoundryProjectDisplayName) ? 'Default AI Foundry Project.' : aiFoundryProjectDisplayName!
+            displayName: empty(aiFoundryProjectDisplayName) ? aiFoundryProjectName : aiFoundryProjectDisplayName!
             description: empty(aiFoundryProjectDescription) ? 'This is the default project for AI Foundry.' : aiFoundryProjectDescription!
           }
         : null

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
-  "tag": "v2.0.18",
+  "tag": "v2.0.19",
   "repo": "https://github.com/azure/bicep-ptn-aiml-landing-zone.git",
-  "ailz_tag": "v2.0.18",
+  "ailz_tag": "v2.0.19",
   "components": []
 }


### PR DESCRIPTION
## Summary
- use aiFoundryProjectName for the deployed AI Foundry project resource
- add optional display name and description parameters with existing defaults
- bump release metadata to v2.0.19

## Validation
- az bicep build --file main.bicep

Closes #101