### PR TITLE
Incrementally modularize main.bicep (#87)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
 ### Changed
 
 - **`main.bicep` has clearer modular seams for the issue #87 maintainability track.** Container Apps naming, Dapr, and base environment shaping now use named locals; Azure Firewall rule construction is separated from the firewall resources; and private endpoint DNS zone groups are centralized in a single map. These are behavior-preserving refactors intended to reduce future edit risk in the large orchestration template.
+- **`main.bicep` is reduced by extracting large resource bodies into local modules (issue #87).** The Azure Firewall (policy, rule collection groups, public IP, diagnostics, and FQDN rule data) moved to `modules/networking/azure-firewall.bicep`; the per-app container control-plane role loops were consolidated into a single array-driven `resource-role-assignment` invocation; and the remaining cross-service control-plane role grants (Search, Storage, and AI Foundry project identities) were consolidated into one array-driven invocation. This is an internal maintainability refactor that moves code without changing any deployed resource, name, condition, dependency, or property value. The orchestration template went from roughly 4329 to 3698 lines.
 
 ## [v2.1.5] - 2026-06-30
 

--- a/main.bicep
+++ b/main.bicep
@@ -3215,23 +3215,59 @@ module assignContainerAppRoles 'modules/security/resource-role-assignment.bicep'
   }
 ]
 
-// AI Foundry Account - Cognitive Services User -> Search Service (for agentic retrieval vectorizers)
-module assignAiFoundryAccountCognitiveServicesUserSearch 'modules/security/resource-role-assignment.bicep' = if (deployAiFoundry && deploySearchService) {
-  name: 'assignAiFoundryAccountCognitiveServicesUserSearch'
+// Cross-service control-plane role assignments (consolidated; see #87).
+// Each entry is conditionally included exactly as before; the underlying
+// guid(principalId, roleDefinitionId, resourceId) keeps deployed role
+// assignment GUIDs identical regardless of the deployment/module name.
+var _crossServiceRoleAssignments = concat(
+  // AI Foundry Account - Cognitive Services User -> Search Service (for agentic retrieval vectorizers)
+  (deployAiFoundry && deploySearchService) ? [
+    {
+      #disable-next-line BCP318
+      principalId: (_useUAI) ? searchServiceUAI.properties.principalId : searchService.outputs.systemAssignedMIPrincipalId!
+      roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', const.roles.CognitiveServicesUser.guid)
+      resourceId: aiFoundryAccountResourceId
+      principalType: 'ServicePrincipal'
+    }
+  ] : [],
+  // Storage Account - Storage Blob Data Reader -> Search Service
+  (deployStorageAccount && deploySearchService) ? [
+    {
+      #disable-next-line BCP318
+      principalId: (_useUAI) ? searchServiceUAI.properties.principalId : searchService.outputs.systemAssignedMIPrincipalId!
+      roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', const.roles.StorageBlobDataReader.guid)
+      #disable-next-line BCP318
+      resourceId: storageAccount.outputs.resourceId
+      principalType: 'ServicePrincipal'
+    }
+  ] : [],
+  // Search Service - Search Index Data Reader -> AiFoundryProject
+  (deployAiFoundry && deploySearchService) ? [
+    {
+      principalId: aiFoundry!.outputs.aiProjectPrincipalId
+      roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', const.roles.SearchIndexDataReader.guid)
+      #disable-next-line BCP318
+      resourceId: searchService.outputs.resourceId
+      principalType: 'ServicePrincipal'
+    }
+  ] : [],
+  // Storage Account - Storage Blob Data Reader -> AiFoundry Project
+  (deployAiFoundry && deployStorageAccount) ? [
+    {
+      principalId: aiFoundry!.outputs.aiProjectPrincipalId
+      roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', const.roles.StorageBlobDataReader.guid)
+      #disable-next-line BCP318
+      resourceId: storageAccount.outputs.resourceId
+      principalType: 'ServicePrincipal'
+    }
+  ] : []
+)
+
+module assignCrossServiceRoles 'modules/security/resource-role-assignment.bicep' = if ((deployAiFoundry && deploySearchService) || (deployStorageAccount && deploySearchService) || (deployAiFoundry && deployStorageAccount)) {
+  name: 'assignCrossServiceRoles'
   params: {
-    name: 'assignAiFoundryAccountCognitiveServicesUserSearch'
-    roleAssignments: [
-      {
-        #disable-next-line BCP318
-        principalId: (_useUAI) ? searchServiceUAI.properties.principalId : searchService.outputs.systemAssignedMIPrincipalId!
-        roleDefinitionId: subscriptionResourceId(
-          'Microsoft.Authorization/roleDefinitions',
-          const.roles.CognitiveServicesUser.guid
-        )
-        resourceId: aiFoundryAccountResourceId
-        principalType: 'ServicePrincipal'
-      }
-    ]
+    name: 'assignCrossServiceRoles'
+    roleAssignments: _crossServiceRoleAssignments
   }
 }
 
@@ -3253,72 +3289,11 @@ module assignCosmosDBCosmosDbBuiltInDataContributorContainerApps 'modules/securi
   }
 ]
 
-// Storage Account - Storage Blob Data Reader -> Search Service
-module assignStorageStorageBlobDataReaderSearch 'modules/security/resource-role-assignment.bicep' = if (deployStorageAccount && deploySearchService) {
-  name: 'assignStorageStorageBlobDataReaderSearch'
-  params: {
-    name: 'assignStorageStorageBlobDataReaderSearch'
-    roleAssignments: [
-      {
-        #disable-next-line BCP318
-        principalId: (_useUAI) ? searchServiceUAI.properties.principalId : searchService.outputs.systemAssignedMIPrincipalId!
-        roleDefinitionId: subscriptionResourceId(
-          'Microsoft.Authorization/roleDefinitions',
-          const.roles.StorageBlobDataReader.guid
-        )
-        #disable-next-line BCP318
-        resourceId: storageAccount.outputs.resourceId
-        principalType: 'ServicePrincipal'
-      }
-    ]
-  }
-}
-
-// Search Service - Search Index Data Reader -> AiFoundryProject
-module assignSearchSearchIndexDataReaderAIFoundryProject 'modules/security/resource-role-assignment.bicep' = if (deployAiFoundry && deploySearchService) {
-  name: 'assignSearchSearchIndexDataReaderAIFoundryProject'
-  params: {
-    name: 'assignSearchSearchIndexDataReaderAIFoundryProject'
-    roleAssignments: [
-      {
-        principalId: aiFoundry!.outputs.aiProjectPrincipalId
-        roleDefinitionId: subscriptionResourceId(
-          'Microsoft.Authorization/roleDefinitions',
-          const.roles.SearchIndexDataReader.guid
-        )
-        #disable-next-line BCP318
-        resourceId: searchService.outputs.resourceId
-        principalType: 'ServicePrincipal'
-      }
-    ]
-  }
-}
-
 // NOTE: Search Service Contributor for the AI Foundry Project identity on the
 // Search service is already created by the AVM AI Foundry module (avm/ptn/ai-ml/ai-foundry)
 // when aiSearchConfiguration is provided. Creating it again here causes a
 // RoleAssignmentExists conflict because both produce the same deterministic GUID.
 // Intentionally omitted.
-
-// Storage Account - Storage Blob Data Reader -> AiFoundry Project
-module assignStorageStorageBlobDataReaderAIFoundryProject 'modules/security/resource-role-assignment.bicep' = if (deployAiFoundry && deployStorageAccount) {
-  name: 'assignStorageStorageBlobDataReaderAIFoundryProject'
-  params: {
-    name: 'assignStorageStorageBlobDataReaderAIFoundryProject'
-    roleAssignments: [
-      {
-        principalId: aiFoundry!.outputs.aiProjectPrincipalId
-        roleDefinitionId: subscriptionResourceId(
-          'Microsoft.Authorization/roleDefinitions',
-          const.roles.StorageBlobDataReader.guid
-        )
-        #disable-next-line BCP318
-        resourceId: storageAccount.outputs.resourceId
-        principalType: 'ServicePrincipal'
-      }
-    ]
-  }
-}
 
 //////////////////////////////////////////////////////////////////////////
 // App Configuration Settings Service

--- a/main.bicep
+++ b/main.bicep
@@ -903,9 +903,8 @@ var _effectiveRouteTableId = _hasExistingRouteTable
   ? hubIntegrationExistingRouteTableResourceId!
   : (_createRouteTable ? routeTable.id : '')
 var _createDefaultRoute    = _createRouteTable && (deployAzureFirewall || _hasExternalEgress)
-#disable-next-line BCP318
 var _defaultRouteNextHopIp = deployAzureFirewall
-  ? (_networkIsolation ? azureFirewall!.properties.ipConfigurations[0].properties.privateIPAddress : '')
+  ? firewall.outputs.privateIp
   : (_hasExternalEgress ? hubIntegrationEgressNextHopIp! : '')
 
 // ----------------------------------------------------------------------
@@ -1068,160 +1067,6 @@ module appGwNsg 'modules/networking/appgw-nsg.bicep' = if (_publicIngressEnabled
   }
 }
 
-// Firewall FQDN allowlist for essential outbound connectivity
-// Essential (shared across subnets, source = '*'): auth, container registry mirror, GitHub
-var _firewallEssentialAuthFqdns = [
-  #disable-next-line no-hardcoded-env-urls
-  'login.microsoftonline.com'
-  'login.windows.net'
-  #disable-next-line no-hardcoded-env-urls
-  'management.azure.com'
-  'graph.microsoft.com'
-  '*.applicationinsights.azure.com'
-]
-var _firewallEssentialContainerFqdns = ['mcr.microsoft.com', '*.data.mcr.microsoft.com']
-// Platform-internal FQDNs required by the Container Apps Environment itself when egress
-// is forced through Azure Firewall (fixes #39, #40). The per-pod IMDS sidecar that backs
-// IDENTITY_ENDPOINT / IDENTITY_HEADER has two independent legs that both need to traverse
-// the firewall: (a) a Microsoft-managed Service Bus / Event Hub namespace whose FQDN
-// matches `gsm*eh.servicebus.windows.net` (the broker leg, fixes #39); (b) the ACA token
-// endpoint at `control-{region}.identity.azure.net` (the token-endpoint leg, fixes #40).
-// Without BOTH allow rules, every DefaultAzureCredential / ManagedIdentityCredential call
-// from a Container App fails at runtime with HTTP 500 "An unexpected error occured while
-// fetching the AAD Token", with no log entry on the workload side indicating the firewall
-// is the cause. Also includes ACA control-plane and Azure Monitor / Log Analytics /
-// Application Insights ingestion endpoints used by the platform's diagnostics pipeline.
-// Azure Firewall application-rule wildcards only match a single label, so explicit
-// wildcarded FQDNs are required (a generic `*.windows.net` does NOT match
-// `gsm123eh.servicebus.windows.net`, and `*.azure.com` does NOT match
-// `control-swedencentral.identity.azure.net`).
-var _firewallEssentialPlatformFqdns = [
-  '*.servicebus.windows.net'
-  '*.identity.azure.net'
-  '*.azurecontainerapps.io'
-  '*.azurecontainerapps.dev'
-  '*.in.applicationinsights.azure.com'
-  '*.livediagnostics.monitor.azure.com'
-  '*.ingest.monitor.azure.com'
-  '*.monitor.azure.com'
-  '*.monitor.core.windows.net'
-  '*.opinsights.azure.com'
-  '*.loganalytics.io'
-  // Certificate revocation / trust list (Schannel + .NET) — fixes #42.
-  // Without these, Windows TLS clients (Bastion/jumpbox curl.exe, Invoke-WebRequest,
-  // .NET HttpClient with CheckCertificateRevocationList=true) fail with
-  // CRYPT_E_REVOCATION_OFFLINE when validating Azure-managed certs served by
-  // Container Apps / App Service / etc. These are public Microsoft + DigiCert
-  // revocation endpoints implicit in any Azure-issued cert chain — allowing them
-  // in an outbound rule does not weaken the Zero Trust posture.
-  'oneocsp.microsoft.com'
-  'ocsp.digicert.com'
-  'crl.microsoft.com'
-  'crl2.microsoft.com'
-  'crl3.microsoft.com'
-  'crl.digicert.com'
-  'crl3.digicert.com'
-  'crl4.digicert.com'
-  'ctldl.windowsupdate.com'
-]
-var _firewallEssentialGitHubFqdns = [
-  'github.com'
-  '*.github.com'
-  'raw.githubusercontent.com'
-  'codeload.github.com'
-  'objects.githubusercontent.com'
-  '*.githubusercontent.com'
-]
-
-// Jumpbox-only FQDNs — scoped to jumpboxSubnetPrefix so ACA/agent subnets do not
-// inherit developer-tooling egress. Split into purpose-labeled sets so consumers can
-// audit which tool requires which endpoint.
-// Docker / Docker Hub FQDNs intentionally removed — image builds run in the ACR
-// Tasks agent pool (see deployAcrTaskAgentPool) and the Windows Server jumpbox
-// cannot build Linux images with BuildKit anyway.
-var _firewallVmBootstrapFqdns = [
-  'community.chocolatey.org'
-  'packages.chocolatey.org'
-  '*.chocolatey.org'
-  'api.nuget.org'
-  'www.nuget.org'
-  'dist.nuget.org'
-  '*.nuget.org'
-  'download.visualstudio.microsoft.com'
-  '*.visualstudio.microsoft.com'
-  'download.microsoft.com'
-  '*.download.microsoft.com'
-  'aka.ms'
-  'go.microsoft.com'
-  // azd auto-downloads the Bicep CLI binary from `downloads.bicep.azure.com`
-  // on first run (`azd env refresh` / `azd provision`); without this FQDN the
-  // jumpbox fails at "Downloading Bicep" before any deployment work begins
-  // (#36).
-  'downloads.bicep.azure.com'
-  // GitHub release fallback used by azd, the .NET installer, and many
-  // bootstrap scripts. `objects.githubusercontent.com` and
-  // `codeload.github.com` are the actual content hosts behind release asset
-  // and source-archive URLs respectively (#36).
-  'github.com'
-  '*.githubusercontent.com'
-  'objects.githubusercontent.com'
-  'codeload.github.com'
-  #disable-next-line no-hardcoded-env-urls
-  '*.core.windows.net'
-  '*.azureedge.net'
-]
-#disable-next-line no-hardcoded-env-urls
-var _firewallDevRuntimeFqdns = [
-  'www.python.org'
-  '*.python.org'
-  'pypi.org'
-  '*.pypi.org'
-  'files.pythonhosted.org'
-  '*.pythonhosted.org'
-  // get-pip.py is served from bootstrap.pypa.io. Required by the Python
-  // embeddable-distribution install path on the jumpbox (see issue #48 and
-  // install.ps1) which downloads `get-pip.py` to bootstrap pip into
-  // `C:\Python311` after extracting the embeddable zip.
-  'bootstrap.pypa.io'
-  '*.pypa.io'
-  'registry.npmjs.org'
-  '*.npmjs.org'
-]
-// Jumpbox ACME workflow egress (issue #53): scoped only to the jumpbox subnet
-// and only when `extendFirewallForJumpboxBootstrap=true`.
-// - api.github.com: reserved for ACME-client release discovery / plugin checks.
-// - acme-v02.api.letsencrypt.org: Let's Encrypt ACME v2 directory endpoint
-//   used during certificate issuance/renewal.
-var _firewallJumpboxAcmeFqdns = [
-  'api.github.com'
-  'acme-v02.api.letsencrypt.org'
-]
-#disable-next-line no-hardcoded-env-urls
-var _firewallEditorFqdns = [
-  'update.code.visualstudio.com'
-  '*.vo.msecnd.net'
-  '*.vscode-cdn.net'
-]
-
-// Azure AI Speech FQDNs (#35) — only added to the bootstrap allow rule when
-// `deploySpeechService` is true. Covers control plane, TTS, and STT regional
-// endpoints used by the Speech SDK.
-#disable-next-line no-hardcoded-env-urls
-var _firewallSpeechFqdns = deploySpeechService ? [
-  '*.cognitiveservices.azure.com'
-  '*.tts.speech.microsoft.com'
-  '*.stt.speech.microsoft.com'
-] : []
-
-// ACR Tasks agent-pool FQDNs — scoped to devopsBuildAgentsSubnetPrefix. Only
-// populated when the agent pool is actually deployed.
-//
-// Note: ACR Tasks agents need egress to ACR data plane (`*.azurecr.io`,
-// `*.data.azurecr.io`) AND to the Azure Storage queue/blob/table endpoints
-// the ACR Tasks control plane uses to dispatch jobs to the agent VM.
-// Without the *.core.windows.net FQDNs, builds queued via
-// `az acr build --agent-pool` hang indefinitely in `Queued` state because
-// the agent VM cannot reach the storage queue. See issue #18.
 var _deployAcrTaskAgentPool = deployContainerRegistry && _networkIsolation && deployAcrTaskAgentPool
 
 // Public Ingress (#49) — only effective in network-isolated mode with Container
@@ -1230,193 +1075,6 @@ var _deployAcrTaskAgentPool = deployContainerRegistry && _networkIsolation && de
 var _publicIngressEnabled = publicIngress.enabled && _networkIsolation && deployContainerEnv && deployContainerApps && length(containerAppsList) > 0
 var _publicIngressBackendIndex = publicIngress.?backendAppIndex ?? 0
 var _publicIngressAllowedSources = publicIngress.?allowedSourceAddressPrefixes ?? []
-var _firewallAcrTaskFqdns = _deployAcrTaskAgentPool ? [
-  '*.azurecr.io'
-  '*.data.azurecr.io'
-  '*.blob.${environment().suffixes.storage}'
-  '*.queue.${environment().suffixes.storage}'
-  '*.table.${environment().suffixes.storage}'
-] : []
-
-// OS package repositories used by Debian/Ubuntu-based builder images during
-// `apt-get` steps in ACR Tasks runs. Scoped to devopsBuildAgentsSubnetPrefix
-// via `AllowAcrTaskOsPackages`. Includes packages.microsoft.com because
-// Microsoft-supported Linux packages such as msodbcsql18 are common build-time
-// dependencies for solution accelerators. Language registries (npm/PyPI/python.org)
-// are reused from `_firewallDevRuntimeFqdns` via `AllowAcrTaskDevRuntimes`.
-// See issues #20 and #68.
-#disable-next-line no-hardcoded-env-urls
-var _firewallAcrTaskOsPackageFqdns = [
-  'deb.debian.org'
-  'security.debian.org'
-  'archive.ubuntu.com'
-  'security.ubuntu.com'
-  'dl.yarnpkg.com'
-  'packages.microsoft.com'
-]
-
-// Azure Firewall rejects ApplicationRules whose targetFqdns is an empty
-// array with `BadRequest: "The request is invalid."` at the ARM
-// request-validation layer (no rule-collection-group operation is even
-// created). Build the full set of rules here, then filter out any whose
-// targetFqdns ended up empty due to disabled feature flags (for example
-// deployJumpbox=false or deployAcrTaskAgentPool=false). This keeps every rule
-// definition co-located while ensuring the ARM payload only ever contains rules
-// with at least one FQDN target.
-var _firewallDefaultApplicationRules = filter([
-  {
-    ruleType: 'ApplicationRule'
-    name: 'AllowMicrosoftContainerRegistry'
-    protocols: [
-      { protocolType: 'Https', port: 443 }
-    ]
-    targetFqdns: _firewallEssentialContainerFqdns
-    sourceAddresses: ['*']
-  }
-  {
-    ruleType: 'ApplicationRule'
-    name: 'AllowEntraIdAuth'
-    protocols: [
-      { protocolType: 'Https', port: 443 }
-    ]
-    targetFqdns: _firewallEssentialAuthFqdns
-    sourceAddresses: ['*']
-  }
-  {
-    ruleType: 'ApplicationRule'
-    name: 'AllowGitHub'
-    protocols: [
-      { protocolType: 'Https', port: 443 }
-    ]
-    targetFqdns: _firewallEssentialGitHubFqdns
-    sourceAddresses: ['*']
-  }
-  {
-    ruleType: 'ApplicationRule'
-    name: 'AllowContainerAppsPlatform'
-    protocols: [
-      { protocolType: 'Https', port: 443 }
-    ]
-    targetFqdns: _firewallEssentialPlatformFqdns
-    sourceAddresses: ['*']
-  }
-  {
-    ruleType: 'ApplicationRule'
-    name: 'AllowJumpboxBootstrap'
-    protocols: [
-      { protocolType: 'Https', port: 443 }
-      { protocolType: 'Http', port: 80 }
-    ]
-    targetFqdns: extendFirewallForJumpboxBootstrap ? concat(_firewallVmBootstrapFqdns, _firewallSpeechFqdns) : []
-    sourceAddresses: [jumpboxSubnetPrefix]
-  }
-  {
-    ruleType: 'ApplicationRule'
-    name: 'AllowJumpboxDevRuntimes'
-    protocols: [
-      { protocolType: 'Https', port: 443 }
-    ]
-    targetFqdns: extendFirewallForJumpboxBootstrap ? _firewallDevRuntimeFqdns : []
-    sourceAddresses: [jumpboxSubnetPrefix]
-  }
-  {
-    ruleType: 'ApplicationRule'
-    name: 'AllowJumpboxEditors'
-    protocols: [
-      { protocolType: 'Https', port: 443 }
-    ]
-    targetFqdns: extendFirewallForJumpboxBootstrap ? _firewallEditorFqdns : []
-    sourceAddresses: [jumpboxSubnetPrefix]
-  }
-  {
-    ruleType: 'ApplicationRule'
-    name: 'AllowJumpboxAcme'
-    protocols: [
-      { protocolType: 'Https', port: 443 }
-    ]
-    targetFqdns: extendFirewallForJumpboxBootstrap ? _firewallJumpboxAcmeFqdns : []
-    sourceAddresses: [jumpboxSubnetPrefix]
-  }
-  {
-    ruleType: 'ApplicationRule'
-    name: 'AllowAcrTasks'
-    protocols: [
-      { protocolType: 'Https', port: 443 }
-    ]
-    targetFqdns: _firewallAcrTaskFqdns
-    sourceAddresses: [devopsBuildAgentsSubnetPrefix]
-  }
-  {
-    ruleType: 'ApplicationRule'
-    name: 'AllowAcrTaskDevRuntimes'
-    protocols: [
-      { protocolType: 'Https', port: 443 }
-    ]
-    targetFqdns: (_deployAcrTaskAgentPool && extendFirewallForAcrTaskBuilds) ? union(_firewallDevRuntimeFqdns, additionalAcrTaskBuildFqdns) : []
-    sourceAddresses: [devopsBuildAgentsSubnetPrefix]
-  }
-  {
-    ruleType: 'ApplicationRule'
-    name: 'AllowAcrTaskOsPackages'
-    protocols: [
-      { protocolType: 'Https', port: 443 }
-      { protocolType: 'Http', port: 80 }
-    ]
-    targetFqdns: (_deployAcrTaskAgentPool && extendFirewallForAcrTaskBuilds) ? _firewallAcrTaskOsPackageFqdns : []
-    sourceAddresses: [devopsBuildAgentsSubnetPrefix]
-  }
-], rule => !empty(rule.targetFqdns))
-
-var _firewallDefaultRuleCollections = [
-  {
-    ruleCollectionType: 'FirewallPolicyFilterRuleCollection'
-    name: 'AllowEssentialOutbound'
-    priority: 100
-    action: {
-      type: 'Allow'
-    }
-    rules: _firewallDefaultApplicationRules
-  }
-]
-
-var _firewallAcsMediaRules = [
-  {
-    ruleType: 'NetworkRule'
-    name: 'AllowAcsMediaUdp'
-    ipProtocols: ['UDP']
-    sourceAddresses: [
-      jumpboxSubnetPrefix
-      acaEnvironmentSubnetPrefix
-      agentSubnetPrefix
-    ]
-    destinationAddresses: ['AzureCloud']
-    destinationPorts: ['3478-3481']
-  }
-  {
-    ruleType: 'NetworkRule'
-    name: 'AllowAcsMediaTcp'
-    ipProtocols: ['TCP']
-    sourceAddresses: [
-      jumpboxSubnetPrefix
-      acaEnvironmentSubnetPrefix
-      agentSubnetPrefix
-    ]
-    destinationAddresses: ['AzureCloud']
-    destinationPorts: ['443', '3478-3481']
-  }
-]
-
-var _firewallAcsMediaRuleCollections = [
-  {
-    ruleCollectionType: 'FirewallPolicyFilterRuleCollection'
-    name: 'AllowAcsMedia'
-    priority: 100
-    action: {
-      type: 'Allow'
-    }
-    rules: _firewallAcsMediaRules
-  }
-]
 
 // Route Table for egress traffic control through Azure Firewall (or external NVA, Gap 6).
 // Created only when network isolation is on AND no existing RT is provided via
@@ -1637,94 +1295,28 @@ resource testVmBastionHost 'Microsoft.Network/bastionHosts@2024-07-01' = if (_de
 // Azure Firewall for egress traffic control
 ///////////////////////////////////////////////////////////////////////////
 
-resource firewallPublicIp 'Microsoft.Network/publicIPAddresses@2024-07-01' = if (deployAzureFirewall && _networkIsolation) {
-  name: '${const.abbrs.networking.publicIPAddress}${const.abbrs.networking.firewall}${resourceToken}'
-  location: location
-  sku: {
-    name: 'Standard'
-    tier: 'Regional'
-  }
-  properties: {
-    publicIPAllocationMethod: 'Static'
-    publicIPAddressVersion: 'IPv4'
-  }
-  tags: _tags
-}
-
-resource firewallPolicy 'Microsoft.Network/firewallPolicies@2024-07-01' = if (deployAzureFirewall && _networkIsolation) {
-  name: '${const.abbrs.networking.firewallPolicy}${resourceToken}'
-  location: location
-  tags: _tags
-  properties: {
-    sku: {
-      tier: 'Standard'
-    }
-    threatIntelMode: 'Alert'
-  }
-}
-
-resource firewallPolicyDefaultRuleCollectionGroup 'Microsoft.Network/firewallPolicies/ruleCollectionGroups@2024-07-01' = if (deployAzureFirewall && _networkIsolation) {
-  parent: firewallPolicy
-  name: 'DefaultRuleCollectionGroup'
-  properties: {
-    priority: 200
-    ruleCollections: _firewallDefaultRuleCollections
-  }
-}
-
-// ACS Media (WebRTC / TURN) — opt-in network rule collection.
-// Required for Speech real-time avatar, ACS Calling, Teams Media. The signaling
-// path is HTTPS (already covered by application rules); the *media* path uses
-// UDP 3478-3481 / TCP 443+3478-3481 to the ACS / Speech avatar TURN fleet,
-// which is otherwise dropped by the firewall under network isolation.
-// Note: the destination is the `AzureCloud` service tag, not a hypothetical
-// `AzureCommunicationServices` tag — the latter does not exist in the Azure
-// service-tag namespace, and the actual TURN backends (e.g.
-// `relay.communication.microsoft.com`,
-// `a-tr-skysc-*.<region>.cloudapp.azure.com`) resolve into IP ranges covered
-// by `AzureCloud` / `AzureCloud.<region>`. See issue #50.
-// Separate rule collection group so it can be toggled independently of the
-// default group, and so the default group's priority doesn't have to shift.
-resource firewallPolicyAcsMediaRuleCollectionGroup 'Microsoft.Network/firewallPolicies/ruleCollectionGroups@2024-07-01' = if (deployAzureFirewall && _networkIsolation && enableAcsMediaEgress) {
-  parent: firewallPolicy
-  name: 'AcsMediaRuleCollectionGroup'
-  properties: {
-    priority: 300
-    ruleCollections: _firewallAcsMediaRuleCollections
-  }
-  dependsOn: [
-    firewallPolicyDefaultRuleCollectionGroup
-  ]
-}
-
-#disable-next-line BCP318
-var _firewallSubnetId = _networkIsolation ? '${virtualNetworkResourceId}/subnets/${azureFirewallSubnetName}' : ''
-
-resource azureFirewall 'Microsoft.Network/azureFirewalls@2024-07-01' = if (deployAzureFirewall && _networkIsolation) {
-  name: '${const.abbrs.networking.firewall}${resourceToken}'
-  location: location
-  tags: _tags
-  properties: {
-    sku: {
-      name: 'AZFW_VNet'
-      tier: 'Standard'
-    }
-    ipConfigurations: [
-      {
-        name: 'ipconfig1'
-        properties: {
-          publicIPAddress: {
-            id: firewallPublicIp.id
-          }
-          subnet: {
-            id: _firewallSubnetId
-          }
-        }
-      }
-    ]
-    firewallPolicy: {
-      id: firewallPolicy.id
-    }
+module firewall 'modules/networking/azure-firewall.bicep' = {
+  name: 'firewall'
+  params: {
+    deployAzureFirewall: deployAzureFirewall
+    networkIsolation: _networkIsolation
+    enableAcsMediaEgress: enableAcsMediaEgress
+    deploySpeechService: deploySpeechService
+    deployAcrTaskAgentPool: _deployAcrTaskAgentPool
+    extendFirewallForJumpboxBootstrap: extendFirewallForJumpboxBootstrap
+    extendFirewallForAcrTaskBuilds: extendFirewallForAcrTaskBuilds
+    additionalAcrTaskBuildFqdns: additionalAcrTaskBuildFqdns
+    resourceToken: resourceToken
+    location: location
+    tags: _tags
+    virtualNetworkResourceId: virtualNetworkResourceId
+    azureFirewallSubnetName: azureFirewallSubnetName
+    jumpboxSubnetPrefix: jumpboxSubnetPrefix
+    devopsBuildAgentsSubnetPrefix: devopsBuildAgentsSubnetPrefix
+    acaEnvironmentSubnetPrefix: acaEnvironmentSubnetPrefix
+    agentSubnetPrefix: agentSubnetPrefix
+    hasEffectiveLaw: _hasEffectiveLaw
+    lawResourceId: _lawResourceId
   }
   dependsOn: [
     #disable-next-line BCP321
@@ -1744,27 +1336,6 @@ resource defaultRoute 'Microsoft.Network/routeTables/routes@2024-07-01' = if (_c
     addressPrefix: '0.0.0.0/0'
     nextHopType: 'VirtualAppliance'
     nextHopIpAddress: _defaultRouteNextHopIp
-  }
-}
-
-// Azure Firewall diagnostics to Log Analytics
-resource firewallDiagnostics 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = if (deployAzureFirewall && _networkIsolation && _hasEffectiveLaw) {
-  name: 'fw-diagnostics'
-  scope: azureFirewall
-  properties: {
-    workspaceId: _lawResourceId
-    logs: [
-      {
-        categoryGroup: 'allLogs'
-        enabled: true
-      }
-    ]
-    metrics: [
-      {
-        category: 'AllMetrics'
-        enabled: true
-      }
-    ]
   }
 }
 
@@ -2080,8 +1651,7 @@ resource cse 'Microsoft.Compute/virtualMachines/extensions@2024-11-01' = if (_de
     appConfigPopulate
     assignTestVmRoles
     assignCosmosDBCosmosDbBuiltInDataContributorTestVm
-    azureFirewall
-    firewallPolicyDefaultRuleCollectionGroup
+    firewall
   ]
 }
 
@@ -3021,7 +2591,7 @@ module containerApps 'br/public:avm/res/app/container-app:0.18.1' = [
       // The reference is to a conditional resource; in Basic mode
       // (`deployAzureFirewall=false` or `networkIsolation=false`) the
       // dependency is simply absent.
-      firewallPolicyDefaultRuleCollectionGroup
+      firewall
     ]
   }
 ]

--- a/main.bicep
+++ b/main.bicep
@@ -3519,131 +3519,128 @@ module assignCosmosDBCosmosDbBuiltInDataContributorExecutor 'modules/security/co
   }
 }
 
-// Key Vault Service - Key Vault Secrets User -> ContainerApp (per-app loop preserved)
-module assignKeyVaultSecretsUserAca 'modules/security/resource-role-assignment.bicep' = [
-  for (app, i) in containerAppsList: if (deployContainerApps && deployKeyVault && contains(app.roles, const.roles.KeyVaultSecretsUser.key)) {
-    name: 'assignKeyVaultSecretsUserAca-${app.service_name}'
+// Container App control-plane role assignments (consolidated).
+// Each app gets a single array-driven module invocation that builds the full
+// set of control-plane roles it qualifies for, replacing the previous
+// per-role per-app loops. Role assignment names are deterministic
+// (guid(principalId, roleDefinitionId, resourceId)), so consolidating the
+// deployment invocations does not change the deployed role assignment set.
+// Cosmos DB data-plane assignments stay in their dedicated module below.
+module assignContainerAppRoles 'modules/security/resource-role-assignment.bicep' = [
+  for (app, i) in containerAppsList: if (deployContainerApps && ((deployKeyVault && contains(app.roles, const.roles.KeyVaultSecretsUser.key)) || (deployAppConfig && _runtimeConfigIsAppConfig && contains(app.roles, const.roles.AppConfigurationDataReader.key)) || (deployAiFoundry && contains(app.roles, const.roles.CognitiveServicesUser.key)) || (deployAiFoundry && contains(app.roles, const.roles.CognitiveServicesOpenAIUser.key)) || (deploySpeechService && contains(app.roles, const.roles.CognitiveServicesUser.key)) || (deployContainerRegistry && contains(app.roles, const.roles.AcrPull.key)) || (deploySearchService && contains(app.roles, const.roles.SearchIndexDataReader.key)) || (deploySearchService && contains(app.roles, const.roles.SearchIndexDataContributor.key)) || (deployStorageAccount && contains(app.roles, const.roles.StorageBlobDataContributor.key)) || (deployStorageAccount && contains(app.roles, const.roles.StorageBlobDataReader.key)) || (deployStorageAccount && contains(app.roles, const.roles.StorageBlobDelegator.key)))) {
+    name: 'assignContainerAppRoles-${app.service_name}'
     params: {
-      name: 'assignKeyVaultSecretsUserAca-${app.service_name}'
-      roleAssignments: [
-        {
-          roleDefinitionId: subscriptionResourceId(
-            'Microsoft.Authorization/roleDefinitions',
-            const.roles.KeyVaultSecretsUser.guid
-          )
-          #disable-next-line BCP318
-          principalId: (_useUAI) ? containerAppsUAI[i].properties.principalId : containerApps[i].outputs.systemAssignedMIPrincipalId!
-          #disable-next-line BCP318
-          resourceId: keyVault.id
-          principalType: 'ServicePrincipal'
-        }
-      ]
-    }
-  }
-]
-
-// App Configuration Settings Service - App Configuration Data Reader -> ContainerApp
-module assignAppConfigAppConfigurationDataReaderContainerApps 'modules/security/resource-role-assignment.bicep' = [
-  for (app, i) in containerAppsList: if (deployContainerApps && deployAppConfig && _runtimeConfigIsAppConfig && contains(
-    app.roles,
-    const.roles.AppConfigurationDataReader.key
-  )) {
-    name: 'assignAppConfigAppConfigurationDataReader-${app.service_name}'
-    params: {
-      name: 'assignAppConfigAppConfigurationDataReader-${app.service_name}'
-      roleAssignments: [
-        {
-          roleDefinitionId: subscriptionResourceId(
-            'Microsoft.Authorization/roleDefinitions',
-            const.roles.AppConfigurationDataReader.guid
-          )
-          #disable-next-line BCP318
-          principalId: (_useUAI) ? containerAppsUAI[i].properties.principalId : containerApps[i].outputs.systemAssignedMIPrincipalId!
-          #disable-next-line BCP318
-          resourceId: appConfig.id
-          principalType: 'ServicePrincipal'
-        }
-      ]
-    }
-  }
-]
-
-// AI Foundry Account - Cognitive Services User -> ContainerApp
-module assignAiFoundryAccountCognitiveServicesUserContainerApps 'modules/security/resource-role-assignment.bicep' = [
-  for (app, i) in containerAppsList: if (deployContainerApps && deployAiFoundry && contains(
-    app.roles,
-    const.roles.CognitiveServicesUser.key
-  )) {
-    name: 'assignAIFoundryAccountCognitiveServicesUser-${app.service_name}'
-    params: {
-      name: 'assignAIFoundryAccountCognitiveServicesUser-${app.service_name}'
-      roleAssignments: [
-        {
-          roleDefinitionId: subscriptionResourceId(
-            'Microsoft.Authorization/roleDefinitions',
-            const.roles.CognitiveServicesUser.guid
-          )
-          #disable-next-line BCP318
-          principalId: (_useUAI) ? containerAppsUAI[i].properties.principalId : containerApps[i].outputs.systemAssignedMIPrincipalId!
-          resourceId: aiFoundryAccountResourceId
-          principalType: 'ServicePrincipal'
-        }
-      ]
-    }
-  }
-]
-
-// AI Foundry Account - Cognitive Services OpenAI User -> ContainerApp
-module assignAIFoundryCogServOAIUserContainerApps 'modules/security/resource-role-assignment.bicep' = [
-  for (app, i) in containerAppsList: if (deployContainerApps && deployAiFoundry && contains(
-    app.roles,
-    const.roles.CognitiveServicesOpenAIUser.key
-  )) {
-    name: 'assignAIFoundryCogServOAIUserContainerApps-${app.service_name}'
-    params: {
-      name: 'assignAIFoundryCogServOAIUserContainerApps-${app.service_name}'
-      roleAssignments: [
-        {
-          roleDefinitionId: subscriptionResourceId(
-            'Microsoft.Authorization/roleDefinitions',
-            const.roles.CognitiveServicesOpenAIUser.guid
-          )
-          #disable-next-line BCP318
-          principalId: (_useUAI) ? containerAppsUAI[i].properties.principalId : containerApps[i].outputs.systemAssignedMIPrincipalId!
-          resourceId: aiFoundryAccountResourceId
-          principalType: 'ServicePrincipal'
-        }
-      ]
-    }
-  }
-]
-
-// Speech Service - Cognitive Services User -> ContainerApp (#35)
-// Granted whenever a container app declares the `CognitiveServicesUser` role
-// token in its `roles` array AND `deploySpeechService=true`. Idempotent with
-// the AI Foundry assignment of the same role token because the two have
-// different `resourceId` scopes.
-module assignSpeechCognitiveServicesUserContainerApps 'modules/security/resource-role-assignment.bicep' = [
-  for (app, i) in containerAppsList: if (deployContainerApps && deploySpeechService && contains(
-    app.roles,
-    const.roles.CognitiveServicesUser.key
-  )) {
-    name: 'assignSpeechCognitiveServicesUser-${app.service_name}'
-    params: {
-      name: 'assignSpeechCognitiveServicesUser-${app.service_name}'
-      roleAssignments: [
-        {
-          roleDefinitionId: subscriptionResourceId(
-            'Microsoft.Authorization/roleDefinitions',
-            const.roles.CognitiveServicesUser.guid
-          )
-          #disable-next-line BCP318
-          principalId: (_useUAI) ? containerAppsUAI[i].properties.principalId : containerApps[i].outputs.systemAssignedMIPrincipalId!
-          #disable-next-line BCP318
-          resourceId: speechService.outputs.resourceId
-          principalType: 'ServicePrincipal'
-        }
-      ]
+      name: 'assignContainerAppRoles-${app.service_name}'
+      roleAssignments: concat(
+        (deployKeyVault && contains(app.roles, const.roles.KeyVaultSecretsUser.key)) ? [
+          {
+            roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', const.roles.KeyVaultSecretsUser.guid)
+            #disable-next-line BCP318
+            principalId: (_useUAI) ? containerAppsUAI[i].properties.principalId : containerApps[i].outputs.systemAssignedMIPrincipalId!
+            #disable-next-line BCP318
+            resourceId: keyVault.id
+            principalType: 'ServicePrincipal'
+          }
+        ] : [],
+        (deployAppConfig && _runtimeConfigIsAppConfig && contains(app.roles, const.roles.AppConfigurationDataReader.key)) ? [
+          {
+            roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', const.roles.AppConfigurationDataReader.guid)
+            #disable-next-line BCP318
+            principalId: (_useUAI) ? containerAppsUAI[i].properties.principalId : containerApps[i].outputs.systemAssignedMIPrincipalId!
+            #disable-next-line BCP318
+            resourceId: appConfig.id
+            principalType: 'ServicePrincipal'
+          }
+        ] : [],
+        (deployAiFoundry && contains(app.roles, const.roles.CognitiveServicesUser.key)) ? [
+          {
+            roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', const.roles.CognitiveServicesUser.guid)
+            #disable-next-line BCP318
+            principalId: (_useUAI) ? containerAppsUAI[i].properties.principalId : containerApps[i].outputs.systemAssignedMIPrincipalId!
+            resourceId: aiFoundryAccountResourceId
+            principalType: 'ServicePrincipal'
+          }
+        ] : [],
+        (deployAiFoundry && contains(app.roles, const.roles.CognitiveServicesOpenAIUser.key)) ? [
+          {
+            roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', const.roles.CognitiveServicesOpenAIUser.guid)
+            #disable-next-line BCP318
+            principalId: (_useUAI) ? containerAppsUAI[i].properties.principalId : containerApps[i].outputs.systemAssignedMIPrincipalId!
+            resourceId: aiFoundryAccountResourceId
+            principalType: 'ServicePrincipal'
+          }
+        ] : [],
+        (deploySpeechService && contains(app.roles, const.roles.CognitiveServicesUser.key)) ? [
+          {
+            roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', const.roles.CognitiveServicesUser.guid)
+            #disable-next-line BCP318
+            principalId: (_useUAI) ? containerAppsUAI[i].properties.principalId : containerApps[i].outputs.systemAssignedMIPrincipalId!
+            #disable-next-line BCP318
+            resourceId: speechService.outputs.resourceId
+            principalType: 'ServicePrincipal'
+          }
+        ] : [],
+        (deployContainerRegistry && contains(app.roles, const.roles.AcrPull.key)) ? [
+          {
+            roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', const.roles.AcrPull.guid)
+            #disable-next-line BCP318
+            principalId: (_useUAI) ? containerAppsUAI[i].properties.principalId : containerApps[i].outputs.systemAssignedMIPrincipalId!
+            #disable-next-line BCP318
+            resourceId: containerRegistry.id
+            principalType: 'ServicePrincipal'
+          }
+        ] : [],
+        (deploySearchService && contains(app.roles, const.roles.SearchIndexDataReader.key)) ? [
+          {
+            roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', const.roles.SearchIndexDataReader.guid)
+            #disable-next-line BCP318
+            principalId: (_useUAI) ? containerAppsUAI[i].properties.principalId : containerApps[i].outputs.systemAssignedMIPrincipalId!
+            #disable-next-line BCP318
+            resourceId: searchService.outputs.resourceId
+            principalType: 'ServicePrincipal'
+          }
+        ] : [],
+        (deploySearchService && contains(app.roles, const.roles.SearchIndexDataContributor.key)) ? [
+          {
+            roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', const.roles.SearchIndexDataContributor.guid)
+            #disable-next-line BCP318
+            principalId: (_useUAI) ? containerAppsUAI[i].properties.principalId : containerApps[i].outputs.systemAssignedMIPrincipalId!
+            #disable-next-line BCP318
+            resourceId: searchService.outputs.resourceId
+            principalType: 'ServicePrincipal'
+          }
+        ] : [],
+        (deployStorageAccount && contains(app.roles, const.roles.StorageBlobDataContributor.key)) ? [
+          {
+            roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', const.roles.StorageBlobDataContributor.guid)
+            #disable-next-line BCP318
+            principalId: (_useUAI) ? containerAppsUAI[i].properties.principalId : containerApps[i].outputs.systemAssignedMIPrincipalId!
+            #disable-next-line BCP318
+            resourceId: storageAccount.outputs.resourceId
+            principalType: 'ServicePrincipal'
+          }
+        ] : [],
+        (deployStorageAccount && contains(app.roles, const.roles.StorageBlobDataReader.key)) ? [
+          {
+            roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', const.roles.StorageBlobDataReader.guid)
+            #disable-next-line BCP318
+            principalId: (_useUAI) ? containerAppsUAI[i].properties.principalId : containerApps[i].outputs.systemAssignedMIPrincipalId!
+            #disable-next-line BCP318
+            resourceId: storageAccount.outputs.resourceId
+            principalType: 'ServicePrincipal'
+          }
+        ] : [],
+        (deployStorageAccount && contains(app.roles, const.roles.StorageBlobDelegator.key)) ? [
+          {
+            roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', const.roles.StorageBlobDelegator.guid)
+            #disable-next-line BCP318
+            principalId: (_useUAI) ? containerAppsUAI[i].properties.principalId : containerApps[i].outputs.systemAssignedMIPrincipalId!
+            #disable-next-line BCP318
+            resourceId: storageAccount.outputs.resourceId
+            principalType: 'ServicePrincipal'
+          }
+        ] : []
+      )
     }
   }
 ]
@@ -3668,26 +3665,6 @@ module assignAiFoundryAccountCognitiveServicesUserSearch 'modules/security/resou
   }
 }
 
-// Azure Container Registry Service - AcrPull -> ContainerApp
-module assignCrAcrPullContainerApps 'modules/security/resource-role-assignment.bicep' = [
-  for (app, i) in containerAppsList: if (deployContainerApps && deployContainerRegistry && contains(app.roles, const.roles.AcrPull.key)) {
-    name: 'assignCrAcrPull-${app.service_name}'
-    params: {
-      name: 'assignCrAcrPull-${app.service_name}'
-      roleAssignments: [
-        {
-          roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', const.roles.AcrPull.guid)
-          #disable-next-line BCP318
-          principalId: (_useUAI) ? containerAppsUAI[i].properties.principalId : containerApps[i].outputs.systemAssignedMIPrincipalId!
-          #disable-next-line BCP318
-          resourceId: containerRegistry.id
-          principalType: 'ServicePrincipal'
-        }
-      ]
-    }
-  }
-]
-
 // Cosmos DB Account - Cosmos DB Built-in Data Contributor -> ContainerApp
 module assignCosmosDBCosmosDbBuiltInDataContributorContainerApps 'modules/security/cosmos-data-plane-role-assignment.bicep' = [
   for (app, i) in containerAppsList: if (deployContainerApps && deployCosmosDb && contains(
@@ -3702,159 +3679,6 @@ module assignCosmosDBCosmosDbBuiltInDataContributorContainerApps 'modules/securi
       principalId: (_useUAI) ? containerAppsUAI[i].properties.principalId : containerApps[i].outputs.systemAssignedMIPrincipalId!
       roleDefinitionGuid: const.roles.CosmosDBBuiltInDataContributor.guid
       scopePath: '/subscriptions/${subscription().subscriptionId}/resourceGroups/${resourceGroup().name}/providers/Microsoft.DocumentDB/databaseAccounts/${dbAccountName}'
-    }
-  }
-]
-
-// Key Vault Service - Key Vault Secrets User -> ContainerApp
-module assignKeyVaultKeyVaultSecretsUserContainerApps 'modules/security/resource-role-assignment.bicep' = [
-  for (app, i) in containerAppsList: if (deployContainerApps && deployKeyVault && contains(app.roles, const.roles.KeyVaultSecretsUser.key)) {
-    name: 'assignKeyVaultKeyVaultSecretsUser-${app.service_name}'
-    params: {
-      name: 'assignKeyVaultKeyVaultSecretsUser-${app.service_name}'
-      roleAssignments: [
-        {
-          roleDefinitionId: subscriptionResourceId(
-            'Microsoft.Authorization/roleDefinitions',
-            const.roles.KeyVaultSecretsUser.guid
-          )
-          #disable-next-line BCP318
-          principalId: (_useUAI) ? containerAppsUAI[i].properties.principalId : containerApps[i].outputs.systemAssignedMIPrincipalId!
-          #disable-next-line BCP318
-          resourceId: keyVault.id
-          principalType: 'ServicePrincipal'
-        }
-      ]
-    }
-  }
-]
-
-// Search Service - Search Index Data Reader -> ContainerApp
-module assignSearchSearchIndexDataReaderContainerApps 'modules/security/resource-role-assignment.bicep' = [
-  for (app, i) in containerAppsList: if (deployContainerApps && deploySearchService && contains(
-    app.roles,
-    const.roles.SearchIndexDataReader.key
-  )) {
-    name: 'assignSearchSearchIndexDataReader-${app.service_name}'
-    params: {
-      name: 'assignSearchSearchIndexDataReader-${app.service_name}'
-      roleAssignments: [
-        {
-          roleDefinitionId: subscriptionResourceId(
-            'Microsoft.Authorization/roleDefinitions',
-            const.roles.SearchIndexDataReader.guid
-          )
-          #disable-next-line BCP318
-          principalId: (_useUAI)  ? containerAppsUAI[i].properties.principalId : containerApps[i].outputs.systemAssignedMIPrincipalId!
-          #disable-next-line BCP318
-          resourceId: searchService.outputs.resourceId
-          principalType: 'ServicePrincipal'
-        }
-      ]
-    }
-  }
-]
-
-// Search Service - Search Index Data Contributor -> ContainerApp
-module assignSearchSearchIndexDataContributorContainerApps 'modules/security/resource-role-assignment.bicep' = [
-  for (app, i) in containerAppsList: if (deployContainerApps && deploySearchService && contains(
-    app.roles,
-    const.roles.SearchIndexDataContributor.key
-  )) {
-    name: 'assignSearchSearchIndexDataContributor-${app.service_name}'
-    params: {
-      name: 'assignSearchSearchIndexDataContributor-${app.service_name}'
-      roleAssignments: [
-        {
-          roleDefinitionId: subscriptionResourceId(
-            'Microsoft.Authorization/roleDefinitions',
-            const.roles.SearchIndexDataContributor.guid
-          )
-          #disable-next-line BCP318
-          principalId: (_useUAI) ? containerAppsUAI[i].properties.principalId  : containerApps[i].outputs.systemAssignedMIPrincipalId!
-          #disable-next-line BCP318
-          resourceId: searchService.outputs.resourceId
-          principalType: 'ServicePrincipal'
-        }
-      ]
-    }
-  }
-]
-
-// Storage Account - Storage Blob Data Contributor -> ContainerApp
-module assignStorageStorageBlobDataContributorAca 'modules/security/resource-role-assignment.bicep' = [
-  for (app, i) in containerAppsList: if (deployContainerApps && deployStorageAccount && contains(
-    app.roles,
-    const.roles.StorageBlobDataContributor.key
-  )) {
-    name: 'assignStorageStorageBlobDataContributor-${app.service_name}'
-    params: {
-      name: 'assignStorageStorageBlobDataContributor-${app.service_name}'
-      roleAssignments: [
-        {
-          roleDefinitionId: subscriptionResourceId(
-            'Microsoft.Authorization/roleDefinitions',
-            const.roles.StorageBlobDataContributor.guid
-          )
-          #disable-next-line BCP318
-          principalId: (_useUAI) ? containerAppsUAI[i].properties.principalId : containerApps[i].outputs.systemAssignedMIPrincipalId!
-          #disable-next-line BCP318
-          resourceId: storageAccount.outputs.resourceId
-          principalType: 'ServicePrincipal'
-        }
-      ]
-    }
-  }
-]
-
-// Storage Account - Storage Blob Data Reader -> ContainerApp
-module assignStorageStorageBlobDataReaderAca 'modules/security/resource-role-assignment.bicep' = [
-  for (app, i) in containerAppsList: if (deployContainerApps && deployStorageAccount && contains(
-    app.roles,
-    const.roles.StorageBlobDataReader.key
-  )) {
-    name: 'assignStorageStorageBlobDataReaderAca-${app.service_name}'
-    params: {
-      name: 'assignStorageStorageBlobDataReaderAca-${app.service_name}'
-      roleAssignments: [
-        {
-          roleDefinitionId: subscriptionResourceId(
-            'Microsoft.Authorization/roleDefinitions',
-            const.roles.StorageBlobDataReader.guid
-          )
-          #disable-next-line BCP318
-          principalId: (_useUAI)  ? containerAppsUAI[i].properties.principalId : containerApps[i].outputs.systemAssignedMIPrincipalId!
-          #disable-next-line BCP318
-          resourceId: storageAccount.outputs.resourceId
-          principalType: 'ServicePrincipal'
-        }
-      ]
-    }
-  }
-]
-
-// Storage Account - Storage Blob Data Delegator -> ContainerApp
-module assignStorageStorageBlobDataDelegatorAca 'modules/security/resource-role-assignment.bicep' = [
-  for (app, i) in containerAppsList: if (deployContainerApps && deployStorageAccount && contains(
-    app.roles,
-    const.roles.StorageBlobDelegator.key
-  )) {
-    name: 'assignStorageStorageBlobDataDelegatorAca-${app.service_name}'
-    params: {
-      name: 'assignStorageStorageBlobDataDelegatorAca-${app.service_name}'
-      roleAssignments: [
-        {
-          roleDefinitionId: subscriptionResourceId(
-            'Microsoft.Authorization/roleDefinitions',
-            const.roles.StorageBlobDelegator.guid
-          )
-          #disable-next-line BCP318
-          principalId: (_useUAI)  ? containerAppsUAI[i].properties.principalId : containerApps[i].outputs.systemAssignedMIPrincipalId!
-          #disable-next-line BCP318
-          resourceId: storageAccount.outputs.resourceId
-          principalType: 'ServicePrincipal'
-        }
-      ]
     }
   }
 ]

--- a/modules/networking/azure-firewall.bicep
+++ b/modules/networking/azure-firewall.bicep
@@ -1,0 +1,520 @@
+targetScope = 'resourceGroup'
+
+import * as const from '../../constants/constants.bicep'
+
+@description('Master switch for deploying the spoke-local Azure Firewall.')
+param deployAzureFirewall bool
+
+@description('Whether the deployment runs in network-isolated mode.')
+param networkIsolation bool
+
+@description('Enable the ACS Media (WebRTC/TURN) network rule collection.')
+param enableAcsMediaEgress bool
+
+@description('Whether Azure AI Speech is deployed (adds Speech FQDNs to jumpbox bootstrap rule).')
+param deploySpeechService bool
+
+@description('Whether the ACR Tasks agent pool is effectively deployed (computed in main.bicep).')
+param deployAcrTaskAgentPool bool
+
+@description('Extend the firewall policy with jumpbox bootstrap egress FQDNs.')
+param extendFirewallForJumpboxBootstrap bool
+
+@description('Extend the firewall policy with ACR Tasks build egress FQDNs.')
+param extendFirewallForAcrTaskBuilds bool
+
+@description('Additional FQDNs to allow for ACR Tasks builds.')
+param additionalAcrTaskBuildFqdns array
+
+@description('Deterministic resource token used to compose resource names.')
+param resourceToken string
+
+@description('Azure region for the firewall resources.')
+param location string
+
+@description('Resource tags.')
+param tags object
+
+@description('Resource ID of the virtual network hosting the AzureFirewallSubnet.')
+param virtualNetworkResourceId string
+
+@description('Name of the AzureFirewallSubnet.')
+param azureFirewallSubnetName string
+
+@description('Address prefix of the jumpbox subnet (rule source scoping).')
+param jumpboxSubnetPrefix string
+
+@description('Address prefix of the DevOps build-agents subnet (rule source scoping).')
+param devopsBuildAgentsSubnetPrefix string
+
+@description('Address prefix of the ACA environment subnet (rule source scoping).')
+param acaEnvironmentSubnetPrefix string
+
+@description('Address prefix of the agent subnet (rule source scoping).')
+param agentSubnetPrefix string
+
+@description('Whether an effective Log Analytics workspace is available for diagnostics.')
+param hasEffectiveLaw bool
+
+@description('Resource ID of the Log Analytics workspace for firewall diagnostics.')
+param lawResourceId string
+
+// Firewall FQDN allowlist for essential outbound connectivity
+// Essential (shared across subnets, source = '*'): auth, container registry mirror, GitHub
+var _firewallEssentialAuthFqdns = [
+  #disable-next-line no-hardcoded-env-urls
+  'login.microsoftonline.com'
+  'login.windows.net'
+  #disable-next-line no-hardcoded-env-urls
+  'management.azure.com'
+  'graph.microsoft.com'
+  '*.applicationinsights.azure.com'
+]
+var _firewallEssentialContainerFqdns = ['mcr.microsoft.com', '*.data.mcr.microsoft.com']
+// Platform-internal FQDNs required by the Container Apps Environment itself when egress
+// is forced through Azure Firewall (fixes #39, #40). The per-pod IMDS sidecar that backs
+// IDENTITY_ENDPOINT / IDENTITY_HEADER has two independent legs that both need to traverse
+// the firewall: (a) a Microsoft-managed Service Bus / Event Hub namespace whose FQDN
+// matches `gsm*eh.servicebus.windows.net` (the broker leg, fixes #39); (b) the ACA token
+// endpoint at `control-{region}.identity.azure.net` (the token-endpoint leg, fixes #40).
+// Without BOTH allow rules, every DefaultAzureCredential / ManagedIdentityCredential call
+// from a Container App fails at runtime with HTTP 500 "An unexpected error occured while
+// fetching the AAD Token", with no log entry on the workload side indicating the firewall
+// is the cause. Also includes ACA control-plane and Azure Monitor / Log Analytics /
+// Application Insights ingestion endpoints used by the platform's diagnostics pipeline.
+// Azure Firewall application-rule wildcards only match a single label, so explicit
+// wildcarded FQDNs are required (a generic `*.windows.net` does NOT match
+// `gsm123eh.servicebus.windows.net`, and `*.azure.com` does NOT match
+// `control-swedencentral.identity.azure.net`).
+var _firewallEssentialPlatformFqdns = [
+  '*.servicebus.windows.net'
+  '*.identity.azure.net'
+  '*.azurecontainerapps.io'
+  '*.azurecontainerapps.dev'
+  '*.in.applicationinsights.azure.com'
+  '*.livediagnostics.monitor.azure.com'
+  '*.ingest.monitor.azure.com'
+  '*.monitor.azure.com'
+  '*.monitor.core.windows.net'
+  '*.opinsights.azure.com'
+  '*.loganalytics.io'
+  // Certificate revocation / trust list (Schannel + .NET) — fixes #42.
+  // Without these, Windows TLS clients (Bastion/jumpbox curl.exe, Invoke-WebRequest,
+  // .NET HttpClient with CheckCertificateRevocationList=true) fail with
+  // CRYPT_E_REVOCATION_OFFLINE when validating Azure-managed certs served by
+  // Container Apps / App Service / etc. These are public Microsoft + DigiCert
+  // revocation endpoints implicit in any Azure-issued cert chain — allowing them
+  // in an outbound rule does not weaken the Zero Trust posture.
+  'oneocsp.microsoft.com'
+  'ocsp.digicert.com'
+  'crl.microsoft.com'
+  'crl2.microsoft.com'
+  'crl3.microsoft.com'
+  'crl.digicert.com'
+  'crl3.digicert.com'
+  'crl4.digicert.com'
+  'ctldl.windowsupdate.com'
+]
+var _firewallEssentialGitHubFqdns = [
+  'github.com'
+  '*.github.com'
+  'raw.githubusercontent.com'
+  'codeload.github.com'
+  'objects.githubusercontent.com'
+  '*.githubusercontent.com'
+]
+
+// Jumpbox-only FQDNs — scoped to jumpboxSubnetPrefix so ACA/agent subnets do not
+// inherit developer-tooling egress. Split into purpose-labeled sets so consumers can
+// audit which tool requires which endpoint.
+// Docker / Docker Hub FQDNs intentionally removed — image builds run in the ACR
+// Tasks agent pool (see deployAcrTaskAgentPool) and the Windows Server jumpbox
+// cannot build Linux images with BuildKit anyway.
+var _firewallVmBootstrapFqdns = [
+  'community.chocolatey.org'
+  'packages.chocolatey.org'
+  '*.chocolatey.org'
+  'api.nuget.org'
+  'www.nuget.org'
+  'dist.nuget.org'
+  '*.nuget.org'
+  'download.visualstudio.microsoft.com'
+  '*.visualstudio.microsoft.com'
+  'download.microsoft.com'
+  '*.download.microsoft.com'
+  'aka.ms'
+  'go.microsoft.com'
+  // azd auto-downloads the Bicep CLI binary from `downloads.bicep.azure.com`
+  // on first run (`azd env refresh` / `azd provision`); without this FQDN the
+  // jumpbox fails at "Downloading Bicep" before any deployment work begins
+  // (#36).
+  'downloads.bicep.azure.com'
+  // GitHub release fallback used by azd, the .NET installer, and many
+  // bootstrap scripts. `objects.githubusercontent.com` and
+  // `codeload.github.com` are the actual content hosts behind release asset
+  // and source-archive URLs respectively (#36).
+  'github.com'
+  '*.githubusercontent.com'
+  'objects.githubusercontent.com'
+  'codeload.github.com'
+  #disable-next-line no-hardcoded-env-urls
+  '*.core.windows.net'
+  '*.azureedge.net'
+]
+#disable-next-line no-hardcoded-env-urls
+var _firewallDevRuntimeFqdns = [
+  'www.python.org'
+  '*.python.org'
+  'pypi.org'
+  '*.pypi.org'
+  'files.pythonhosted.org'
+  '*.pythonhosted.org'
+  // get-pip.py is served from bootstrap.pypa.io. Required by the Python
+  // embeddable-distribution install path on the jumpbox (see issue #48 and
+  // install.ps1) which downloads `get-pip.py` to bootstrap pip into
+  // `C:\Python311` after extracting the embeddable zip.
+  'bootstrap.pypa.io'
+  '*.pypa.io'
+  'registry.npmjs.org'
+  '*.npmjs.org'
+]
+// Jumpbox ACME workflow egress (issue #53): scoped only to the jumpbox subnet
+// and only when `extendFirewallForJumpboxBootstrap=true`.
+// - api.github.com: reserved for ACME-client release discovery / plugin checks.
+// - acme-v02.api.letsencrypt.org: Let's Encrypt ACME v2 directory endpoint
+//   used during certificate issuance/renewal.
+var _firewallJumpboxAcmeFqdns = [
+  'api.github.com'
+  'acme-v02.api.letsencrypt.org'
+]
+#disable-next-line no-hardcoded-env-urls
+var _firewallEditorFqdns = [
+  'update.code.visualstudio.com'
+  '*.vo.msecnd.net'
+  '*.vscode-cdn.net'
+]
+
+// Azure AI Speech FQDNs (#35) — only added to the bootstrap allow rule when
+// `deploySpeechService` is true. Covers control plane, TTS, and STT regional
+// endpoints used by the Speech SDK.
+#disable-next-line no-hardcoded-env-urls
+var _firewallSpeechFqdns = deploySpeechService ? [
+  '*.cognitiveservices.azure.com'
+  '*.tts.speech.microsoft.com'
+  '*.stt.speech.microsoft.com'
+] : []
+
+// ACR Tasks agent-pool FQDNs — scoped to devopsBuildAgentsSubnetPrefix. Only
+// populated when the agent pool is actually deployed.
+//
+// Note: ACR Tasks agents need egress to ACR data plane (`*.azurecr.io`,
+// `*.data.azurecr.io`) AND to the Azure Storage queue/blob/table endpoints
+// the ACR Tasks control plane uses to dispatch jobs to the agent VM.
+// Without the *.core.windows.net FQDNs, builds queued via
+// `az acr build --agent-pool` hang indefinitely in `Queued` state because
+// the agent VM cannot reach the storage queue. See issue #18.
+var _firewallAcrTaskFqdns = deployAcrTaskAgentPool ? [
+  '*.azurecr.io'
+  '*.data.azurecr.io'
+  '*.blob.${environment().suffixes.storage}'
+  '*.queue.${environment().suffixes.storage}'
+  '*.table.${environment().suffixes.storage}'
+] : []
+
+// OS package repositories used by Debian/Ubuntu-based builder images during
+// `apt-get` steps in ACR Tasks runs. Scoped to devopsBuildAgentsSubnetPrefix
+// via `AllowAcrTaskOsPackages`. Includes packages.microsoft.com because
+// Microsoft-supported Linux packages such as msodbcsql18 are common build-time
+// dependencies for solution accelerators. Language registries (npm/PyPI/python.org)
+// are reused from `_firewallDevRuntimeFqdns` via `AllowAcrTaskDevRuntimes`.
+// See issues #20 and #68.
+#disable-next-line no-hardcoded-env-urls
+var _firewallAcrTaskOsPackageFqdns = [
+  'deb.debian.org'
+  'security.debian.org'
+  'archive.ubuntu.com'
+  'security.ubuntu.com'
+  'dl.yarnpkg.com'
+  'packages.microsoft.com'
+]
+
+// Azure Firewall rejects ApplicationRules whose targetFqdns is an empty
+// array with `BadRequest: "The request is invalid."` at the ARM
+// request-validation layer (no rule-collection-group operation is even
+// created). Build the full set of rules here, then filter out any whose
+// targetFqdns ended up empty due to disabled feature flags (for example
+// deployJumpbox=false or deployAcrTaskAgentPool=false). This keeps every rule
+// definition co-located while ensuring the ARM payload only ever contains rules
+// with at least one FQDN target.
+var _firewallDefaultApplicationRules = filter([
+  {
+    ruleType: 'ApplicationRule'
+    name: 'AllowMicrosoftContainerRegistry'
+    protocols: [
+      { protocolType: 'Https', port: 443 }
+    ]
+    targetFqdns: _firewallEssentialContainerFqdns
+    sourceAddresses: ['*']
+  }
+  {
+    ruleType: 'ApplicationRule'
+    name: 'AllowEntraIdAuth'
+    protocols: [
+      { protocolType: 'Https', port: 443 }
+    ]
+    targetFqdns: _firewallEssentialAuthFqdns
+    sourceAddresses: ['*']
+  }
+  {
+    ruleType: 'ApplicationRule'
+    name: 'AllowGitHub'
+    protocols: [
+      { protocolType: 'Https', port: 443 }
+    ]
+    targetFqdns: _firewallEssentialGitHubFqdns
+    sourceAddresses: ['*']
+  }
+  {
+    ruleType: 'ApplicationRule'
+    name: 'AllowContainerAppsPlatform'
+    protocols: [
+      { protocolType: 'Https', port: 443 }
+    ]
+    targetFqdns: _firewallEssentialPlatformFqdns
+    sourceAddresses: ['*']
+  }
+  {
+    ruleType: 'ApplicationRule'
+    name: 'AllowJumpboxBootstrap'
+    protocols: [
+      { protocolType: 'Https', port: 443 }
+      { protocolType: 'Http', port: 80 }
+    ]
+    targetFqdns: extendFirewallForJumpboxBootstrap ? concat(_firewallVmBootstrapFqdns, _firewallSpeechFqdns) : []
+    sourceAddresses: [jumpboxSubnetPrefix]
+  }
+  {
+    ruleType: 'ApplicationRule'
+    name: 'AllowJumpboxDevRuntimes'
+    protocols: [
+      { protocolType: 'Https', port: 443 }
+    ]
+    targetFqdns: extendFirewallForJumpboxBootstrap ? _firewallDevRuntimeFqdns : []
+    sourceAddresses: [jumpboxSubnetPrefix]
+  }
+  {
+    ruleType: 'ApplicationRule'
+    name: 'AllowJumpboxEditors'
+    protocols: [
+      { protocolType: 'Https', port: 443 }
+    ]
+    targetFqdns: extendFirewallForJumpboxBootstrap ? _firewallEditorFqdns : []
+    sourceAddresses: [jumpboxSubnetPrefix]
+  }
+  {
+    ruleType: 'ApplicationRule'
+    name: 'AllowJumpboxAcme'
+    protocols: [
+      { protocolType: 'Https', port: 443 }
+    ]
+    targetFqdns: extendFirewallForJumpboxBootstrap ? _firewallJumpboxAcmeFqdns : []
+    sourceAddresses: [jumpboxSubnetPrefix]
+  }
+  {
+    ruleType: 'ApplicationRule'
+    name: 'AllowAcrTasks'
+    protocols: [
+      { protocolType: 'Https', port: 443 }
+    ]
+    targetFqdns: _firewallAcrTaskFqdns
+    sourceAddresses: [devopsBuildAgentsSubnetPrefix]
+  }
+  {
+    ruleType: 'ApplicationRule'
+    name: 'AllowAcrTaskDevRuntimes'
+    protocols: [
+      { protocolType: 'Https', port: 443 }
+    ]
+    targetFqdns: (deployAcrTaskAgentPool && extendFirewallForAcrTaskBuilds) ? union(_firewallDevRuntimeFqdns, additionalAcrTaskBuildFqdns) : []
+    sourceAddresses: [devopsBuildAgentsSubnetPrefix]
+  }
+  {
+    ruleType: 'ApplicationRule'
+    name: 'AllowAcrTaskOsPackages'
+    protocols: [
+      { protocolType: 'Https', port: 443 }
+      { protocolType: 'Http', port: 80 }
+    ]
+    targetFqdns: (deployAcrTaskAgentPool && extendFirewallForAcrTaskBuilds) ? _firewallAcrTaskOsPackageFqdns : []
+    sourceAddresses: [devopsBuildAgentsSubnetPrefix]
+  }
+], rule => !empty(rule.targetFqdns))
+
+var _firewallDefaultRuleCollections = [
+  {
+    ruleCollectionType: 'FirewallPolicyFilterRuleCollection'
+    name: 'AllowEssentialOutbound'
+    priority: 100
+    action: {
+      type: 'Allow'
+    }
+    rules: _firewallDefaultApplicationRules
+  }
+]
+
+var _firewallAcsMediaRules = [
+  {
+    ruleType: 'NetworkRule'
+    name: 'AllowAcsMediaUdp'
+    ipProtocols: ['UDP']
+    sourceAddresses: [
+      jumpboxSubnetPrefix
+      acaEnvironmentSubnetPrefix
+      agentSubnetPrefix
+    ]
+    destinationAddresses: ['AzureCloud']
+    destinationPorts: ['3478-3481']
+  }
+  {
+    ruleType: 'NetworkRule'
+    name: 'AllowAcsMediaTcp'
+    ipProtocols: ['TCP']
+    sourceAddresses: [
+      jumpboxSubnetPrefix
+      acaEnvironmentSubnetPrefix
+      agentSubnetPrefix
+    ]
+    destinationAddresses: ['AzureCloud']
+    destinationPorts: ['443', '3478-3481']
+  }
+]
+
+var _firewallAcsMediaRuleCollections = [
+  {
+    ruleCollectionType: 'FirewallPolicyFilterRuleCollection'
+    name: 'AllowAcsMedia'
+    priority: 100
+    action: {
+      type: 'Allow'
+    }
+    rules: _firewallAcsMediaRules
+  }
+]
+
+// Azure Firewall for egress traffic control
+///////////////////////////////////////////////////////////////////////////
+
+resource firewallPublicIp 'Microsoft.Network/publicIPAddresses@2024-07-01' = if (deployAzureFirewall && networkIsolation) {
+  name: '${const.abbrs.networking.publicIPAddress}${const.abbrs.networking.firewall}${resourceToken}'
+  location: location
+  sku: {
+    name: 'Standard'
+    tier: 'Regional'
+  }
+  properties: {
+    publicIPAllocationMethod: 'Static'
+    publicIPAddressVersion: 'IPv4'
+  }
+  tags: tags
+}
+
+resource firewallPolicy 'Microsoft.Network/firewallPolicies@2024-07-01' = if (deployAzureFirewall && networkIsolation) {
+  name: '${const.abbrs.networking.firewallPolicy}${resourceToken}'
+  location: location
+  tags: tags
+  properties: {
+    sku: {
+      tier: 'Standard'
+    }
+    threatIntelMode: 'Alert'
+  }
+}
+
+resource firewallPolicyDefaultRuleCollectionGroup 'Microsoft.Network/firewallPolicies/ruleCollectionGroups@2024-07-01' = if (deployAzureFirewall && networkIsolation) {
+  parent: firewallPolicy
+  name: 'DefaultRuleCollectionGroup'
+  properties: {
+    priority: 200
+    ruleCollections: _firewallDefaultRuleCollections
+  }
+}
+
+// ACS Media (WebRTC / TURN) — opt-in network rule collection.
+// Required for Speech real-time avatar, ACS Calling, Teams Media. The signaling
+// path is HTTPS (already covered by application rules); the *media* path uses
+// UDP 3478-3481 / TCP 443+3478-3481 to the ACS / Speech avatar TURN fleet,
+// which is otherwise dropped by the firewall under network isolation.
+// Note: the destination is the `AzureCloud` service tag, not a hypothetical
+// `AzureCommunicationServices` tag — the latter does not exist in the Azure
+// service-tag namespace, and the actual TURN backends (e.g.
+// `relay.communication.microsoft.com`,
+// `a-tr-skysc-*.<region>.cloudapp.azure.com`) resolve into IP ranges covered
+// by `AzureCloud` / `AzureCloud.<region>`. See issue #50.
+// Separate rule collection group so it can be toggled independently of the
+// default group, and so the default group's priority doesn't have to shift.
+resource firewallPolicyAcsMediaRuleCollectionGroup 'Microsoft.Network/firewallPolicies/ruleCollectionGroups@2024-07-01' = if (deployAzureFirewall && networkIsolation && enableAcsMediaEgress) {
+  parent: firewallPolicy
+  name: 'AcsMediaRuleCollectionGroup'
+  properties: {
+    priority: 300
+    ruleCollections: _firewallAcsMediaRuleCollections
+  }
+  dependsOn: [
+    firewallPolicyDefaultRuleCollectionGroup
+  ]
+}
+
+#disable-next-line BCP318
+var _firewallSubnetId = networkIsolation ? '${virtualNetworkResourceId}/subnets/${azureFirewallSubnetName}' : ''
+
+resource azureFirewall 'Microsoft.Network/azureFirewalls@2024-07-01' = if (deployAzureFirewall && networkIsolation) {
+  name: '${const.abbrs.networking.firewall}${resourceToken}'
+  location: location
+  tags: tags
+  properties: {
+    sku: {
+      name: 'AZFW_VNet'
+      tier: 'Standard'
+    }
+    ipConfigurations: [
+      {
+        name: 'ipconfig1'
+        properties: {
+          publicIPAddress: {
+            id: firewallPublicIp.id
+          }
+          subnet: {
+            id: _firewallSubnetId
+          }
+        }
+      }
+    ]
+    firewallPolicy: {
+      id: firewallPolicy.id
+    }
+  }
+}
+
+// Azure Firewall diagnostics to Log Analytics
+resource firewallDiagnostics 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = if (deployAzureFirewall && networkIsolation && hasEffectiveLaw) {
+  name: 'fw-diagnostics'
+  scope: azureFirewall
+  properties: {
+    workspaceId: lawResourceId
+    logs: [
+      {
+        categoryGroup: 'allLogs'
+        enabled: true
+      }
+    ]
+    metrics: [
+      {
+        category: 'AllMetrics'
+        enabled: true
+      }
+    ]
+  }
+}
+
+#disable-next-line BCP318
+output privateIp string = (deployAzureFirewall && networkIsolation) ? azureFirewall!.properties.ipConfigurations[0].properties.privateIPAddress : ''

--- a/modules/networking/azure-firewall.json
+++ b/modules/networking/azure-firewall.json
@@ -1,0 +1,2004 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "languageVersion": "2.0",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.42.1.51946",
+      "templateHash": "12835075359658225108"
+    }
+  },
+  "definitions": {
+    "_1.workloadProfileInfo": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "metadata": {
+            "description": "Friendly name of the workload profile."
+          }
+        },
+        "workloadProfileType": {
+          "type": "string",
+          "allowedValues": [
+            "Consumption",
+            "D16",
+            "D32",
+            "D4",
+            "D8",
+            "E16",
+            "E32",
+            "E4",
+            "E8",
+            "NC24-A100",
+            "NC48-A100",
+            "NC96-A100"
+          ],
+          "metadata": {
+            "description": "Type of the workload profile."
+          }
+        },
+        "minimumCount": {
+          "type": "int",
+          "nullable": false,
+          "metadata": {
+            "description": "Minimum number of nodes for the workload profile."
+          }
+        },
+        "maximumCount": {
+          "type": "int",
+          "nullable": false,
+          "metadata": {
+            "description": "Maximum number of nodes for the workload profile."
+          }
+        }
+      },
+      "metadata": {
+        "description": "Information about a workload profile for the environment.",
+        "__bicep_imported_from!": {
+          "sourceTemplate": "../../constants/constants.bicep"
+        }
+      }
+    }
+  },
+  "parameters": {
+    "deployAzureFirewall": {
+      "type": "bool",
+      "metadata": {
+        "description": "Master switch for deploying the spoke-local Azure Firewall."
+      }
+    },
+    "networkIsolation": {
+      "type": "bool",
+      "metadata": {
+        "description": "Whether the deployment runs in network-isolated mode."
+      }
+    },
+    "enableAcsMediaEgress": {
+      "type": "bool",
+      "metadata": {
+        "description": "Enable the ACS Media (WebRTC/TURN) network rule collection."
+      }
+    },
+    "deploySpeechService": {
+      "type": "bool",
+      "metadata": {
+        "description": "Whether Azure AI Speech is deployed (adds Speech FQDNs to jumpbox bootstrap rule)."
+      }
+    },
+    "deployAcrTaskAgentPool": {
+      "type": "bool",
+      "metadata": {
+        "description": "Whether the ACR Tasks agent pool is effectively deployed (computed in main.bicep)."
+      }
+    },
+    "extendFirewallForJumpboxBootstrap": {
+      "type": "bool",
+      "metadata": {
+        "description": "Extend the firewall policy with jumpbox bootstrap egress FQDNs."
+      }
+    },
+    "extendFirewallForAcrTaskBuilds": {
+      "type": "bool",
+      "metadata": {
+        "description": "Extend the firewall policy with ACR Tasks build egress FQDNs."
+      }
+    },
+    "additionalAcrTaskBuildFqdns": {
+      "type": "array",
+      "metadata": {
+        "description": "Additional FQDNs to allow for ACR Tasks builds."
+      }
+    },
+    "resourceToken": {
+      "type": "string",
+      "metadata": {
+        "description": "Deterministic resource token used to compose resource names."
+      }
+    },
+    "location": {
+      "type": "string",
+      "metadata": {
+        "description": "Azure region for the firewall resources."
+      }
+    },
+    "tags": {
+      "type": "object",
+      "metadata": {
+        "description": "Resource tags."
+      }
+    },
+    "virtualNetworkResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Resource ID of the virtual network hosting the AzureFirewallSubnet."
+      }
+    },
+    "azureFirewallSubnetName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the AzureFirewallSubnet."
+      }
+    },
+    "jumpboxSubnetPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "Address prefix of the jumpbox subnet (rule source scoping)."
+      }
+    },
+    "devopsBuildAgentsSubnetPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "Address prefix of the DevOps build-agents subnet (rule source scoping)."
+      }
+    },
+    "acaEnvironmentSubnetPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "Address prefix of the ACA environment subnet (rule source scoping)."
+      }
+    },
+    "agentSubnetPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "Address prefix of the agent subnet (rule source scoping)."
+      }
+    },
+    "hasEffectiveLaw": {
+      "type": "bool",
+      "metadata": {
+        "description": "Whether an effective Log Analytics workspace is available for diagnostics."
+      }
+    },
+    "lawResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Resource ID of the Log Analytics workspace for firewall diagnostics."
+      }
+    }
+  },
+  "variables": {
+    "_firewallEssentialAuthFqdns": [
+      "login.microsoftonline.com",
+      "login.windows.net",
+      "management.azure.com",
+      "graph.microsoft.com",
+      "*.applicationinsights.azure.com"
+    ],
+    "_firewallEssentialContainerFqdns": [
+      "mcr.microsoft.com",
+      "*.data.mcr.microsoft.com"
+    ],
+    "_firewallEssentialPlatformFqdns": [
+      "*.servicebus.windows.net",
+      "*.identity.azure.net",
+      "*.azurecontainerapps.io",
+      "*.azurecontainerapps.dev",
+      "*.in.applicationinsights.azure.com",
+      "*.livediagnostics.monitor.azure.com",
+      "*.ingest.monitor.azure.com",
+      "*.monitor.azure.com",
+      "*.monitor.core.windows.net",
+      "*.opinsights.azure.com",
+      "*.loganalytics.io",
+      "oneocsp.microsoft.com",
+      "ocsp.digicert.com",
+      "crl.microsoft.com",
+      "crl2.microsoft.com",
+      "crl3.microsoft.com",
+      "crl.digicert.com",
+      "crl3.digicert.com",
+      "crl4.digicert.com",
+      "ctldl.windowsupdate.com"
+    ],
+    "_firewallEssentialGitHubFqdns": [
+      "github.com",
+      "*.github.com",
+      "raw.githubusercontent.com",
+      "codeload.github.com",
+      "objects.githubusercontent.com",
+      "*.githubusercontent.com"
+    ],
+    "_firewallVmBootstrapFqdns": [
+      "community.chocolatey.org",
+      "packages.chocolatey.org",
+      "*.chocolatey.org",
+      "api.nuget.org",
+      "www.nuget.org",
+      "dist.nuget.org",
+      "*.nuget.org",
+      "download.visualstudio.microsoft.com",
+      "*.visualstudio.microsoft.com",
+      "download.microsoft.com",
+      "*.download.microsoft.com",
+      "aka.ms",
+      "go.microsoft.com",
+      "downloads.bicep.azure.com",
+      "github.com",
+      "*.githubusercontent.com",
+      "objects.githubusercontent.com",
+      "codeload.github.com",
+      "*.core.windows.net",
+      "*.azureedge.net"
+    ],
+    "_firewallDevRuntimeFqdns": [
+      "www.python.org",
+      "*.python.org",
+      "pypi.org",
+      "*.pypi.org",
+      "files.pythonhosted.org",
+      "*.pythonhosted.org",
+      "bootstrap.pypa.io",
+      "*.pypa.io",
+      "registry.npmjs.org",
+      "*.npmjs.org"
+    ],
+    "_firewallJumpboxAcmeFqdns": [
+      "api.github.com",
+      "acme-v02.api.letsencrypt.org"
+    ],
+    "_firewallEditorFqdns": [
+      "update.code.visualstudio.com",
+      "*.vo.msecnd.net",
+      "*.vscode-cdn.net"
+    ],
+    "_firewallSpeechFqdns": "[if(parameters('deploySpeechService'), createArray('*.cognitiveservices.azure.com', '*.tts.speech.microsoft.com', '*.stt.speech.microsoft.com'), createArray())]",
+    "_firewallAcrTaskFqdns": "[if(parameters('deployAcrTaskAgentPool'), createArray('*.azurecr.io', '*.data.azurecr.io', format('*.blob.{0}', environment().suffixes.storage), format('*.queue.{0}', environment().suffixes.storage), format('*.table.{0}', environment().suffixes.storage)), createArray())]",
+    "_firewallAcrTaskOsPackageFqdns": [
+      "deb.debian.org",
+      "security.debian.org",
+      "archive.ubuntu.com",
+      "security.ubuntu.com",
+      "dl.yarnpkg.com",
+      "packages.microsoft.com"
+    ],
+    "_firewallDefaultApplicationRules": "[filter(createArray(createObject('ruleType', 'ApplicationRule', 'name', 'AllowMicrosoftContainerRegistry', 'protocols', createArray(createObject('protocolType', 'Https', 'port', 443)), 'targetFqdns', variables('_firewallEssentialContainerFqdns'), 'sourceAddresses', createArray('*')), createObject('ruleType', 'ApplicationRule', 'name', 'AllowEntraIdAuth', 'protocols', createArray(createObject('protocolType', 'Https', 'port', 443)), 'targetFqdns', variables('_firewallEssentialAuthFqdns'), 'sourceAddresses', createArray('*')), createObject('ruleType', 'ApplicationRule', 'name', 'AllowGitHub', 'protocols', createArray(createObject('protocolType', 'Https', 'port', 443)), 'targetFqdns', variables('_firewallEssentialGitHubFqdns'), 'sourceAddresses', createArray('*')), createObject('ruleType', 'ApplicationRule', 'name', 'AllowContainerAppsPlatform', 'protocols', createArray(createObject('protocolType', 'Https', 'port', 443)), 'targetFqdns', variables('_firewallEssentialPlatformFqdns'), 'sourceAddresses', createArray('*')), createObject('ruleType', 'ApplicationRule', 'name', 'AllowJumpboxBootstrap', 'protocols', createArray(createObject('protocolType', 'Https', 'port', 443), createObject('protocolType', 'Http', 'port', 80)), 'targetFqdns', if(parameters('extendFirewallForJumpboxBootstrap'), concat(variables('_firewallVmBootstrapFqdns'), variables('_firewallSpeechFqdns')), createArray()), 'sourceAddresses', createArray(parameters('jumpboxSubnetPrefix'))), createObject('ruleType', 'ApplicationRule', 'name', 'AllowJumpboxDevRuntimes', 'protocols', createArray(createObject('protocolType', 'Https', 'port', 443)), 'targetFqdns', if(parameters('extendFirewallForJumpboxBootstrap'), variables('_firewallDevRuntimeFqdns'), createArray()), 'sourceAddresses', createArray(parameters('jumpboxSubnetPrefix'))), createObject('ruleType', 'ApplicationRule', 'name', 'AllowJumpboxEditors', 'protocols', createArray(createObject('protocolType', 'Https', 'port', 443)), 'targetFqdns', if(parameters('extendFirewallForJumpboxBootstrap'), variables('_firewallEditorFqdns'), createArray()), 'sourceAddresses', createArray(parameters('jumpboxSubnetPrefix'))), createObject('ruleType', 'ApplicationRule', 'name', 'AllowJumpboxAcme', 'protocols', createArray(createObject('protocolType', 'Https', 'port', 443)), 'targetFqdns', if(parameters('extendFirewallForJumpboxBootstrap'), variables('_firewallJumpboxAcmeFqdns'), createArray()), 'sourceAddresses', createArray(parameters('jumpboxSubnetPrefix'))), createObject('ruleType', 'ApplicationRule', 'name', 'AllowAcrTasks', 'protocols', createArray(createObject('protocolType', 'Https', 'port', 443)), 'targetFqdns', variables('_firewallAcrTaskFqdns'), 'sourceAddresses', createArray(parameters('devopsBuildAgentsSubnetPrefix'))), createObject('ruleType', 'ApplicationRule', 'name', 'AllowAcrTaskDevRuntimes', 'protocols', createArray(createObject('protocolType', 'Https', 'port', 443)), 'targetFqdns', if(and(parameters('deployAcrTaskAgentPool'), parameters('extendFirewallForAcrTaskBuilds')), union(variables('_firewallDevRuntimeFqdns'), parameters('additionalAcrTaskBuildFqdns')), createArray()), 'sourceAddresses', createArray(parameters('devopsBuildAgentsSubnetPrefix'))), createObject('ruleType', 'ApplicationRule', 'name', 'AllowAcrTaskOsPackages', 'protocols', createArray(createObject('protocolType', 'Https', 'port', 443), createObject('protocolType', 'Http', 'port', 80)), 'targetFqdns', if(and(parameters('deployAcrTaskAgentPool'), parameters('extendFirewallForAcrTaskBuilds')), variables('_firewallAcrTaskOsPackageFqdns'), createArray()), 'sourceAddresses', createArray(parameters('devopsBuildAgentsSubnetPrefix')))), lambda('rule', not(empty(lambdaVariables('rule').targetFqdns))))]",
+    "_firewallDefaultRuleCollections": [
+      {
+        "ruleCollectionType": "FirewallPolicyFilterRuleCollection",
+        "name": "AllowEssentialOutbound",
+        "priority": 100,
+        "action": {
+          "type": "Allow"
+        },
+        "rules": "[variables('_firewallDefaultApplicationRules')]"
+      }
+    ],
+    "_firewallAcsMediaRules": [
+      {
+        "ruleType": "NetworkRule",
+        "name": "AllowAcsMediaUdp",
+        "ipProtocols": [
+          "UDP"
+        ],
+        "sourceAddresses": [
+          "[parameters('jumpboxSubnetPrefix')]",
+          "[parameters('acaEnvironmentSubnetPrefix')]",
+          "[parameters('agentSubnetPrefix')]"
+        ],
+        "destinationAddresses": [
+          "AzureCloud"
+        ],
+        "destinationPorts": [
+          "3478-3481"
+        ]
+      },
+      {
+        "ruleType": "NetworkRule",
+        "name": "AllowAcsMediaTcp",
+        "ipProtocols": [
+          "TCP"
+        ],
+        "sourceAddresses": [
+          "[parameters('jumpboxSubnetPrefix')]",
+          "[parameters('acaEnvironmentSubnetPrefix')]",
+          "[parameters('agentSubnetPrefix')]"
+        ],
+        "destinationAddresses": [
+          "AzureCloud"
+        ],
+        "destinationPorts": [
+          "443",
+          "3478-3481"
+        ]
+      }
+    ],
+    "_firewallAcsMediaRuleCollections": [
+      {
+        "ruleCollectionType": "FirewallPolicyFilterRuleCollection",
+        "name": "AllowAcsMedia",
+        "priority": 100,
+        "action": {
+          "type": "Allow"
+        },
+        "rules": "[variables('_firewallAcsMediaRules')]"
+      }
+    ],
+    "_firewallSubnetId": "[if(parameters('networkIsolation'), format('{0}/subnets/{1}', parameters('virtualNetworkResourceId'), parameters('azureFirewallSubnetName')), '')]",
+    "_1._2": {
+      "ai": {
+        "aiFoundry": "aif-",
+        "aiFoundryProject": "aifp-",
+        "aiSearch": "srch-",
+        "aiServices": "aisa-",
+        "aiVideoIndexer": "avi-",
+        "bing": "bing-",
+        "machineLearningWorkspace": "mlw-",
+        "openAIService": "oai-",
+        "botService": "bot-",
+        "computerVision": "cv-",
+        "contentModerator": "cm-",
+        "contentSafety": "cs-",
+        "customVisionPrediction": "cstv-",
+        "customVisionTraining": "cstvt-",
+        "documentIntelligence": "di-",
+        "faceApi": "face-",
+        "healthInsights": "hi-",
+        "immersiveReader": "ir-",
+        "languageService": "lang-",
+        "speechService": "spch-",
+        "translator": "trsl-",
+        "aiHub": "aih-",
+        "aiHubProject": "aihp-"
+      },
+      "analytics": {
+        "analysisServicesServer": "as",
+        "databricksWorkspace": "dbw-",
+        "dataExplorerCluster": "dec",
+        "dataExplorerClusterDatabase": "dedb",
+        "dataFactory": "adf-",
+        "digitalTwin": "dt-",
+        "streamAnalytics": "asa-",
+        "synapseAnalyticsPrivateLinkHub": "synplh-",
+        "synapseAnalyticsSQLDedicatedPool": "syndp",
+        "synapseAnalyticsSparkPool": "synsp",
+        "synapseAnalyticsWorkspaces": "synw",
+        "dataLakeStoreAccount": "dls",
+        "dataLakeAnalyticsAccount": "dla",
+        "eventHubsNamespace": "evhns-",
+        "eventHub": "evh-",
+        "eventGridDomain": "evgd-",
+        "eventGridSubscriptions": "evgs-",
+        "eventGridTopic": "evgt-",
+        "eventGridSystemTopic": "egst-",
+        "hdInsightHadoopCluster": "hadoop-",
+        "hdInsightHBaseCluster": "hbase-",
+        "hdInsightKafkaCluster": "kafka-",
+        "hdInsightSparkCluster": "spark-",
+        "hdInsightStormCluster": "storm-",
+        "hdInsightMLServicesCluster": "mls-",
+        "iotHub": "iot-",
+        "provisioningServices": "provs-",
+        "provisioningServicesCertificate": "pcert-",
+        "powerBIEmbedded": "pbi-",
+        "timeSeriesInsightsEnvironment": "tsi-"
+      },
+      "configuration": {
+        "appConfiguration": "appcs-"
+      },
+      "compute": {
+        "appServiceEnvironment": "ase-",
+        "appServicePlan": "asp-",
+        "loadTesting": "lt-",
+        "availabilitySet": "avail-",
+        "arcEnabledServer": "arcs-",
+        "arcEnabledKubernetesCluster": "arck",
+        "batchAccounts": "ba-",
+        "cloudService": "cld-",
+        "communicationServices": "acs-",
+        "diskEncryptionSet": "des",
+        "functionApp": "func-",
+        "gallery": "gal",
+        "hostingEnvironment": "host-",
+        "imageTemplate": "it-",
+        "managedDiskOS": "osdisk",
+        "managedDiskData": "disk",
+        "notificationHubs": "ntf-",
+        "notificationHubsNamespace": "ntfns-",
+        "proximityPlacementGroup": "ppg-",
+        "restorePointCollection": "rpc-",
+        "snapshot": "snap-",
+        "staticWebApp": "stapp-",
+        "virtualMachine": "vm-",
+        "virtualMachineScaleSet": "vmss-",
+        "virtualMachineMaintenanceConfiguration": "mc-",
+        "virtualMachineStorageAccount": "stvm",
+        "webApp": "app-"
+      },
+      "containers": {
+        "aksCluster": "aks-",
+        "aksSystemNodePool": "npsystem-",
+        "aksUserNodePool": "np-",
+        "containerApp": "ca-",
+        "containerAppsEnvironment": "cae-",
+        "containerRegistry": "cr",
+        "containerInstance": "ci",
+        "serviceFabricCluster": "sf-",
+        "serviceFabricManagedCluster": "sfmc-"
+      },
+      "databases": {
+        "cosmosDBDatabase": "cosmos-",
+        "cosmosDBApacheCassandra": "coscas-",
+        "cosmosDBMongoDB": "cosmon-",
+        "cosmosDBNoSQL": "cosno-",
+        "cosmosDBTable": "costab-",
+        "cosmosDBGremlin": "cosgrm-",
+        "cosmosDBPostgreSQL": "cospos-",
+        "cacheForRedis": "redis-",
+        "sqlDatabaseServer": "sql-",
+        "sqlDatabase": "sqldb-",
+        "sqlElasticJobAgent": "sqlja-",
+        "sqlElasticPool": "sqlep-",
+        "mariaDBServer": "maria-",
+        "mariaDBDatabase": "mariadb-",
+        "mySQLDatabase": "mysql-",
+        "postgreSQLDatabase": "psql-",
+        "sqlServerStretchDatabase": "sqlstrdb-",
+        "sqlManagedInstance": "sqlmi-"
+      },
+      "developerTools": {
+        "appConfigurationStore": "appcs-",
+        "mapsAccount": "map-",
+        "signalR": "sigr",
+        "webPubSub": "wps-"
+      },
+      "devOps": {
+        "managedGrafana": "amg-"
+      },
+      "integration": {
+        "integrationAccount": "ia-",
+        "logicApp": "logic-",
+        "serviceBusNamespace": "sbns-",
+        "serviceBusQueue": "sbq-",
+        "serviceBusTopic": "sbt-",
+        "serviceBusTopicSubscription": "sbts-"
+      },
+      "managementGovernance": {
+        "automationAccount": "aa-",
+        "applicationInsights": "appi-",
+        "grafana": "graf-",
+        "monitorActionGroup": "ag-",
+        "monitorDataCollectionRules": "dcr-",
+        "monitorAlertProcessingRule": "apr-",
+        "blueprint": "bp-",
+        "blueprintAssignment": "bpa-",
+        "dataCollectionEndpoint": "dce-",
+        "logAnalyticsWorkspace": "log-",
+        "logAnalyticsQueryPacks": "pack-",
+        "managementGroup": "mg-",
+        "purviewInstance": "pview-",
+        "resourceGroup": "rg-",
+        "templateSpecsName": "ts-"
+      },
+      "migration": {
+        "migrateProject": "migr-",
+        "databaseMigrationService": "dms-",
+        "recoveryServicesVault": "rsv-"
+      },
+      "networking": {
+        "aivnet": "aivnet-",
+        "applicationGateway": "agw-",
+        "applicationSecurityGroup": "asg-",
+        "cdnProfile": "cdnp-",
+        "cdnEndpoint": "cdne-",
+        "connections": "con-",
+        "dnsForwardingRuleset": "dnsfrs-",
+        "dnsPrivateResolver": "dnspr-",
+        "dnsPrivateResolverInboundEndpoint": "in-",
+        "dnsPrivateResolverOutboundEndpoint": "out-",
+        "firewall": "afw-",
+        "firewallPolicy": "afwp-",
+        "expressRouteCircuit": "erc-",
+        "expressRouteGateway": "ergw-",
+        "frontDoorProfile": "afd-",
+        "frontDoorEndpoint": "fde-",
+        "frontDoorFirewallPolicy": "fdfp-",
+        "ipGroups": "ipg-",
+        "loadBalancerInternal": "lbi-",
+        "loadBalancerExternal": "lbe-",
+        "loadBalancerRule": "rule-",
+        "localNetworkGateway": "lgw-",
+        "natGateway": "ng-",
+        "networkInterface": "nic-",
+        "networkSecurityGroup": "nsg-",
+        "networkSecurityGroupSecurityRules": "nsgsr-",
+        "networkWatcher": "nw-",
+        "privateLink": "pl-",
+        "privateLinkScope": "pls-",
+        "privateEndpoint": "pep-",
+        "publicIPAddress": "pip-",
+        "publicIPAddressPrefix": "ippre-",
+        "routeFilter": "rf-",
+        "routeServer": "rtserv-",
+        "routeTable": "rt-",
+        "serviceEndpointPolicy": "se-",
+        "trafficManagerProfile": "traf-",
+        "userDefinedRoute": "udr-",
+        "virtualNetwork": "vnet-",
+        "virtualNetworkGateway": "vgw-",
+        "virtualNetworkManager": "vnm-",
+        "virtualNetworkPeering": "peer-",
+        "virtualNetworkSubnet": "snet-",
+        "virtualWAN": "vwan-",
+        "virtualWANHub": "vhub-"
+      },
+      "security": {
+        "bastion": "bas-",
+        "keyVault": "kv-",
+        "privateEndpoint": "pe-",
+        "keyVaultManagedHSM": "kvmhsm-",
+        "managedIdentity": "uai-",
+        "sshKey": "sshkey-",
+        "vpnGateway": "vpng-",
+        "vpnConnection": "vcn-",
+        "vpnSite": "vst-",
+        "webApplicationFirewallPolicy": "waf",
+        "webApplicationFirewallPolicyRuleGroup": "wafrg"
+      },
+      "storage": {
+        "storSimple": "ssimp",
+        "backupVault": "bvault-",
+        "backupVaultPolicy": "bkpol-",
+        "fileShare": "share-",
+        "storageAccount": "st",
+        "storageSyncService": "sss-"
+      },
+      "virtualDesktop": {
+        "labServicesPlan": "lp-",
+        "virtualDesktopHostPool": "vdpool-",
+        "virtualDesktopApplicationGroup": "vdag-",
+        "virtualDesktopWorkspace": "vdws-",
+        "virtualDesktopScalingPlan": "vdscaling-"
+      }
+    },
+    "_1._3": {
+      "AcrDelete": {
+        "guid": "c2f4ef07-c644-48eb-af81-4b1b4947fb11",
+        "key": "AcrDelete"
+      },
+      "AcrImageSigner": {
+        "guid": "6cef56e8-d556-48e5-a04f-b8e64114680f",
+        "key": "AcrImageSigner"
+      },
+      "AcrPull": {
+        "guid": "7f951dda-4ed3-4680-a7ca-43fe172d538d",
+        "key": "AcrPull"
+      },
+      "AcrPush": {
+        "guid": "8311e382-0749-4cb8-b61a-304f252e45ec",
+        "key": "AcrPush"
+      },
+      "AcrQuarantineReader": {
+        "guid": "cdda3590-29a3-44f6-95f2-9f980659eb04",
+        "key": "AcrQuarantineReader"
+      },
+      "AcrQuarantineWriter": {
+        "guid": "c8d4ff99-41c3-41a8-9f60-21dfdad59608",
+        "key": "AcrQuarantineWriter"
+      },
+      "AksClusterAdminRole": {
+        "guid": "0ab0b1a8-8aac-4efd-b8c2-3ee1fb270be8",
+        "key": "AksClusterAdminRole"
+      },
+      "AksClusterMonitoringUser": {
+        "guid": "1afdec4b-e479-420e-99e7-f82237c7c5e6",
+        "key": "AksClusterMonitoringUser"
+      },
+      "AksClusterUserRole": {
+        "guid": "4abbcc35-e782-43d8-92c5-2d3f1bd2253f",
+        "key": "AksClusterUserRole"
+      },
+      "AksContributorRole": {
+        "guid": "ed7f3fbd-7b88-4dd4-9017-9adb7ce333f8",
+        "key": "AksContributorRole"
+      },
+      "AksFleetManagerContributorRole": {
+        "guid": "63bb64ad-9799-4770-b5c3-24ed299a07bf",
+        "key": "AksFleetManagerContributorRole"
+      },
+      "AksFleetManagerRBACAdmin": {
+        "guid": "434fb43a-c01c-447e-9f67-c3ad923cfaba",
+        "key": "AksFleetManagerRBACAdmin"
+      },
+      "AksFleetManagerRBACClusterAdmin": {
+        "guid": "18ab4d3d-a1bf-4477-8ad9-8359bc988f69",
+        "key": "AksFleetManagerRBACClusterAdmin"
+      },
+      "AksFleetManagerRBACReader": {
+        "guid": "30b27cfc-9c84-438e-b0ce-70e35255df80",
+        "key": "AksFleetManagerRBACReader"
+      },
+      "AksFleetManagerRBACWriter": {
+        "guid": "5af6afb3-c06c-4fa4-8848-71a8aee05683",
+        "key": "AksFleetManagerRBACWriter"
+      },
+      "AksRBACAdmin": {
+        "guid": "3498e952-d568-435e-9b2c-8d77e338d7f7",
+        "key": "AksRBACAdmin"
+      },
+      "AksRBACClusterAdmin": {
+        "guid": "b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b",
+        "key": "AksRBACClusterAdmin"
+      },
+      "AksRBACReader": {
+        "guid": "7f6c6a51-bcf8-42ba-9220-52d62157d7db",
+        "key": "AksRBACReader"
+      },
+      "AksRBACWriter": {
+        "guid": "a7ffa36f-339b-4b5c-8bdf-e2c188b2c0eb",
+        "key": "AksRBACWriter"
+      },
+      "AppComplianceAutomationAdministrator": {
+        "guid": "0f37683f-2463-46b6-9ce7-9b788b988ba2",
+        "key": "AppComplianceAutomationAdministrator"
+      },
+      "AppComplianceAutomationReader": {
+        "guid": "ffc6bbe0-e443-4c3b-bf54-26581bb2f78e",
+        "key": "AppComplianceAutomationReader"
+      },
+      "AppConfigurationDataOwner": {
+        "guid": "5ae67dd6-50cb-40e7-96ff-dc2bfa4b606b",
+        "key": "AppConfigurationDataOwner"
+      },
+      "AppConfigurationDataReader": {
+        "guid": "516239f1-63e1-4d78-a4de-a74fb236a071",
+        "key": "AppConfigurationDataReader"
+      },
+      "ApplicationInsightsComponentContributor": {
+        "guid": "ae349356-3a1b-4a5e-921d-050484c6347e",
+        "key": "ApplicationInsightsComponentContributor"
+      },
+      "ApplicationInsightsSnapshotDebugger": {
+        "guid": "08954f03-6346-4c2e-81c0-ec3a5cfae23b",
+        "key": "ApplicationInsightsSnapshotDebugger"
+      },
+      "AttestationContributor": {
+        "guid": "bbf86eb8-f7b4-4cce-96e4-18cddf81d86e",
+        "key": "AttestationContributor"
+      },
+      "AttestationReader": {
+        "guid": "fd1bd22b-8476-40bc-a0bc-69b95687b9f3",
+        "key": "AttestationReader"
+      },
+      "AutomationContributor": {
+        "guid": "f353d9bd-d4a6-484e-a77a-8050b599b867",
+        "key": "AutomationContributor"
+      },
+      "AutomationJobOperator": {
+        "guid": "4fe576fe-1146-4730-92eb-48519fa6bf9f",
+        "key": "AutomationJobOperator"
+      },
+      "AutomationOperator": {
+        "guid": "d3881f73-407a-4167-8283-e981cbba0404",
+        "key": "AutomationOperator"
+      },
+      "AutomationRunbookOperator": {
+        "guid": "5fb5aef8-1081-4b8e-bb16-9d5d0385bab5",
+        "key": "AutomationRunbookOperator"
+      },
+      "AvereContributor": {
+        "guid": "4f8fab4f-1852-4a58-a46a-8eaf358af14a",
+        "key": "AvereContributor"
+      },
+      "AvereOperator": {
+        "guid": "c025889f-8102-4ebf-b32c-fc0c6f0c6bd9",
+        "key": "AvereOperator"
+      },
+      "AzureAIAdministrator": {
+        "guid": "b78c5d69-af96-48a3-bf8d-a8b4d589de94",
+        "key": "AzureAIAdministrator"
+      },
+      "AzureAIDeveloper": {
+        "guid": "64702f94-c441-49e6-a78b-ef80e0188fee",
+        "key": "AzureAIDeveloper"
+      },
+      "AzureAIEnterpriseNetworkConnectionApprover": {
+        "guid": "b556d68e-0be0-4f35-a333-ad7ee1ce17ea",
+        "key": "AzureAIEnterpriseNetworkConnectionApprover"
+      },
+      "AzureAIInferenceDeploymentOperator": {
+        "guid": "3afb7f49-54cb-416e-8c09-6dc049efa503",
+        "key": "AzureAIInferenceDeploymentOperator"
+      },
+      "AzureAIProjectManager": {
+        "guid": "eadc314b-1a2d-4efa-be10-5d325db5065e",
+        "key": "AzureAIProjectManager"
+      },
+      "AzureAISafetyEvaluator": {
+        "guid": "11102f94-c441-49e6-a78b-ef80e0188abc",
+        "key": "AzureAISafetyEvaluator"
+      },
+      "AzureAIUser": {
+        "guid": "53ca6127-db72-4b80-b1b0-d745d6d5456d",
+        "key": "AzureAIUser"
+      },
+      "AzureApiCenterComplianceManager": {
+        "guid": "ede9aaa3-4627-494e-be13-4aa7c256148d",
+        "key": "AzureApiCenterComplianceManager"
+      },
+      "AzureApiCenterDataReader": {
+        "guid": "c7244dfb-f447-457d-b2ba-3999044d1706",
+        "key": "AzureApiCenterDataReader"
+      },
+      "AzureApiCenterServiceContributor": {
+        "guid": "dd24193f-ef65-44e5-8a7e-6fa6e03f7713",
+        "key": "AzureApiCenterServiceContributor"
+      },
+      "AzureApiCenterServiceReader": {
+        "guid": "6cba8790-29c5-48e5-bab1-c7541b01cb04",
+        "key": "AzureApiCenterServiceReader"
+      },
+      "AzureArcEnabledKubernetesClusterUser": {
+        "guid": "00493d72-78f6-4148-b6c5-d3ce8e4799dd",
+        "key": "AzureArcEnabledKubernetesClusterUser"
+      },
+      "AzureArcKubernetesAdmin": {
+        "guid": "dffb1e0c-446f-4dde-a09f-99eb5cc68b96",
+        "key": "AzureArcKubernetesAdmin"
+      },
+      "AzureArcKubernetesClusterAdmin": {
+        "guid": "8393591c-06b9-48a2-a542-1bd6b377f6a2",
+        "key": "AzureArcKubernetesClusterAdmin"
+      },
+      "AzureArcKubernetesViewer": {
+        "guid": "63f0a09d-1495-4db4-a681-037d84835eb4",
+        "key": "AzureArcKubernetesViewer"
+      },
+      "AzureArcKubernetesWriter": {
+        "guid": "5b999177-9696-4545-85c7-50de3797e5a1",
+        "key": "AzureArcKubernetesWriter"
+      },
+      "AzureConnectedMachineOnboarding": {
+        "guid": "b64e21ea-ac4e-4cdf-9dc9-5b892992bee7",
+        "key": "AzureConnectedMachineOnboarding"
+      },
+      "AzureConnectedMachineResourceAdministrator": {
+        "guid": "cd570a14-e51a-42ad-bac8-bafd67325302",
+        "key": "AzureConnectedMachineResourceAdministrator"
+      },
+      "AzureConnectedMachineResourceManager": {
+        "guid": "f5819b54-e033-4d82-ac66-4fec3cbf3f4c",
+        "key": "AzureConnectedMachineResourceManager"
+      },
+      "AzureConnectedSQLServerOnboarding": {
+        "guid": "e8113dce-c529-4d33-91fa-e9b972617508",
+        "key": "AzureConnectedSQLServerOnboarding"
+      },
+      "AzureContainerStorageOperator": {
+        "guid": "08d4c71a-cc63-4ce4-a9c8-5dd251b4d619",
+        "key": "AzureContainerStorageOperator"
+      },
+      "AzureContainerStorageOwner": {
+        "guid": "95de85bd-744d-4664-9dde-11430bc34793",
+        "key": "AzureContainerStorageOwner"
+      },
+      "AzureDigitalTwinsDataOwner": {
+        "guid": "bcd981a7-7f74-457b-83e1-cceb9e632ffe",
+        "key": "AzureDigitalTwinsDataOwner"
+      },
+      "AzureDigitalTwinsDataReader": {
+        "guid": "d57506d4-4c8d-48b1-8587-93c323f6a5a3",
+        "key": "AzureDigitalTwinsDataReader"
+      },
+      "AzureEventHubsDataOwner": {
+        "guid": "f526a384-b230-433a-b45c-95f59c4a2dec",
+        "key": "AzureEventHubsDataOwner"
+      },
+      "AzureEventHubsDataReceiver": {
+        "guid": "a638d3c7-ab3a-418d-83e6-5f17a39d4fde",
+        "key": "AzureEventHubsDataReceiver"
+      },
+      "AzureEventHubsDataSender": {
+        "guid": "2b629674-e913-4c01-ae53-ef4638d8f975",
+        "key": "AzureEventHubsDataSender"
+      },
+      "AzureFrontDoorDomainContributor": {
+        "guid": "0ab34830-df19-4f8c-b84e-aa85b8afa6e8",
+        "key": "AzureFrontDoorDomainContributor"
+      },
+      "AzureFrontDoorDomainReader": {
+        "guid": "0f99d363-226e-4dca-9920-b807cf8e1a5f",
+        "key": "AzureFrontDoorDomainReader"
+      },
+      "AzureFrontDoorProfileReader": {
+        "guid": "662802e2-50f6-46b0-aed2-e834bacc6d12",
+        "key": "AzureFrontDoorProfileReader"
+      },
+      "AzureFrontDoorSecretReader": {
+        "guid": "0db238c4-885e-4c4f-a933-aa2cef684fca",
+        "key": "AzureFrontDoorSecretReader"
+      },
+      "AzureMLComputeOperator": {
+        "guid": "e503ece1-11d0-4e8e-8e2c-7a6c3bf38815",
+        "key": "AzureMLComputeOperator"
+      },
+      "AzureMLDataScientist": {
+        "guid": "f6c7c914-8db3-469d-8ca1-694a8f32e121",
+        "key": "AzureMLDataScientist"
+      },
+      "AzureMapsDataContributor": {
+        "guid": "8f5e0ce6-4f7b-4dcf-bddf-e6f48634a204",
+        "key": "AzureMapsDataContributor"
+      },
+      "AzureMapsDataReader": {
+        "guid": "423170ca-a8f6-4b0f-8487-9e4eb8f49bfa",
+        "key": "AzureMapsDataReader"
+      },
+      "AzureRelayListener": {
+        "guid": "26e0b698-aa6d-4085-9386-aadae190014d",
+        "key": "AzureRelayListener"
+      },
+      "AzureRelayOwner": {
+        "guid": "2787bf04-f1f5-4bfe-8383-c8a24483ee38",
+        "key": "AzureRelayOwner"
+      },
+      "AzureRelaySender": {
+        "guid": "26baccc8-eea7-41f1-98f4-1762cc7f685d",
+        "key": "AzureRelaySender"
+      },
+      "AzureServiceBusDataOwner": {
+        "guid": "090c5cfd-751d-490a-894a-3ce6f1109419",
+        "key": "AzureServiceBusDataOwner"
+      },
+      "AzureServiceBusDataReceiver": {
+        "guid": "4f6d3b9b-027b-4f4c-9142-0e5a2a2247e0",
+        "key": "AzureServiceBusDataReceiver"
+      },
+      "AzureServiceBusDataSender": {
+        "guid": "69a216fc-b8fb-44d8-bc22-1f3c2cd27a39",
+        "key": "AzureServiceBusDataSender"
+      },
+      "AzureSpringCloudConfigServerContributor": {
+        "guid": "a06f5c24-21a7-4e1a-aa2b-f19eb6684f5b",
+        "key": "AzureSpringCloudConfigServerContributor"
+      },
+      "AzureSpringCloudConfigServerReader": {
+        "guid": "d04c6db6-4947-4782-9e91-30a88feb7be7",
+        "key": "AzureSpringCloudConfigServerReader"
+      },
+      "AzureSpringCloudDataReader": {
+        "guid": "b5537268-8956-4941-a8f0-646150406f0c",
+        "key": "AzureSpringCloudDataReader"
+      },
+      "AzureSpringCloudServiceRegistryContributor": {
+        "guid": "f5880b48-c26d-48be-b172-7927bfa1c8f1",
+        "key": "AzureSpringCloudServiceRegistryContributor"
+      },
+      "AzureSpringCloudServiceRegistryReader": {
+        "guid": "cff1b556-2399-4e7e-856d-a8f754be7b65",
+        "key": "AzureSpringCloudServiceRegistryReader"
+      },
+      "AzureStackRegistrationOwner": {
+        "guid": "6f12a6df-dd06-4f3e-bcb1-ce8be600526a",
+        "key": "AzureStackRegistrationOwner"
+      },
+      "BackupContributor": {
+        "guid": "5e467623-bb1f-42f4-a55d-6e525e11384b",
+        "key": "BackupContributor"
+      },
+      "BackupOperator": {
+        "guid": "00c29273-979b-4161-815c-10b084fb9324",
+        "key": "BackupOperator"
+      },
+      "BackupReader": {
+        "guid": "a795c7a0-d4a2-40c1-ae25-d81f01202912",
+        "key": "BackupReader"
+      },
+      "BillingReader": {
+        "guid": "fa23ad8b-c56e-40d8-ac0c-ce449e1d2c64",
+        "key": "BillingReader"
+      },
+      "BizTalkContributor": {
+        "guid": "5e3c6656-6cfa-4708-81fe-0de47ac73342",
+        "key": "BizTalkContributor"
+      },
+      "BlueprintContributor": {
+        "guid": "41077137-e803-4205-871c-5a86e6a753b4",
+        "key": "BlueprintContributor"
+      },
+      "BlueprintOperator": {
+        "guid": "437d2ced-4a38-4302-8479-ed2bcb43d090",
+        "key": "BlueprintOperator"
+      },
+      "CarbonOptimizationReader": {
+        "guid": "fa0d39e6-28e5-40cf-8521-1eb320653a4c",
+        "key": "CarbonOptimizationReader"
+      },
+      "CdnEndpointContributor": {
+        "guid": "426e0c7f-0c7e-4658-b36f-ff54d6c29b45",
+        "key": "CdnEndpointContributor"
+      },
+      "CdnEndpointReader": {
+        "guid": "871e35f6-b5c1-49cc-a043-bde969a0f2cd",
+        "key": "CdnEndpointReader"
+      },
+      "CdnProfileContributor": {
+        "guid": "ec156ff8-a8d1-4d15-830c-5b80698ca432",
+        "key": "CdnProfileContributor"
+      },
+      "CdnProfileReader": {
+        "guid": "8f96442b-4075-438f-813d-ad51ab4019af",
+        "key": "CdnProfileReader"
+      },
+      "ClassicNetworkContributor": {
+        "guid": "b34d265f-36f7-4a0d-a4d4-e158ca92e90f",
+        "key": "ClassicNetworkContributor"
+      },
+      "ClassicStorageAccountContributor": {
+        "guid": "86e8f5dc-a6e9-4c67-9d15-de283e8eac25",
+        "key": "ClassicStorageAccountContributor"
+      },
+      "ClassicStorageAccountKeyOperatorServiceRole": {
+        "guid": "985d6b00-f706-48f5-a6fe-d0ca12fb668d",
+        "key": "ClassicStorageAccountKeyOperatorServiceRole"
+      },
+      "ClassicVirtualMachineContributor": {
+        "guid": "d73bb868-a0df-4d4d-bd69-98a00b01fccb",
+        "key": "ClassicVirtualMachineContributor"
+      },
+      "CognitiveServicesContributor": {
+        "guid": "25fbc0a9-bd7c-42a3-aa1a-3b75d497ee68",
+        "key": "CognitiveServicesContributor"
+      },
+      "CognitiveServicesCustomVisionContributor": {
+        "guid": "c1ff6cc2-c111-46fe-8896-e0ef812ad9f3",
+        "key": "CognitiveServicesCustomVisionContributor"
+      },
+      "CognitiveServicesCustomVisionDeployment": {
+        "guid": "5c4089e1-6d96-4d2f-b296-c1bc7137275f",
+        "key": "CognitiveServicesCustomVisionDeployment"
+      },
+      "CognitiveServicesCustomVisionLabeler": {
+        "guid": "88424f51-ebe7-446f-bc41-7fa16989e96c",
+        "key": "CognitiveServicesCustomVisionLabeler"
+      },
+      "CognitiveServicesCustomVisionReader": {
+        "guid": "93586559-c37d-4a6b-ba08-b9f0940c2d73",
+        "key": "CognitiveServicesCustomVisionReader"
+      },
+      "CognitiveServicesCustomVisionTrainer": {
+        "guid": "0a5ae4ab-0d65-4eeb-be61-29fc9b54394b",
+        "key": "CognitiveServicesCustomVisionTrainer"
+      },
+      "CognitiveServicesDataReader": {
+        "guid": "b59867f0-fa02-499b-be73-45a86b5b3e1c",
+        "key": "CognitiveServicesDataReader"
+      },
+      "CognitiveServicesFaceRecognizer": {
+        "guid": "9894cab4-e18a-44aa-828b-cb588cd6f2d7",
+        "key": "CognitiveServicesFaceRecognizer"
+      },
+      "CognitiveServicesMetricsAdvisorAdministrator": {
+        "guid": "cb43c632-a144-4ec5-977c-e80c4affc34a",
+        "key": "CognitiveServicesMetricsAdvisorAdministrator"
+      },
+      "CognitiveServicesOpenAIContributor": {
+        "guid": "a001fd3d-188f-4b5d-821b-7da978bf7442",
+        "key": "CognitiveServicesOpenAIContributor"
+      },
+      "CognitiveServicesOpenAIUser": {
+        "guid": "5e0bd9bd-7b93-4f28-af87-19fc36ad61bd",
+        "key": "CognitiveServicesOpenAIUser"
+      },
+      "CognitiveServicesQnAMakerEditor": {
+        "guid": "f4cc2bf9-21be-47a1-bdf1-5c5804381025",
+        "key": "CognitiveServicesQnAMakerEditor"
+      },
+      "CognitiveServicesQnAMakerReader": {
+        "guid": "466ccd10-b268-4a11-b098-b4849f024126",
+        "key": "CognitiveServicesQnAMakerReader"
+      },
+      "CognitiveServicesUsagesReader": {
+        "guid": "bba48692-92b0-4667-a9ad-c31c7b334ac2",
+        "key": "CognitiveServicesUsagesReader"
+      },
+      "CognitiveServicesUser": {
+        "guid": "a97b65f3-24c7-4388-baec-2e87135dc908",
+        "key": "CognitiveServicesUser"
+      },
+      "ContainerAppReader": {
+        "guid": "ad2dd5fb-cd4b-4fd4-a9b6-4fed3630980b",
+        "key": "ContainerAppReader"
+      },
+      "ContainerAppsConnectedEnvironmentsContributor": {
+        "guid": "6f4fe6fc-f04f-4d97-8528-8bc18c848dca",
+        "key": "ContainerAppsConnectedEnvironmentsContributor"
+      },
+      "ContainerAppsConnectedEnvironmentsReader": {
+        "guid": "d5adeb5b-107f-4aca-99ea-4e3f4fc008d5",
+        "key": "ContainerAppsConnectedEnvironmentsReader"
+      },
+      "ContainerAppsContributor": {
+        "guid": "358470bc-b998-42bd-ab17-a7e34c199c0f",
+        "key": "ContainerAppsContributor"
+      },
+      "ContainerAppsJobsContributor": {
+        "guid": "4e3d2b60-56ae-4dc6-a233-09c8e5a82e68",
+        "key": "ContainerAppsJobsContributor"
+      },
+      "ContainerAppsJobsOperator": {
+        "guid": "b9a307c4-5aa3-4b52-ba60-2b17c136cd7b",
+        "key": "ContainerAppsJobsOperator"
+      },
+      "ContainerAppsJobsReader": {
+        "guid": "edd66693-d32a-450b-997d-0158c03976b0",
+        "key": "ContainerAppsJobsReader"
+      },
+      "ContainerAppsManagedEnvironmentsContributor": {
+        "guid": "57cc5028-e6a7-4284-868d-0611c5923f8d",
+        "key": "ContainerAppsManagedEnvironmentsContributor"
+      },
+      "ContainerAppsManagedEnvironmentsReader": {
+        "guid": "1b32c00b-7eff-4c22-93e6-93d11d72d2d8",
+        "key": "ContainerAppsManagedEnvironmentsReader"
+      },
+      "ContainerAppsOperator": {
+        "guid": "f3bd1b5c-91fa-40e7-afe7-0c11d331232c",
+        "key": "ContainerAppsOperator"
+      },
+      "ContainerAppsSessionExecutor": {
+        "guid": "0fb8eba5-a2bb-4abe-b1c1-49dfad359bb0",
+        "key": "ContainerAppsSessionExecutor"
+      },
+      "ContainerAppsSessionPoolsContributor": {
+        "guid": "f7669afb-68b2-44b4-9c5f-6d2a47fddda0",
+        "key": "ContainerAppsSessionPoolsContributor"
+      },
+      "ContainerRegistryRepositoryWriter": {
+        "guid": "2a1e307c-b015-4ebd-883e-5b7698a07328",
+        "key": "ContainerRegistryRepositoryWriter"
+      },
+      "ContainerRegistryTasksContributor": {
+        "guid": "fb382eab-e894-4461-af04-94435c366c3f",
+        "key": "ContainerRegistryTasksContributor"
+      },
+      "ContainerRegistryContributorDataAccessConfigurationAdministrator": {
+        "guid": "3bc748fc-213d-45c1-8d91-9da5725539b9",
+        "key": "ContainerRegistryContributorDataAccessConfigurationAdministrator"
+      },
+      "Contributor": {
+        "guid": "b24988ac-6180-42a0-ab88-20f7382dd24c",
+        "key": "Contributor"
+      },
+      "CosmosBackupOperator": {
+        "guid": "db7b14f2-5adf-42da-9f96-f2ee17bab5cb",
+        "key": "CosmosBackupOperator"
+      },
+      "CosmosDBAccountReaderRole": {
+        "guid": "fbdf93bf-df7d-467e-a4d2-9458aa1360c8",
+        "key": "CosmosDBAccountReaderRole"
+      },
+      "CosmosDBBuiltInDataContributor": {
+        "guid": "00000000-0000-0000-0000-000000000002",
+        "key": "CosmosDBBuiltInDataContributor"
+      },
+      "CosmosDBBuiltInDataReader": {
+        "guid": "00000000-0000-0000-0000-000000000001",
+        "key": "CosmosDBBuiltInDataReader"
+      },
+      "CosmosDBOperator": {
+        "guid": "230815da-be43-4aae-9cb4-875f7bd000aa",
+        "key": "CosmosDBOperator"
+      },
+      "CosmosRestoreOperator": {
+        "guid": "5432c526-bc82-444a-b7ba-57c5b0b5b34f",
+        "key": "CosmosRestoreOperator"
+      },
+      "CostManagementContributor": {
+        "guid": "434105ed-43f6-45c7-a02f-909b2ba83430",
+        "key": "CostManagementContributor"
+      },
+      "CostManagementReader": {
+        "guid": "72fafb9e-0641-4937-9268-a91bfd8191a3",
+        "key": "CostManagementReader"
+      },
+      "DataBoxContributor": {
+        "guid": "add466c9-e687-43fc-8d98-dfcf8d720be5",
+        "key": "DataBoxContributor"
+      },
+      "DataBoxReader": {
+        "guid": "028f4ed7-e2a9-465e-a8f4-9c0ffdfdc027",
+        "key": "DataBoxReader"
+      },
+      "DataFactoryContributor": {
+        "guid": "673868aa-7521-48a0-acc6-0f60742d39f5",
+        "key": "DataFactoryContributor"
+      },
+      "DataLakeAnalyticsDeveloper": {
+        "guid": "47b7735b-770e-4598-a7da-8b91488b4c88",
+        "key": "DataLakeAnalyticsDeveloper"
+      },
+      "DataOperatorForManagedDisks": {
+        "guid": "959f8984-c045-4866-89c7-12bf9737be2e",
+        "key": "DataOperatorForManagedDisks"
+      },
+      "DataPurger": {
+        "guid": "150f5e0c-0603-4f03-8c7f-cf70034c4e90",
+        "key": "DataPurger"
+      },
+      "DefenderForStorageDataScanner": {
+        "guid": "1e7ca9b1-60d1-4db8-a914-f2ca1ff27c40",
+        "key": "DefenderForStorageDataScanner"
+      },
+      "DesktopVirtualizationApplicationGroupContributor": {
+        "guid": "86240b0e-9422-4c43-887b-b61143f32ba8",
+        "key": "DesktopVirtualizationApplicationGroupContributor"
+      },
+      "DesktopVirtualizationApplicationGroupReader": {
+        "guid": "aebf23d0-b568-4e86-b8f9-fe83a2c6ab55",
+        "key": "DesktopVirtualizationApplicationGroupReader"
+      },
+      "DesktopVirtualizationContributor": {
+        "guid": "082f0a83-3be5-4ba1-904c-961cca79b387",
+        "key": "DesktopVirtualizationContributor"
+      },
+      "DesktopVirtualizationHostPoolContributor": {
+        "guid": "e307426c-f9b6-4e81-87de-d99efb3c32bc",
+        "key": "DesktopVirtualizationHostPoolContributor"
+      },
+      "DesktopVirtualizationHostPoolReader": {
+        "guid": "ceadfde2-b300-400a-ab7b-6143895aa822",
+        "key": "DesktopVirtualizationHostPoolReader"
+      },
+      "DesktopVirtualizationReader": {
+        "guid": "49a72310-ab8d-41df-bbb0-79b649203868",
+        "key": "DesktopVirtualizationReader"
+      },
+      "DesktopVirtualizationSessionHostOperator": {
+        "guid": "2ad6aaab-ead9-4eaa-8ac5-da422f562408",
+        "key": "DesktopVirtualizationSessionHostOperator"
+      },
+      "DesktopVirtualizationUser": {
+        "guid": "1d18fff3-a72a-46b5-b4a9-0b38a3cd7e63",
+        "key": "DesktopVirtualizationUser"
+      },
+      "DesktopVirtualizationUserSessionOperator": {
+        "guid": "ea4bfff8-7fb4-485a-aadd-d4129a0ffaa6",
+        "key": "DesktopVirtualizationUserSessionOperator"
+      },
+      "DesktopVirtualizationWorkspaceContributor": {
+        "guid": "21efdde3-836f-432b-bf3d-3e8e734d4b2b",
+        "key": "DesktopVirtualizationWorkspaceContributor"
+      },
+      "DesktopVirtualizationWorkspaceReader": {
+        "guid": "0fa44ee9-7a7d-466b-9bb2-2bf446b1204d",
+        "key": "DesktopVirtualizationWorkspaceReader"
+      },
+      "DevTestLabsUser": {
+        "guid": "76283e04-6283-4c54-8f91-bcf1374a3c64",
+        "key": "DevTestLabsUser"
+      },
+      "DeviceUpdateAdministrator": {
+        "guid": "02ca0879-e8e4-47a5-a61e-5c618b76e64a",
+        "key": "DeviceUpdateAdministrator"
+      },
+      "DeviceUpdateContentAdministrator": {
+        "guid": "0378884a-3af5-44ab-8323-f5b22f9f3c98",
+        "key": "DeviceUpdateContentAdministrator"
+      },
+      "DeviceUpdateContentReader": {
+        "guid": "d1ee9a80-8b14-47f0-bdc2-f4a351625a7b",
+        "key": "DeviceUpdateContentReader"
+      },
+      "DeviceUpdateDeploymentsAdministrator": {
+        "guid": "e4237640-0e3d-4a46-8fda-70bc94856432",
+        "key": "DeviceUpdateDeploymentsAdministrator"
+      },
+      "DeviceUpdateDeploymentsReader": {
+        "guid": "49e2f5d2-7741-4835-8efa-19e1fe35e47f",
+        "key": "DeviceUpdateDeploymentsReader"
+      },
+      "DeviceUpdateReader": {
+        "guid": "e9dba6fb-3d52-4cf0-bce3-f06ce71b9e0f",
+        "key": "DeviceUpdateReader"
+      },
+      "DiskBackupReader": {
+        "guid": "3e5e47e6-65f7-47ef-90b5-e5dd4d455f24",
+        "key": "DiskBackupReader"
+      },
+      "DiskPoolOperator": {
+        "guid": "60fc6e62-5479-42d4-8bf4-67625fcc2840",
+        "key": "DiskPoolOperator"
+      },
+      "DiskRestoreOperator": {
+        "guid": "b50d9833-a0cb-478e-945f-707fcc997c13",
+        "key": "DiskRestoreOperator"
+      },
+      "DiskSnapshotContributor": {
+        "guid": "7efff54f-a5b4-42b5-a1c5-5411624893ce",
+        "key": "DiskSnapshotContributor"
+      },
+      "DnsZoneContributor": {
+        "guid": "befefa01-2a29-4197-83a8-272ff33ce314",
+        "key": "DnsZoneContributor"
+      },
+      "DocumentDBAccountContributor": {
+        "guid": "5bd9cd88-fe45-4216-938b-f97437e15450",
+        "key": "DocumentDBAccountContributor"
+      },
+      "DomainServicesContributor": {
+        "guid": "eeaeda52-9324-47f6-8069-5d5bade478b2",
+        "key": "DomainServicesContributor"
+      },
+      "DomainServicesReader": {
+        "guid": "361898ef-9ed1-48c2-849c-a832951106bb",
+        "key": "DomainServicesReader"
+      },
+      "ElasticSANOwner": {
+        "guid": "80dcbedb-47ef-405d-95bd-188a1b4ac406",
+        "key": "ElasticSANOwner"
+      },
+      "ElasticSANReader": {
+        "guid": "af6a70f8-3c9f-4105-acf1-d719e9fca4ca",
+        "key": "ElasticSANReader"
+      },
+      "ElasticSANVolumeGroupOwner": {
+        "guid": "a8281131-f312-4f34-8d98-ae12be9f0d23",
+        "key": "ElasticSANVolumeGroupOwner"
+      },
+      "EventGridContributor": {
+        "guid": "1e241071-0855-49ea-94dc-649edcd759de",
+        "key": "EventGridContributor"
+      },
+      "EventGridDataSender": {
+        "guid": "d5a91429-5739-47e2-a06b-3470a27159e7",
+        "key": "EventGridDataSender"
+      },
+      "EventGridEventSubscriptionContributor": {
+        "guid": "428e0ff0-5e57-4d9c-a221-2c70d0e0a443",
+        "key": "EventGridEventSubscriptionContributor"
+      },
+      "EventGridEventSubscriptionReader": {
+        "guid": "2414bbcf-6497-4faf-8c65-045460748405",
+        "key": "EventGridEventSubscriptionReader"
+      },
+      "FhirDataContributor": {
+        "guid": "5a1fc7df-4bf1-4951-a576-89034ee01acd",
+        "key": "FhirDataContributor"
+      },
+      "FhirDataExporter": {
+        "guid": "3db33094-8700-4567-8da5-1501d4e7e843",
+        "key": "FhirDataExporter"
+      },
+      "FhirDataImporter": {
+        "guid": "4465e953-8ced-4406-a58e-0f6e3f3b530b",
+        "key": "FhirDataImporter"
+      },
+      "FhirDataReader": {
+        "guid": "4c8d0bbc-75d3-4935-991f-5f3c56d81508",
+        "key": "FhirDataReader"
+      },
+      "FhirDataWriter": {
+        "guid": "3f88fce4-5892-4214-ae73-ba5294559913",
+        "key": "FhirDataWriter"
+      },
+      "GrafanaAdmin": {
+        "guid": "22926164-76b3-42b3-bc55-97df8dab3e41",
+        "key": "GrafanaAdmin"
+      },
+      "GrafanaEditor": {
+        "guid": "a79a5197-3a5c-4973-a920-486035ffd60f",
+        "key": "GrafanaEditor"
+      },
+      "GrafanaViewer": {
+        "guid": "60921a7e-fef1-4a43-9b16-a26c52ad4769",
+        "key": "GrafanaViewer"
+      },
+      "HdInsightClusterOperator": {
+        "guid": "61ed4efc-fab3-44fd-b111-e24485cc132a",
+        "key": "HdInsightClusterOperator"
+      },
+      "HdInsightDomainServicesContributor": {
+        "guid": "8d8d5a11-05d3-4bda-a417-a08778121c7c",
+        "key": "HdInsightDomainServicesContributor"
+      },
+      "HierarchySettingsAdministrator": {
+        "guid": "350f8d15-c687-4448-8ae1-157740a3936d",
+        "key": "HierarchySettingsAdministrator"
+      },
+      "IntegrationServiceEnvironmentContributor": {
+        "guid": "a41e2c5b-bd99-4a07-88f4-9bf657a760b8",
+        "key": "IntegrationServiceEnvironmentContributor"
+      },
+      "IntegrationServiceEnvironmentDeveloper": {
+        "guid": "c7aa55d3-1abb-444a-a5ca-5e51e485d6ec",
+        "key": "IntegrationServiceEnvironmentDeveloper"
+      },
+      "IntelligentSystemsAccountContributor": {
+        "guid": "03a6d094-3444-4b3d-88af-7477090a9e5e",
+        "key": "IntelligentSystemsAccountContributor"
+      },
+      "IotHubDataContributor": {
+        "guid": "4fc6c259-987e-4a07-842e-c321cc9d413f",
+        "key": "IotHubDataContributor"
+      },
+      "IotHubDataReader": {
+        "guid": "b447c946-2db7-41ec-983d-d8bf3b1c77e3",
+        "key": "IotHubDataReader"
+      },
+      "IotHubRegistryContributor": {
+        "guid": "4ea46cd5-c1b2-4a8e-910b-273211f9ce47",
+        "key": "IotHubRegistryContributor"
+      },
+      "IotHubTwinContributor": {
+        "guid": "494bdba2-168f-4f31-a0a1-191d2f7c028c",
+        "key": "IotHubTwinContributor"
+      },
+      "KeyVaultAdministrator": {
+        "guid": "00482a5a-887f-4fb3-b363-3b7fe8e74483",
+        "key": "KeyVaultAdministrator"
+      },
+      "KeyVaultCertificateUser": {
+        "guid": "db79e9a7-68ee-4b58-9aeb-b90e7c24fcba",
+        "key": "KeyVaultCertificateUser"
+      },
+      "KeyVaultCertificatesOfficer": {
+        "guid": "a4417e6f-fecd-4de8-b567-7b0420556985",
+        "key": "KeyVaultCertificatesOfficer"
+      },
+      "KeyVaultContributor": {
+        "guid": "f25e0fa2-a7c8-4377-a976-54943a77a395",
+        "key": "KeyVaultContributor"
+      },
+      "KeyVaultCryptoOfficer": {
+        "guid": "14b46e9e-c2b7-41b4-b07b-48a6ebf60603",
+        "key": "KeyVaultCryptoOfficer"
+      },
+      "KeyVaultCryptoServiceEncryptionUser": {
+        "guid": "e147488a-f6f5-4113-8e2d-b22465e65bf6",
+        "key": "KeyVaultCryptoServiceEncryptionUser"
+      },
+      "KeyVaultCryptoServiceReleaseUser": {
+        "guid": "08bbd89e-9f13-488c-ac41-acfcb10c90ab",
+        "key": "KeyVaultCryptoServiceReleaseUser"
+      },
+      "KeyVaultCryptoUser": {
+        "guid": "12338af0-0e69-4776-bea7-57ae8d297424",
+        "key": "KeyVaultCryptoUser"
+      },
+      "KeyVaultDataAccessAdministrator": {
+        "guid": "8b54135c-b56d-4d72-a534-26097cfdc8d8",
+        "key": "KeyVaultDataAccessAdministrator"
+      },
+      "KeyVaultReader": {
+        "guid": "21090545-7ca7-4776-b22c-e363652d74d2",
+        "key": "KeyVaultReader"
+      },
+      "KeyVaultSecretsOfficer": {
+        "guid": "b86a8fe4-44ce-4948-aee5-eccb2c155cd7",
+        "key": "KeyVaultSecretsOfficer"
+      },
+      "KeyVaultSecretsUser": {
+        "guid": "4633458b-17de-408a-b874-0445c86b69e6",
+        "key": "KeyVaultSecretsUser"
+      },
+      "KubernetesAgentlessOperator": {
+        "guid": "d5a2ae44-610b-4500-93be-660a0c5f5ca6",
+        "key": "KubernetesAgentlessOperator"
+      },
+      "KubernetesClusterAzureArcOnboarding": {
+        "guid": "34e09817-6cbe-4d01-b1a2-e0eac5743d41",
+        "key": "KubernetesClusterAzureArcOnboarding"
+      },
+      "KubernetesExtensionContributor": {
+        "guid": "85cb6faf-e071-4c9b-8136-154b5a04f717",
+        "key": "KubernetesExtensionContributor"
+      },
+      "LabAssistant": {
+        "guid": "ce40b423-cede-4313-a93f-9b28290b72e1",
+        "key": "LabAssistant"
+      },
+      "LabContributor": {
+        "guid": "5daaa2af-1fe8-407c-9122-bba179798270",
+        "key": "LabContributor"
+      },
+      "LabCreator": {
+        "guid": "b97fb8bc-a8b2-4522-a38b-dd33c7e65ead",
+        "key": "LabCreator"
+      },
+      "LabOperator": {
+        "guid": "a36e6959-b6be-4b12-8e9f-ef4b474d304d",
+        "key": "LabOperator"
+      },
+      "LabServicesContributor": {
+        "guid": "f69b8690-cc87-41d6-b77a-a4bc3c0a966f",
+        "key": "LabServicesContributor"
+      },
+      "LabServicesReader": {
+        "guid": "2a5c394f-5eb7-4d4f-9c8e-e8eae39faebc",
+        "key": "LabServicesReader"
+      },
+      "LoadTestContributor": {
+        "guid": "749a398d-560b-491b-bb21-08924219302e",
+        "key": "LoadTestContributor"
+      },
+      "LoadTestOwner": {
+        "guid": "45bb0b16-2f0c-4e78-afaa-a07599b003f6",
+        "key": "LoadTestOwner"
+      },
+      "LoadTestReader": {
+        "guid": "3ae3fb29-0000-4ccd-bf80-542e7b26e081",
+        "key": "LoadTestReader"
+      },
+      "LogAnalyticsContributor": {
+        "guid": "92aaf0da-9dab-42b6-94a3-d43ce8d16293",
+        "key": "LogAnalyticsContributor"
+      },
+      "LogAnalyticsReader": {
+        "guid": "73c42c96-874c-492b-b04d-ab87d138a893",
+        "key": "LogAnalyticsReader"
+      },
+      "LogicAppContributor": {
+        "guid": "87a39d53-fc1b-424a-814c-f7e04687dc9e",
+        "key": "LogicAppContributor"
+      },
+      "LogicAppOperator": {
+        "guid": "515c2055-d9d4-4321-b1b9-bd0c9a0f79fe",
+        "key": "LogicAppOperator"
+      },
+      "LogicAppsStandardContributor": {
+        "guid": "ad710c24-b039-4e85-a019-deb4a06e8570",
+        "key": "LogicAppsStandardContributor"
+      },
+      "LogicAppsStandardDeveloper": {
+        "guid": "523776ba-4eb2-4600-a3c8-f2dc93da4bdb",
+        "key": "LogicAppsStandardDeveloper"
+      },
+      "LogicAppsStandardOperator": {
+        "guid": "b70c96e9-66fe-4c09-b6e7-c98e69c98555",
+        "key": "LogicAppsStandardOperator"
+      },
+      "LogicAppsStandardReader": {
+        "guid": "4accf36b-2c05-432f-91c8-5c532dff4c73",
+        "key": "LogicAppsStandardReader"
+      },
+      "ManagedApplicationContributorRole": {
+        "guid": "641177b8-a67a-45b9-a033-47bc880bb21e",
+        "key": "ManagedApplicationContributorRole"
+      },
+      "ManagedApplicationOperatorRole": {
+        "guid": "c7393b34-138c-406f-901b-d8cf2b17e6ae",
+        "key": "ManagedApplicationOperatorRole"
+      },
+      "ManagedApplicationsReader": {
+        "guid": "b9331d33-8a36-4f8c-b097-4f54124fdb44",
+        "key": "ManagedApplicationsReader"
+      },
+      "ManagedHSMContributor": {
+        "guid": "18500a29-7fe2-46b2-a342-b16a415e101d",
+        "key": "ManagedHSMContributor"
+      },
+      "ManagedIdentityContributor": {
+        "guid": "e40ec5ca-96e0-45a2-b4ff-59039f2c2b59",
+        "key": "ManagedIdentityContributor"
+      },
+      "ManagedIdentityOperator": {
+        "guid": "f1a07417-d97a-45cb-824c-7a7467783830",
+        "key": "ManagedIdentityOperator"
+      },
+      "ManagedServicesRegistrationAssignmentDeleteRole": {
+        "guid": "91c1777a-f3dc-4fae-b103-61d183457e46",
+        "key": "ManagedServicesRegistrationAssignmentDeleteRole"
+      },
+      "ManagementGroupContributor": {
+        "guid": "5d58bcaf-24a5-4b20-bdb6-eed9f69fbe4c",
+        "key": "ManagementGroupContributor"
+      },
+      "ManagementGroupReader": {
+        "guid": "ac63b705-f282-497d-ac71-919bf39d939d",
+        "key": "ManagementGroupReader"
+      },
+      "MediaServicesAccountAdministrator": {
+        "guid": "054126f8-9a2b-4f1c-a9ad-eca461f08466",
+        "key": "MediaServicesAccountAdministrator"
+      },
+      "MediaServicesLiveEventsAdministrator": {
+        "guid": "532bc159-b25e-42c0-969e-a1d439f60d77",
+        "key": "MediaServicesLiveEventsAdministrator"
+      },
+      "MediaServicesMediaOperator": {
+        "guid": "e4395492-1534-4db2-bedf-88c14621589c",
+        "key": "MediaServicesMediaOperator"
+      },
+      "MediaServicesPolicyAdministrator": {
+        "guid": "c4bba371-dacd-4a26-b320-7250bca963ae",
+        "key": "MediaServicesPolicyAdministrator"
+      },
+      "MediaServicesStreamingEndpointsAdministrator": {
+        "guid": "99dba123-b5fe-44d5-874c-ced7199a5804",
+        "key": "MediaServicesStreamingEndpointsAdministrator"
+      },
+      "MicrosoftSentinelAutomationContributor": {
+        "guid": "f4c81013-99ee-4d62-a7ee-b3f1f648599a",
+        "key": "MicrosoftSentinelAutomationContributor"
+      },
+      "MicrosoftSentinelContributor": {
+        "guid": "ab8e14d6-4a74-4a29-9ba8-549422addade",
+        "key": "MicrosoftSentinelContributor"
+      },
+      "MicrosoftSentinelPlaybookOperator": {
+        "guid": "51d6186e-6489-4900-b93f-92e23144cca5",
+        "key": "MicrosoftSentinelPlaybookOperator"
+      },
+      "MicrosoftSentinelReader": {
+        "guid": "8d289c81-5878-46d4-8554-54e1e3d8b5cb",
+        "key": "MicrosoftSentinelReader"
+      },
+      "MicrosoftSentinelResponder": {
+        "guid": "3e150937-b8fe-4cfb-8069-0eaf05ecd056",
+        "key": "MicrosoftSentinelResponder"
+      },
+      "MonitoringContributor": {
+        "guid": "749f88d5-cbae-40b8-bcfc-e573ddc772fa",
+        "key": "MonitoringContributor"
+      },
+      "MonitoringMetricsPublisher": {
+        "guid": "3913510d-42f4-4e42-8a64-420c390055eb",
+        "key": "MonitoringMetricsPublisher"
+      },
+      "MonitoringReader": {
+        "guid": "43d0d8ad-25c7-4714-9337-8ba259a9fe05",
+        "key": "MonitoringReader"
+      },
+      "NetworkContributor": {
+        "guid": "4d97b98b-1d4f-4787-a291-c67834d212e7",
+        "key": "NetworkContributor"
+      },
+      "NewRelicAPMAccountContributor": {
+        "guid": "5d28c62d-5b37-4476-8438-e587778df237",
+        "key": "NewRelicAPMAccountContributor"
+      },
+      "Owner": {
+        "guid": "8e3af657-a8ff-443c-a75c-2fe8c4bcb635",
+        "key": "Owner"
+      },
+      "PolicyInsightsDataWriter": {
+        "guid": "66bb4e9e-b016-4a94-8249-4c0511c2be84",
+        "key": "PolicyInsightsDataWriter"
+      },
+      "PrivateDNSZoneContributor": {
+        "guid": "b12aa53e-6015-4669-85d0-8515ebb3ae7f",
+        "key": "PrivateDNSZoneContributor"
+      },
+      "QuotaRequestOperator": {
+        "guid": "0e5f05e5-9ab9-446b-b98d-1e2157c94125",
+        "key": "QuotaRequestOperator"
+      },
+      "Reader": {
+        "guid": "acdd72a7-3385-48ef-bd42-f606fba81ae7",
+        "key": "Reader"
+      },
+      "ReaderAndDataAccess": {
+        "guid": "c12c1c16-33a1-487b-954d-41c89c60f349",
+        "key": "ReaderAndDataAccess"
+      },
+      "RedisCacheContributor": {
+        "guid": "e0f68234-74aa-48ed-b826-c38b57376e17",
+        "key": "RedisCacheContributor"
+      },
+      "RemoteRenderingAdministrator": {
+        "guid": "3df8b902-2a6f-47c7-8cc5-360e9b272a7e",
+        "key": "RemoteRenderingAdministrator"
+      },
+      "RemoteRenderingClient": {
+        "guid": "d39065c4-c120-43c9-ab0a-63eed9795f0a",
+        "key": "RemoteRenderingClient"
+      },
+      "ReservationPurchaser": {
+        "guid": "f7b75c60-3036-4b75-91c3-6b41c27c1689",
+        "key": "ReservationPurchaser"
+      },
+      "ReservationsAdministrator": {
+        "guid": "a8889054-8d42-49c9-bc1c-52486c10e7cd",
+        "key": "ReservationsAdministrator"
+      },
+      "ReservationsReader": {
+        "guid": "582fc458-8989-419f-a480-75249bc5db7e",
+        "key": "ReservationsReader"
+      },
+      "ResourcePolicyContributor": {
+        "guid": "36243c78-bf99-498c-9df9-86d9f8d28608",
+        "key": "ResourcePolicyContributor"
+      },
+      "RoleBasedAccessControlAdministrator": {
+        "guid": "f58310d9-a9f6-439a-9e8d-f62e7b41a168",
+        "key": "RoleBasedAccessControlAdministrator"
+      },
+      "ScheduledPatchingContributor": {
+        "guid": "cd08ab90-6b14-449c-ad9a-8f8e549482c6",
+        "key": "ScheduledPatchingContributor"
+      },
+      "SchedulerJobCollectionsContributor": {
+        "guid": "188a0f2f-5c9e-469b-ae67-2aa5ce574b94",
+        "key": "SchedulerJobCollectionsContributor"
+      },
+      "SchemaRegistryContributor": {
+        "guid": "5dffeca3-4936-4216-b2bc-10343a5abb25",
+        "key": "SchemaRegistryContributor"
+      },
+      "SchemaRegistryReader": {
+        "guid": "2c56ea50-c6b3-40a6-83c0-9d98858bc7d2",
+        "key": "SchemaRegistryReader"
+      },
+      "SearchIndexDataContributor": {
+        "guid": "8ebe5a00-799e-43f5-93ac-243d3dce84a7",
+        "key": "SearchIndexDataContributor"
+      },
+      "SearchIndexDataReader": {
+        "guid": "1407120a-92aa-4202-b7e9-c0e197c71c8f",
+        "key": "SearchIndexDataReader"
+      },
+      "SearchServiceContributor": {
+        "guid": "7ca78c08-252a-4471-8644-bb5ff32d4ba0",
+        "key": "SearchServiceContributor"
+      },
+      "SecurityAdmin": {
+        "guid": "fb1c8493-542b-48eb-b624-b4c8fea62acd",
+        "key": "SecurityAdmin"
+      },
+      "SecurityAssessmentContributor": {
+        "guid": "612c2aa1-cb24-443b-ac28-3ab7272de6f5",
+        "key": "SecurityAssessmentContributor"
+      },
+      "SecurityReader": {
+        "guid": "39bc4728-0917-49c7-9d2c-d95423bc2eb4",
+        "key": "SecurityReader"
+      },
+      "ServicesHubOperator": {
+        "guid": "82200a5b-e217-47a5-b665-6d8765ee745b",
+        "key": "ServicesHubOperator"
+      },
+      "SignalRAccessKeyReader": {
+        "guid": "04165923-9d83-45d5-8227-78b77b0a687e",
+        "key": "SignalRAccessKeyReader"
+      },
+      "SignalRAppServer": {
+        "guid": "420fcaa2-552c-430f-98ca-3264be4806c7",
+        "key": "SignalRAppServer"
+      },
+      "SignalRRestAPIOwner": {
+        "guid": "fd53cd77-2268-407a-8f46-7e7863d0f521",
+        "key": "SignalRRestAPIOwner"
+      },
+      "SignalRRestAPIReader": {
+        "guid": "ddde6b66-c0df-4114-a159-3618637b3035",
+        "key": "SignalRRestAPIReader"
+      },
+      "SignalRServiceOwner": {
+        "guid": "7e4f1700-ea5a-4f59-8f37-079cfe29dce3",
+        "key": "SignalRServiceOwner"
+      },
+      "SignalRWebPubSubContributor": {
+        "guid": "8cf5e20a-e4b2-4e9d-b3a1-5ceb692c2761",
+        "key": "SignalRWebPubSubContributor"
+      },
+      "SiteRecoveryContributor": {
+        "guid": "6670b86e-a3f7-4917-ac9b-5d6ab1be4567",
+        "key": "SiteRecoveryContributor"
+      },
+      "SiteRecoveryOperator": {
+        "guid": "494ae006-db33-4328-bf46-533a6560a3ca",
+        "key": "SiteRecoveryOperator"
+      },
+      "SiteRecoveryReader": {
+        "guid": "dbaa88c4-0c30-4179-9fb3-46319faa6149",
+        "key": "SiteRecoveryReader"
+      },
+      "SpatialAnchorsAccountContributor": {
+        "guid": "8bbe83f1-e2a6-4df7-8cb4-4e04d4e5c827",
+        "key": "SpatialAnchorsAccountContributor"
+      },
+      "SpatialAnchorsAccountOwner": {
+        "guid": "70bbe301-9835-447d-afdd-19eb3167307c",
+        "key": "SpatialAnchorsAccountOwner"
+      },
+      "SpatialAnchorsAccountReader": {
+        "guid": "5d51204f-eb77-4b1c-b86a-2ec626c49413",
+        "key": "SpatialAnchorsAccountReader"
+      },
+      "SqlDBContributor": {
+        "guid": "9b7fa17d-e63e-47b0-bb0a-15c516ac86ec",
+        "key": "SqlDBContributor"
+      },
+      "SqlManagedInstanceContributor": {
+        "guid": "4939a1f6-9ae0-4e48-a1e0-f2cbe897382d",
+        "key": "SqlManagedInstanceContributor"
+      },
+      "SqlSecurityManager": {
+        "guid": "056cd41c-7e88-42e1-933e-88ba6a50c9c3",
+        "key": "SqlSecurityManager"
+      },
+      "SqlServerContributor": {
+        "guid": "6d8ee4ec-f05a-4a1d-8b00-a9b17e38b437",
+        "key": "SqlServerContributor"
+      },
+      "StorageAccountBackupContributor": {
+        "guid": "e5e2a7ff-d759-4cd2-bb51-3152d37e2eb1",
+        "key": "StorageAccountBackupContributor"
+      },
+      "StorageAccountContributor": {
+        "guid": "17d1049b-9a84-46fb-8f53-869881c3d3ab",
+        "key": "StorageAccountContributor"
+      },
+      "StorageAccountKeyOperatorServiceRole": {
+        "guid": "81a9662b-bebf-436f-a333-f67b29880f12",
+        "key": "StorageAccountKeyOperatorServiceRole"
+      },
+      "StorageBlobDataContributor": {
+        "guid": "ba92f5b4-2d11-453d-a403-e96b0029c9fe",
+        "key": "StorageBlobDataContributor"
+      },
+      "StorageBlobDataOwner": {
+        "guid": "b7e6dc6d-f1e8-4753-8033-0f276bb0955b",
+        "key": "StorageBlobDataOwner"
+      },
+      "StorageBlobDataReader": {
+        "guid": "2a2b9908-6ea1-4ae2-8e65-a410df84e7d1",
+        "key": "StorageBlobDataReader"
+      },
+      "StorageBlobDelegator": {
+        "guid": "db58b8e5-c6ad-4a2a-8342-4190687cbf4a",
+        "key": "StorageBlobDelegator"
+      },
+      "StorageFileDataPrivilegedContributor": {
+        "guid": "69566ab7-960f-475b-8e7c-b3118f30c6bd",
+        "key": "StorageFileDataPrivilegedContributor"
+      },
+      "StorageFileDataPrivilegedReader": {
+        "guid": "b8eda974-7b85-4f76-af95-65846b26df6d",
+        "key": "StorageFileDataPrivilegedReader"
+      },
+      "StorageFileDataSMBShareContributor": {
+        "guid": "0c867c2a-1d8c-454a-a3db-ab2ea1bdc8bb",
+        "key": "StorageFileDataSMBShareContributor"
+      },
+      "StorageFileDataSMBShareElevatedContributor": {
+        "guid": "a7264617-510b-434b-a828-9731dc254ea7",
+        "key": "StorageFileDataSMBShareElevatedContributor"
+      },
+      "StorageFileDataSMBShareReader": {
+        "guid": "aba4ae5f-2193-4029-9191-0cb91df5e314",
+        "key": "StorageFileDataSMBShareReader"
+      },
+      "StorageQueueDataContributor": {
+        "guid": "974c5e8b-45b9-4653-ba55-5f855dd0fb88",
+        "key": "StorageQueueDataContributor"
+      },
+      "StorageQueueDataMessageProcessor": {
+        "guid": "8a0f0c08-91a1-4084-bc3d-661d67233fed",
+        "key": "StorageQueueDataMessageProcessor"
+      },
+      "StorageQueueDataMessageSender": {
+        "guid": "c6a89b2d-59bc-44d0-9896-0f6e12d7b80a",
+        "key": "StorageQueueDataMessageSender"
+      },
+      "StorageQueueDataReader": {
+        "guid": "19e7f393-937e-4f77-808e-94535e297925",
+        "key": "StorageQueueDataReader"
+      },
+      "StorageTableDataContributor": {
+        "guid": "0a9a7e1f-b9d0-4cc4-a60d-0319b160aaa3",
+        "key": "StorageTableDataContributor"
+      },
+      "StorageTableDataReader": {
+        "guid": "76199698-9eea-4c19-bc75-cec21354c6b6",
+        "key": "StorageTableDataReader"
+      },
+      "StreamAnalyticsQueryTester": {
+        "guid": "1ec5b3c1-b17e-4e25-8312-2acb3c3c5abf",
+        "key": "StreamAnalyticsQueryTester"
+      },
+      "SupportRequestContributor": {
+        "guid": "cfd33db0-3dd1-45e3-aa9d-cdbdf3b6f24e",
+        "key": "SupportRequestContributor"
+      },
+      "TagContributor": {
+        "guid": "4a9ae827-6dc8-4573-8ac7-8239d42aa03f",
+        "key": "TagContributor"
+      },
+      "TemplateSpecContributor": {
+        "guid": "1c9b6475-caf0-4164-b5a1-2142a7116f4b",
+        "key": "TemplateSpecContributor"
+      },
+      "TemplateSpecReader": {
+        "guid": "392ae280-861d-42bd-9ea5-08ee6d83b80e",
+        "key": "TemplateSpecReader"
+      },
+      "TrafficManagerContributor": {
+        "guid": "a4b10055-b0c7-44c2-b00f-c7b5b3550cf7",
+        "key": "TrafficManagerContributor"
+      },
+      "UserAccessAdministrator": {
+        "guid": "18d7d88d-d35e-4fb5-a5c3-7773c20a72d9",
+        "key": "UserAccessAdministrator"
+      },
+      "VirtualMachineAdministratorLogin": {
+        "guid": "1c0163c0-47e6-4577-8991-ea5c82e286e4",
+        "key": "VirtualMachineAdministratorLogin"
+      },
+      "VirtualMachineContributor": {
+        "guid": "9980e02c-c2be-4d73-94e8-173b1dc7cf3c",
+        "key": "VirtualMachineContributor"
+      },
+      "VirtualMachineDataAccessAdministrator": {
+        "guid": "66f75aeb-eabe-4b70-9f1e-c350c4c9ad04",
+        "key": "VirtualMachineDataAccessAdministrator"
+      },
+      "VirtualMachineLocalUserLogin": {
+        "guid": "602da2ba-a5c2-41da-b01d-5360126ab525",
+        "key": "VirtualMachineLocalUserLogin"
+      },
+      "VirtualMachineUserLogin": {
+        "guid": "fb879df8-f326-4884-b1cf-06f3ad86be52",
+        "key": "VirtualMachineUserLogin"
+      },
+      "WebPlanContributor": {
+        "guid": "2cc479cb-7b4d-49a8-b449-8c00fd0f0a4b",
+        "key": "WebPlanContributor"
+      },
+      "WebsiteContributor": {
+        "guid": "de139f84-1756-47ae-9be6-808fbbe84772",
+        "key": "WebsiteContributor"
+      },
+      "WindowsAdminCenterAdministratorLogin": {
+        "guid": "a6333a3e-0164-44c3-b281-7a577aff287f",
+        "key": "WindowsAdminCenterAdministratorLogin"
+      },
+      "WorkbookContributor": {
+        "guid": "e8ddcd69-c73f-4f9f-9844-4100522f16ad",
+        "key": "WorkbookContributor"
+      },
+      "WorkbookReader": {
+        "guid": "b279062a-9be3-42a0-92ae-8b3cf002ec4d",
+        "key": "WorkbookReader"
+      }
+    },
+    "_1.abbrs": "[variables('_1._2')]",
+    "_1.roles": "[variables('_1._3')]"
+  },
+  "resources": {
+    "firewallPublicIp": {
+      "condition": "[and(parameters('deployAzureFirewall'), parameters('networkIsolation'))]",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "apiVersion": "2024-07-01",
+      "name": "[format('{0}{1}{2}', variables('_1.abbrs').networking.publicIPAddress, variables('_1.abbrs').networking.firewall, parameters('resourceToken'))]",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "Standard",
+        "tier": "Regional"
+      },
+      "properties": {
+        "publicIPAllocationMethod": "Static",
+        "publicIPAddressVersion": "IPv4"
+      },
+      "tags": "[parameters('tags')]"
+    },
+    "firewallPolicy": {
+      "condition": "[and(parameters('deployAzureFirewall'), parameters('networkIsolation'))]",
+      "type": "Microsoft.Network/firewallPolicies",
+      "apiVersion": "2024-07-01",
+      "name": "[format('{0}{1}', variables('_1.abbrs').networking.firewallPolicy, parameters('resourceToken'))]",
+      "location": "[parameters('location')]",
+      "tags": "[parameters('tags')]",
+      "properties": {
+        "sku": {
+          "tier": "Standard"
+        },
+        "threatIntelMode": "Alert"
+      }
+    },
+    "firewallPolicyDefaultRuleCollectionGroup": {
+      "condition": "[and(parameters('deployAzureFirewall'), parameters('networkIsolation'))]",
+      "type": "Microsoft.Network/firewallPolicies/ruleCollectionGroups",
+      "apiVersion": "2024-07-01",
+      "name": "[format('{0}/{1}', format('{0}{1}', variables('_1.abbrs').networking.firewallPolicy, parameters('resourceToken')), 'DefaultRuleCollectionGroup')]",
+      "properties": {
+        "priority": 200,
+        "ruleCollections": "[variables('_firewallDefaultRuleCollections')]"
+      },
+      "dependsOn": [
+        "firewallPolicy"
+      ]
+    },
+    "firewallPolicyAcsMediaRuleCollectionGroup": {
+      "condition": "[and(and(parameters('deployAzureFirewall'), parameters('networkIsolation')), parameters('enableAcsMediaEgress'))]",
+      "type": "Microsoft.Network/firewallPolicies/ruleCollectionGroups",
+      "apiVersion": "2024-07-01",
+      "name": "[format('{0}/{1}', format('{0}{1}', variables('_1.abbrs').networking.firewallPolicy, parameters('resourceToken')), 'AcsMediaRuleCollectionGroup')]",
+      "properties": {
+        "priority": 300,
+        "ruleCollections": "[variables('_firewallAcsMediaRuleCollections')]"
+      },
+      "dependsOn": [
+        "firewallPolicy",
+        "firewallPolicyDefaultRuleCollectionGroup"
+      ]
+    },
+    "azureFirewall": {
+      "condition": "[and(parameters('deployAzureFirewall'), parameters('networkIsolation'))]",
+      "type": "Microsoft.Network/azureFirewalls",
+      "apiVersion": "2024-07-01",
+      "name": "[format('{0}{1}', variables('_1.abbrs').networking.firewall, parameters('resourceToken'))]",
+      "location": "[parameters('location')]",
+      "tags": "[parameters('tags')]",
+      "properties": {
+        "sku": {
+          "name": "AZFW_VNet",
+          "tier": "Standard"
+        },
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', format('{0}{1}{2}', variables('_1.abbrs').networking.publicIPAddress, variables('_1.abbrs').networking.firewall, parameters('resourceToken')))]"
+              },
+              "subnet": {
+                "id": "[variables('_firewallSubnetId')]"
+              }
+            }
+          }
+        ],
+        "firewallPolicy": {
+          "id": "[resourceId('Microsoft.Network/firewallPolicies', format('{0}{1}', variables('_1.abbrs').networking.firewallPolicy, parameters('resourceToken')))]"
+        }
+      },
+      "dependsOn": [
+        "firewallPolicy",
+        "firewallPublicIp"
+      ]
+    },
+    "firewallDiagnostics": {
+      "condition": "[and(and(parameters('deployAzureFirewall'), parameters('networkIsolation')), parameters('hasEffectiveLaw'))]",
+      "type": "Microsoft.Insights/diagnosticSettings",
+      "apiVersion": "2021-05-01-preview",
+      "scope": "[resourceId('Microsoft.Network/azureFirewalls', format('{0}{1}', variables('_1.abbrs').networking.firewall, parameters('resourceToken')))]",
+      "name": "fw-diagnostics",
+      "properties": {
+        "workspaceId": "[parameters('lawResourceId')]",
+        "logs": [
+          {
+            "categoryGroup": "allLogs",
+            "enabled": true
+          }
+        ],
+        "metrics": [
+          {
+            "category": "AllMetrics",
+            "enabled": true
+          }
+        ]
+      },
+      "dependsOn": [
+        "azureFirewall"
+      ]
+    }
+  },
+  "outputs": {
+    "privateIp": {
+      "type": "string",
+      "value": "[if(and(parameters('deployAzureFirewall'), parameters('networkIsolation')), reference('azureFirewall').ipConfigurations[0].properties.privateIPAddress, '')]"
+    }
+  }
+}


### PR DESCRIPTION
# Incrementally modularize main.bicep (#87)

Real, validated modularization of `main.bicep`. No deployment behavior changes:
every resource name, condition, property, and `dependsOn` is preserved. This is
an internal maintainability refactor (PATCH-level), so no Portal or Terraform
downstream update is signaled.

## Result
- `main.bicep`: **4329 -> 3698 lines** (-631, -14.6%)
- Compiled ARM: **4.623 MB**, slightly smaller than `develop` (net effect of the
  role-assignment consolidations). Passes the CI size gate (fail 4.7 MB / ceiling
  5.0 MB).

## What changed
- **Firewall extracted** to `modules/networking/azure-firewall.bicep` (policy,
  rule collection groups, public IP, diagnostics, and all FQDN rule data).
  Exposes `privateIp` as an output; the spoke default route and the
  privateEndpoints / containerApps `dependsOn` are rewired to the module with no
  behavior change.
- **Role assignments consolidated**: ~12 per-app control-plane role `for`-loops
  and 4 cross-service grants collapsed into array-driven calls through the
  existing `modules/security/resource-role-assignment.bicep`. RBAC GUIDs are
  deterministic, so the assignments themselves are unchanged.

## Validation (all green)
- `az bicep build --file main.bicep`
- `az bicep build --file tests/hub/main.bicep`
- `python -m json.tool main.parameters.json`
- `git diff --check`
- Size gate at CI thresholds: pass (4.623 MB)

## Honest note on the line target
The original direction was ~1000-2000 lines. The binding constraint turned out
to be the **ARM size gate**, not readability. `develop` already sits near the
limit, and extracting a single non-repeatable resource body into a separate
module *adds* nested-deployment overhead that grows the compiled ARM. The jumpbox
extraction was attempted and reverted for exactly this reason (+0.138 MB pushed
it over the fail threshold). Only size-neutral-or-better moves (array-driven
consolidations) are safe today. Reaching 1000-2000 lines would require raising
the size budget or accepting array-driven mega-modules whose behavior-equivalence
is harder to guarantee. Tracked as a follow-up consideration on #87.

Closes #87
