### PR TITLE
Default foundryIqContentExtractionMode to standard (OCR for scanned PDFs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.  
 This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- **Default `foundryIqContentExtractionMode` is now `standard`.** The native Foundry IQ azureBlob knowledge source now defaults to `standard` content extraction so scanned and image-only PDFs are ingested with OCR by the Foundry IQ Content Understanding skill. Under the prior `minimal` default, such PDFs were ingested with empty content and silently unsearchable. Operators that only ingest text PDFs can opt down with `FOUNDRY_IQ_CONTENT_EXTRACTION_MODE=minimal` before provisioning. The setting is immutable on an existing Knowledge Source; changing it requires recreating the Knowledge Source and Knowledge Base. `standard` mode requires a Foundry resource in a [Content Understanding-supported region](https://learn.microsoft.com/azure/ai-services/content-understanding/service-limits#region-support), may require a one-time `PATCH /contentunderstanding/defaults` call against the Foundry resource on first use, has per-document limits of 300 pages and 5 minutes of processing time, and is billed through Content Understanding meters in addition to the Azure AI Search `knowledgeRetrieval` plan.
+- **`main.parameters.json` now substitutes `FOUNDRY_IQ_CONTENT_EXTRACTION_MODE` and defaults it to `standard`** so `azd env set` and the parameter file stay aligned with the Bicep default.
+
 ## [v2.1.2] - 2026-06-26
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ until the operator intentionally opts in.
 | `foundryIqFilterAddOnEnabled` / `FOUNDRY_IQ_FILTER_ADD_ON_ENABLED` | `true` | Enables GPT-RAG query-time security filtering for Pattern B. |
 | `foundryIqSecurityFieldName` / `FOUNDRY_IQ_SECURITY_FIELD_NAME` | `metadata_security_id` | Field used by the orchestrator to build Pattern B filters. |
 | `foundryIqMaxOutputDocuments` / `FOUNDRY_IQ_MAX_OUTPUT_DOCUMENTS` | Empty | Optional cap on documents returned by the knowledge base. |
+| `foundryIqContentExtractionMode` / `FOUNDRY_IQ_CONTENT_EXTRACTION_MODE` | `standard` | Native Blob content extraction mode. `standard` uses the Foundry IQ Content Understanding skill (layout and OCR) so scanned and image-only PDFs are ingested with text. `minimal` skips Content Understanding and only ingests text already present in the source. The setting is immutable on an existing Knowledge Source. |
 | `foundryIqBaseFilter` / `FOUNDRY_IQ_BASE_FILTER` | Empty | Optional persisted filter for the Pattern B knowledge source. |
 | `foundryIqSourceDataFields` / `FOUNDRY_IQ_SOURCE_DATA_FIELDS` | Template default | Fields exposed by the Pattern B knowledge source. |
 | `foundryIqSearchFields` / `FOUNDRY_IQ_SEARCH_FIELDS` | Template default | Searchable fields used by the Pattern B knowledge source. |

--- a/main.bicep
+++ b/main.bicep
@@ -520,12 +520,12 @@ param foundryIqStorageFolderPath string = ''
 @description('Set true when the native Foundry IQ azureBlob knowledge source points to an ADLS Gen2 account/container with hierarchical namespace enabled.')
 param foundryIqIsAdlsGen2 bool = false
 
-@description('Native Foundry IQ content extraction mode for the azureBlob knowledge source.')
+@description('Native Foundry IQ content extraction mode for the azureBlob knowledge source. standard uses the Content Understanding skill for layout and OCR, which is required for scanned and image-only PDFs. minimal skips Content Understanding and ingests only text already present in the source.')
 @allowed([
   'minimal'
   'standard'
 ])
-param foundryIqContentExtractionMode string = 'minimal'
+param foundryIqContentExtractionMode string = 'standard'
 
 @description('Native Foundry IQ permission metadata to ingest. Blob sources with foundryIqIsAdlsGen2=false support rbacScope and sensitivityLabels. ADLS Gen2 sources can override this to include userIds and groupIds when ACL metadata is required.')
 param foundryIqIngestionPermissionOptions array = [

--- a/main.parameters.json
+++ b/main.parameters.json
@@ -36,6 +36,7 @@
     "foundryIqFilterAddOnEnabled":         { "value": "${FOUNDRY_IQ_FILTER_ADD_ON_ENABLED=true}" },
     "foundryIqSecurityFieldName":          { "value": "${FOUNDRY_IQ_SECURITY_FIELD_NAME=metadata_security_id}" },
     "foundryIqMaxOutputDocuments":         { "value": "${FOUNDRY_IQ_MAX_OUTPUT_DOCUMENTS=}" },
+    "foundryIqContentExtractionMode":      { "value": "${FOUNDRY_IQ_CONTENT_EXTRACTION_MODE=standard}" },
 
     "aiSearchResourceId":                  { "value": null },
     "aiFoundryStorageAccountResourceId":   { "value": null },


### PR DESCRIPTION
## Summary

Switches the Bicep default `foundryIqContentExtractionMode` from `minimal` to `standard` for the native Foundry IQ azureBlob knowledge source.

## Why

Under the prior `minimal` default, scanned and image-only PDFs were ingested with empty content and silently unsearchable. End-to-end validation reproduced the failure (28-page scanned `vw-fuel-system.pdf` ingested as empty) and confirmed `standard` produces a clean OCR pass via the `Microsoft.Skills.Util.ContentUnderstandingSkill`. Most real document libraries include some scanned content, so the safer default is `standard`.

## What changes

- `main.bicep`: `foundryIqContentExtractionMode` default flips to `standard`; description now explains the trade-off.
- `main.parameters.json`: adds `"foundryIqContentExtractionMode": { "value": "${FOUNDRY_IQ_CONTENT_EXTRACTION_MODE=standard}" }` so `azd env set` and the parameter file stay aligned.
- `README.md`: adds the `foundryIqContentExtractionMode` / `FOUNDRY_IQ_CONTENT_EXTRACTION_MODE` row to the Foundry IQ parameters table.
- `CHANGELOG.md` `[Unreleased]`: documents the new default, the Content Understanding region requirement, the one-time `PATCH /contentunderstanding/defaults` prereq, the 300-page / 5-min limits, the Content Understanding billing, and the immutability of the setting on an existing Knowledge Source.

Operators with text-only PDFs can opt down before provisioning:
```bash
azd env set FOUNDRY_IQ_CONTENT_EXTRACTION_MODE minimal
```

## Validation

- `az bicep build --file main.bicep` compiles cleanly (no new warnings; existing warnings are pre-existing).
- No new resources, no role changes, no networking changes. Parameter default only.
- Consumer GPT-RAG core uses the matching default in `scripts/postProvision.ps1`; tracked in Azure/GPT-RAG#532.

## References

- Native content extraction modes: https://learn.microsoft.com/azure/search/search-howto-index-blobs
- Content Understanding skill: https://learn.microsoft.com/azure/search/cognitive-search-skill-content-understanding
- Content Understanding region support: https://learn.microsoft.com/azure/ai-services/content-understanding/service-limits