### PR TITLE
Fix preflight model quota parameter handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.  
 This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres to [Semantic Versioning](https://semver.org/).
 
+## [v2.0.20] - 2026-06-18
+
+### Fixed
+
+- **Preflight now preserves structured parameters before regional model quota checks** ([#103](https://github.com/Azure/bicep-ptn-aiml-landing-zone/issues/103)). `Expand-ParamValue` no longer coerces arrays and objects such as `modelDeploymentList` into strings while expanding `${VAR}` tokens. The AI model quota preflight can now inspect requested OpenAI deployments and fail early with `MODEL_QUOTA_INSUFFICIENT` when the requested capacity exceeds available regional quota, instead of reporting "All checks passed" and letting ARM fail later.
+
 ## [v2.0.19] - 2026-06-17
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A handful of other quality-of-life additions:
 - **`allowedIpRanges`** — let named CIDRs reach the data plane of Storage, Key Vault, Cosmos DB, AI Search, ACR, AI Foundry, and App Configuration without disabling private endpoints. Use this when developers need to query the workload from their laptops without routing through Bastion.
 - **Decoupled hub components** — `deployJumpbox`, `deployBastion`, and `deployNatGateway` are now independent flags. No more all-or-nothing `deployVM`.
 - **Hub integration helpers** — `hubIntegration.hubVnetResourceId` creates the spoke→hub peering for you; `hubIntegration.egressNextHopIp` routes spoke egress through your hub firewall / NVA.
-- **Pre-flight validation** — `scripts/Invoke-PreflightChecks.ps1` runs automatically as an `azd preprovision` hook and catches the usual mistakes (CIDR overlap, undersized subnets, missing BYO resource IDs, conflicting flags) before they reach ARM. Bypass with `PREFLIGHT_SKIP=true`.
+- **Pre-flight validation** — `scripts/Invoke-PreflightChecks.ps1` runs automatically as an `azd preprovision` hook and catches the usual mistakes (CIDR overlap, undersized subnets, missing BYO resource IDs, conflicting flags, and insufficient AI Foundry OpenAI model quota) before they reach ARM. Bypass with `PREFLIGHT_SKIP=true`.
 - **AI Foundry project naming** — `aiFoundryProjectName`, `aiFoundryProjectDisplayName`, and `aiFoundryProjectDescription` let consumers customize the deployed AI Foundry project instead of using a hardcoded default.
 
 **Pick a runbook to deploy:**

--- a/docs/runbook-hub-spoke.md
+++ b/docs/runbook-hub-spoke.md
@@ -235,7 +235,7 @@ Confirm `AZURE_SUBSCRIPTION_ID`, `AZURE_TENANT_ID`, `AZURE_LOCATION=eastus2`, `A
 azd provision
 ```
 
-> A **pre-flight script** (`scripts/Invoke-PreflightChecks.ps1`) runs automatically as an `azd preprovision` hook before the deployment touches Azure. It validates the parameter set (CIDR ranges, BYO resources, conflicting flags) and fails fast on deterministic mistakes. To bypass it temporarily, set `$env:PREFLIGHT_SKIP = 'true'` before running `azd provision`. See [docs/v2-migration.md §6](./v2-migration.md#6-pre-flight-validation-script) for the full list of checks.
+> A **pre-flight script** (`scripts/Invoke-PreflightChecks.ps1`) runs automatically as an `azd preprovision` hook before the deployment touches Azure. It validates the parameter set (CIDR ranges, BYO resources, conflicting flags, and insufficient AI Foundry OpenAI model quota) and fails fast on deterministic mistakes. To bypass it temporarily, set `$env:PREFLIGHT_SKIP = 'true'` before running `azd provision`. See [docs/v2-migration.md §6](./v2-migration.md#6-pre-flight-validation-script) for the full list of checks.
 
 **Expected duration**: 25–35 minutes for a network-isolated spoke with all PEs and the AI Foundry account.
 

--- a/docs/runbook-standalone.md
+++ b/docs/runbook-standalone.md
@@ -133,7 +133,7 @@ You can leave it off (`false`) and run the bootstrap manually after RDP'ing into
 azd provision
 ```
 
-> A **pre-flight script** (`scripts/Invoke-PreflightChecks.ps1`) runs automatically as an `azd preprovision` hook before the deployment touches Azure. It validates the parameter set and fails fast on deterministic mistakes (CIDR overlap, missing BYO resources, conflicting flags). Bypass with `$env:PREFLIGHT_SKIP = 'true'` if needed. See [docs/v2-migration.md §6](./v2-migration.md#6-pre-flight-validation-script).
+> A **pre-flight script** (`scripts/Invoke-PreflightChecks.ps1`) runs automatically as an `azd preprovision` hook before the deployment touches Azure. It validates the parameter set and fails fast on deterministic mistakes (CIDR overlap, missing BYO resources, conflicting flags, and insufficient AI Foundry OpenAI model quota). Bypass with `$env:PREFLIGHT_SKIP = 'true'` if needed. See [docs/v2-migration.md §6](./v2-migration.md#6-pre-flight-validation-script).
 
 **Expected duration**:
 

--- a/docs/v2-migration.md
+++ b/docs/v2-migration.md
@@ -272,6 +272,7 @@ v2.0.0 ships a read-only pre-flight script — **`scripts/Invoke-PreflightChecks
 | **BYO Private DNS** | Each `existingPrivateDnsZone*ResourceId` points at a zone whose name matches the expected `privatelink.<namespace>` convention; zone exists in Azure |
 | **BYO observability** | `existingLogAnalyticsWorkspaceResourceId`, `existingApplicationInsightsResourceId`, `existingBastionResourceId`, `existingNatGatewayResourceId`, `hubIntegrationExistingRouteTableResourceId` exist in Azure |
 | **Hub VNet overlap** | When `hubIntegrationHubVnetResourceId` is set, the spoke's `vnetAddressPrefixes` do not overlap any of the hub's address prefixes (peering would fail) |
+| **Regional readiness** | Provider/location support, jumpbox VM SKU availability, and AI Foundry OpenAI model quota for each OpenAI-format `modelDeploymentList` entry in the AI Foundry region |
 
 ### How it runs
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
-  "tag": "v2.0.19",
+  "tag": "v2.0.20",
   "repo": "https://github.com/azure/bicep-ptn-aiml-landing-zone.git",
-  "ailz_tag": "v2.0.19",
+  "ailz_tag": "v2.0.20",
   "components": []
 }

--- a/scripts/Invoke-PreflightChecks.ps1
+++ b/scripts/Invoke-PreflightChecks.ps1
@@ -182,7 +182,7 @@ function Get-AzdEnvValues {
 
 function Expand-ParamValue {
     param(
-        [string]$Raw,
+        $Raw,
         [hashtable]$EnvValues
     )
     if ($null -eq $Raw) { return $null }

--- a/tests/scripts/Invoke-PreflightChecks.Tests.ps1
+++ b/tests/scripts/Invoke-PreflightChecks.Tests.ps1
@@ -76,6 +76,58 @@ Assert-True 'Contains: /16 contains /24 inside' (Test-CidrContains '10.0.0.0/16'
 Assert-True 'Contains: /16 does not contain /24 outside' (-not (Test-CidrContains '10.0.0.0/16' '10.1.0.0/24'))
 
 # --------------------------------------------------------------------------
+Write-Host 'Parameter expansion preserves structured values' -ForegroundColor Cyan
+
+$envValues = @{ ENVIRONMENT_NAME = 'ailz-test' }
+$expandedString = Expand-ParamValue -Raw 'rg-${ENVIRONMENT_NAME=default}' -EnvValues $envValues
+Assert-True 'String parameters still expand env tokens' ($expandedString -eq 'rg-ailz-test')
+
+$objectValue = [pscustomobject]@{ name = 'text-embedding-3-large'; capacity = 100 }
+$expandedObject = Expand-ParamValue -Raw $objectValue -EnvValues $envValues
+Assert-True 'Object parameter values are preserved' ([object]::ReferenceEquals($objectValue, $expandedObject))
+
+$arrayValue = @(
+    [pscustomobject]@{ model = [pscustomobject]@{ format = 'OpenAI'; name = 'text-embedding-3-large' }; sku = [pscustomobject]@{ name = 'Standard'; capacity = 100 } }
+)
+$expandedArray = Expand-ParamValue -Raw $arrayValue -EnvValues $envValues
+Assert-True 'Array parameter values are preserved' (-not ($expandedArray -is [string]) -and @($expandedArray).Count -eq 1 -and $expandedArray[0].model.name -eq 'text-embedding-3-large')
+
+$paramsFile = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ("ailz-preflight-params-{0}.json" -f ([guid]::NewGuid()))
+try {
+    @'
+{
+  "parameters": {
+    "resourceGroupName": {
+      "value": "rg-${ENVIRONMENT_NAME=default}"
+    },
+    "modelDeploymentList": {
+      "value": [
+        {
+          "model": {
+            "format": "OpenAI",
+            "name": "text-embedding-3-large"
+          },
+          "sku": {
+            "name": "Standard",
+            "capacity": 100
+          }
+        }
+      ]
+    }
+  }
+}
+'@ | Set-Content -Path $paramsFile -Encoding utf8
+    function Get-AzdEnvValues { return @{ ENVIRONMENT_NAME = 'ailz-test' } }
+    Reset-Findings
+    $effectiveParams = Get-EffectiveParameters -Path $paramsFile
+    Assert-True 'Get-EffectiveParameters expands string values' ($effectiveParams['resourceGroupName'] -eq 'rg-ailz-test')
+    Assert-True 'Get-EffectiveParameters preserves modelDeploymentList as array' (-not ($effectiveParams['modelDeploymentList'] -is [string]) -and @($effectiveParams['modelDeploymentList']).Count -eq 1 -and $effectiveParams['modelDeploymentList'][0].sku.capacity -eq 100)
+}
+finally {
+    Remove-Item -Path $paramsFile -ErrorAction SilentlyContinue
+}
+
+# --------------------------------------------------------------------------
 Write-Host 'Topology: policy + BYO DNS conflict' -ForegroundColor Cyan
 Reset-Findings
 Test-Topology -P @{
@@ -238,6 +290,36 @@ finally {
 }
 Assert-True 'REGIONAL_SKIPPED INFO present' (Test-FindingPresent 'REGIONAL_SKIPPED')
 Assert-True 'Only one finding emitted under skip' (@($script:Findings).Count -eq 1)
+
+# --------------------------------------------------------------------------
+Write-Host 'Regional readiness: model quota fails when requested capacity exceeds availability' -ForegroundColor Cyan
+Reset-Findings
+function Invoke-AzCliRaw {
+    param([string[]]$Arguments)
+    if (($Arguments -join ' ') -eq 'cognitiveservices usage list --location westus3 -o json') {
+        return @(
+            [pscustomobject]@{
+                name         = [pscustomobject]@{ value = 'OpenAI.Standard.text-embedding-3-large' }
+                currentValue = 300
+                limit        = 350
+            }
+        )
+    }
+    return $null
+}
+Test-ModelQuota -Location 'westus3' -ModelDeployments @(
+    [pscustomobject]@{
+        model = [pscustomobject]@{
+            format = 'OpenAI'
+            name   = 'text-embedding-3-large'
+        }
+        sku   = [pscustomobject]@{
+            name     = 'Standard'
+            capacity = 100
+        }
+    }
+)
+Assert-True 'MODEL_QUOTA_INSUFFICIENT FAIL raised' (Test-FindingPresent 'MODEL_QUOTA_INSUFFICIENT')
 
 # --------------------------------------------------------------------------
 Write-Host 'Regional readiness: -SkipAzureLookups suppresses block entirely' -ForegroundColor Cyan


### PR DESCRIPTION
## Summary
- Fixes preflight parameter expansion so arrays/objects such as `modelDeploymentList` are preserved instead of coerced to strings.
- Adds coverage for structured parameter preservation and `MODEL_QUOTA_INSUFFICIENT` when requested OpenAI model capacity exceeds available quota.
- Updates v2.0.20 changelog/release metadata and docs that describe preflight regional quota checks.

Fixes #103

## Validation
- `pwsh .\tests\scripts\Invoke-PreflightChecks.Tests.ps1`
- `az bicep build --file main.bicep` (passes with existing Bicep warnings)
- `git --no-pager diff --check`