### PR TITLE
Update AI Landing Zone docs site source reference in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -282,11 +282,14 @@ Where landing-zone documentation lives:
     topology, or migration steps change.
 - **Public AI Landing Zone site (separate repo):** the narrative published at
   https://azure.github.io/AI-Landing-Zones/bicep is sourced from the
-  `Azure/AI-Landing-Zones` repository (built from its `gh-pages` branch), not
-  from this repo. When a change alters the public bicep landing-zone story
-  (architecture, design areas, consumer-facing parameters/flags, what's-new),
-  open a **companion PR in `Azure/AI-Landing-Zones`** and link it from this
-  PR's description.
+  `Azure/AI-Landing-Zones` repository, where the documentation source now lives
+  on the `main` branch (the full MkDocs project under `docs/` and `mkdocs.yml`),
+  not in this repo. The site is built and published automatically to the
+  `gh-pages` branch on every push to `main`, so `gh-pages` is generated output,
+  not the source you edit. When a change alters the public bicep landing-zone
+  story (architecture, design areas, consumer-facing parameters/flags,
+  what's-new), open a **companion PR against `main` of `Azure/AI-Landing-Zones`**
+  and link it from this PR's description.
 
 Rules:
 - A change is **not done** until the matching docs are updated, or you have


### PR DESCRIPTION
The documentation source for the public AI Landing Zone site (https://azure.github.io/AI-Landing-Zones/bicep) moved. It previously lived on a separate `mkdocs` branch of `Azure/AI-Landing-Zones`; it now lives on that repo's `main` branch as the full MkDocs project (`docs/` and `mkdocs.yml`). The site is built and published automatically to the `gh-pages` branch on every push to `main`, so `gh-pages` is generated output rather than the source you edit. The old `mkdocs` and `documentation` branches were retired.

This PR corrects the "Documentation Consistency" guidance in `AGENTS.md` so it reflects the new flow: the narrative source lives on `main` of `Azure/AI-Landing-Zones`, the site rebuilds on push to `main`, and companion PRs for the public bicep landing-zone story should now target `main`.

Only the single relevant bullet was changed; the rest of the section is untouched.