### PR TITLE
Fix Foundry IQ native Blob defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.  
 This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres to [Semantic Versioning](https://semver.org/).
 
+## [v2.1.2] - 2026-06-26
+
+### Fixed
+
+- **Foundry IQ native Blob permission default matches the service contract.** `foundryIqIngestionPermissionOptions` now defaults to `['rbacScope']`, which Foundry IQ accepts for `azureBlob` Knowledge Sources when `foundryIqIsAdlsGen2=false`. ADLS Gen2 deployments can still override the parameter to include ACL-driven metadata such as `userIds` and `groupIds` when the source supports it.
+
 ## [v2.1.1] - 2026-06-26
 
 ### Added

--- a/main.bicep
+++ b/main.bicep
@@ -527,10 +527,8 @@ param foundryIqIsAdlsGen2 bool = false
 ])
 param foundryIqContentExtractionMode string = 'minimal'
 
-@description('Native Foundry IQ permission metadata to ingest for Blob or ADLS Gen2 security trimming.')
+@description('Native Foundry IQ permission metadata to ingest. Blob sources with foundryIqIsAdlsGen2=false support rbacScope and sensitivityLabels. ADLS Gen2 sources can override this to include userIds and groupIds when ACL metadata is required.')
 param foundryIqIngestionPermissionOptions array = [
-  'userIds'
-  'groupIds'
   'rbacScope'
 ]
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "tag": "v2.1.1",
+  "tag": "v2.1.2",
   "repo": "https://github.com/azure/bicep-ptn-aiml-landing-zone.git",
   "ailz_tag": "v2.1.1",
   "components": []


### PR DESCRIPTION
## Summary
- Default native Blob Foundry IQ permission ingestion to rbacScope, which is accepted when foundryIqIsAdlsGen2=false
- Document ADLS Gen2 override path for userIds/groupIds
- Bump module manifest/changelog to v2.1.2

## Validation
- az bicep build --file main.bicep