### PR TITLE
Add generic workload App Configuration passthrough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file.  
 This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- **Workload App Configuration passthrough (`additionalAppConfigurationSettings`).** Solution accelerators can now publish their own runtime key-values into the App Configuration store without adding workload-specific parameters to this template. Each entry takes `name`, `value`, and optional `label` and `contentType`. The landing zone stamps the entries verbatim. Values are plaintext (do not pass secrets), each `name`+`label` must be unique, and a passthrough entry that collides with a built-in setting wins so accelerators can override a stamped default. When the consumer opts out of App Configuration and uses the `containerEnv` runtime mode (Issue #89), the same entries are injected into every Container App as env vars (name/value only, labels ignored), so the passthrough works in both runtime modes. The parameter defaults to an empty array, so existing deployments produce byte-identical App Configuration and container env output. This keeps the landing zone workload-agnostic: GPT-RAG and other accelerators publish their Foundry IQ and other runtime keys through the passthrough instead of the template growing accelerator-specific parameters. See [Workload App Configuration passthrough](README.md#workload-app-configuration-passthrough).
+
+### Deprecated
+
+- **Accelerator-specific `foundryIq*` knowledge-source parameters.** `foundryIqPattern`, `foundryIqKnowledgeSourceName`, `foundryIqSearchIndexName`, `foundryIqBaseFilter`, and `foundryIqFilterAddOnEnabled` (and the wider `foundryIq*` runtime family) still work and are unchanged, but they are superseded by the generic `additionalAppConfigurationSettings` passthrough. New accelerators should publish these keys through the passthrough. `retrievalBackend` is not deprecated: it gates real infrastructure (the AI Foundry knowledge-base connection and shared private links), not just configuration.
+
 ## [v2.2.0] - 2026-06-30
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A handful of other quality-of-life additions:
 - **Hub integration helpers** — `hubIntegration.hubVnetResourceId` creates the spoke→hub peering for you; `hubIntegration.egressNextHopIp` routes spoke egress through your hub firewall / NVA.
 - **Pre-flight validation** — `scripts/Invoke-PreflightChecks.ps1` runs automatically as an `azd preprovision` hook and catches the usual mistakes (CIDR overlap, undersized subnets, missing BYO resource IDs, conflicting flags, and insufficient AI Foundry OpenAI model quota) before they reach ARM. Bypass with `PREFLIGHT_SKIP=true`.
 - **AI Foundry project naming** — `aiFoundryProjectName`, `aiFoundryProjectDisplayName`, and `aiFoundryProjectDescription` let consumers customize the deployed AI Foundry project instead of using a hardcoded default.
+- **Workload App Configuration passthrough** — `additionalAppConfigurationSettings` lets a solution accelerator publish its own runtime key-values into the App Configuration store without adding template-specific parameters. See [Workload App Configuration passthrough](#workload-app-configuration-passthrough).
 - **Foundry IQ groundwork for GPT-RAG:** set `RETRIEVAL_BACKEND=foundry_iq` to stamp the orchestrator settings for a Foundry IQ knowledge base. See [Foundry IQ for GPT-RAG](#foundry-iq-for-gpt-rag) for parameters, security expectations, billing, and the post-provision script.
 
 **Pick a runbook to deploy:**
@@ -242,7 +243,58 @@ Set `extendFirewallForJumpboxBootstrap=false` to skip the jumpbox-scoped rules w
 
 Use `DEPLOY_AAF_AGENT_SVC=false` when an external app only needs hosted model inference from Foundry and does not need Agent Service capability hosts or their associated state resources.
 
+### Workload App Configuration passthrough
+
+The landing zone is workload-agnostic. When a solution accelerator needs its own
+runtime keys stamped into the App Configuration store, it should not require new
+typed parameters in this template. Use `additionalAppConfigurationSettings` to
+publish any number of extra key-values verbatim:
+
+```bicep
+module ailz 'br/public:avm/ptn/aiml/ai-landing-zone:<version>' = {
+  params: {
+    // ...
+    additionalAppConfigurationSettings: [
+      { name: 'MY_WORKLOAD_FLAG', value: 'true' }
+      { name: 'MY_WORKLOAD_MODE', value: 'hybrid', label: 'prod' }
+    ]
+  }
+}
+```
+
+Each entry accepts `name` (required), `value` (required), `label` (optional,
+defaults to `appConfigLabel`), and `contentType` (optional, defaults to
+`text/plain`). Rules and limits:
+
+- Values are stored in plaintext. Do not pass secrets, connection strings, or
+  keys through this parameter. Use Key Vault references for sensitive data.
+- Each `name` + `label` pair must be unique. If an entry collides with a
+  built-in setting the passthrough value wins (the built-in entry is dropped),
+  so an accelerator can also override a stamped default when it needs to.
+- App Configuration is only populated on non-network-isolated deployments where
+  the runtime config store is App Configuration. In isolated deployments the
+  post-provision step running on the jumpbox is responsible for stamping config,
+  so pass workload keys through that path instead.
+- When the consumer selects the `containerEnv` runtime mode (Issue #89) instead
+  of App Configuration, the same entries are injected into every Container App as
+  environment variables. Only `name` and `value` are used in that mode (`label`
+  and `contentType` are ignored, since env vars have neither), and the same
+  "passthrough wins on collision" precedence applies.
+
+This is the forward-looking way to configure workload settings such as the
+GPT-RAG Foundry IQ keys below: accelerators publish their own keys through the
+passthrough instead of the landing zone growing workload-specific parameters.
+
 ### Foundry IQ for GPT-RAG
+
+> The individual `foundryIq*` knowledge-source parameters below are retained for
+> backward compatibility but are being superseded by the generic
+> [workload App Configuration passthrough](#workload-app-configuration-passthrough).
+> New accelerators should publish these keys through
+> `additionalAppConfigurationSettings` rather than relying on template-specific
+> parameters. `retrievalBackend` stays a first-class parameter because it gates
+> real infrastructure (the AI Foundry knowledge-base connection and shared
+> private links), not just configuration.
 
 The landing zone stamps GPT-RAG runtime settings for a Foundry IQ knowledge
 base. New deployments default to Foundry IQ. Existing GPT-RAG deployments can

--- a/docs/v2-migration.md
+++ b/docs/v2-migration.md
@@ -222,6 +222,42 @@ The preset is **advisory** in v2.0.0 — it does not auto-flip any other flag. O
 
 ---
 
+### 3.8. Workload App Configuration passthrough (additive, opt-in)
+
+The `additionalAppConfigurationSettings` parameter lets a solution accelerator
+publish its own runtime key-values into the App Configuration store without new
+template parameters. It defaults to an empty array, so existing deployments are
+unaffected and produce byte-identical App Configuration output.
+
+If your accelerator currently drives runtime config through the workload-specific
+`foundryIq*` parameters, nothing breaks: those parameters still work. Going
+forward, prefer publishing accelerator keys through the passthrough so the
+landing zone stays workload-agnostic:
+
+```bicep
+additionalAppConfigurationSettings: [
+  { name: 'MY_WORKLOAD_FLAG', value: 'true' }
+  { name: 'MY_WORKLOAD_MODE', value: 'hybrid', label: 'prod' }
+]
+```
+
+Notes:
+
+- Values are plaintext. Do not pass secrets; use Key Vault references instead.
+- Each `name` + `label` pair must be unique. A passthrough entry that collides
+  with a built-in setting wins, so it can also override a stamped default.
+- App Configuration is only populated on non-isolated deployments where the
+  runtime config store is App Configuration. In isolated deployments, stamp
+  workload keys through the jumpbox post-provision step instead.
+- In the `containerEnv` runtime mode the same entries are injected as Container
+  App env vars (name/value only), so the passthrough works in both modes.
+
+`retrievalBackend` is **not** deprecated: it gates real infrastructure (the AI
+Foundry knowledge-base connection and shared private links), so it stays a
+first-class parameter.
+
+---
+
 ## 4. Things that are NOT broken
 
 These v1.x patterns continue to work unchanged:

--- a/main.bicep
+++ b/main.bicep
@@ -84,6 +84,9 @@ param deploymentTags object = {}
 @description('Label used for App Configuration key-value pairs.')
 param appConfigLabel string = 'ai-lz'
 
+@description('Optional. Accelerator-specific App Configuration key-values appended verbatim to the App Configuration store. This lets a consuming accelerator publish its own settings without the landing zone needing to know about them. Values are stored as plaintext in App Configuration, so never pass secrets here (use Key Vault references instead). Each entry must have a unique name+label. On a name+label collision with a workload configuration key the landing zone already emits, the passthrough entry wins. Do not redefine reserved infrastructure keys emitted by other modules (the Cosmos identifiers COSMOS_DB_ACCOUNT_RESOURCE_ID and COSMOS_DB_ENDPOINT, and the per-app <APP>_APIKEY Key Vault references); reusing those names would create a duplicate key-value and fail the deployment. Note: this is only applied on non network-isolated deployments, where the landing zone writes App Configuration at deploy time. Network-isolated deployments configure App Configuration from the accelerator post-provision step, so pass these values through that path instead.')
+param additionalAppConfigurationSettings additionalAppConfigurationSettingType[] = []
+
 @description('Enable network isolation for the deployment. This will restrict public access to resources and require private endpoints where applicable.')
 param networkIsolation bool = false
 
@@ -458,6 +461,22 @@ type publicIngressType = {
   sslPolicy: object?
 }
 
+@export()
+@description('Shape for an accelerator-supplied App Configuration key-value that the landing zone passes through verbatim. Values are stored as plaintext, never pass secrets here (use Key Vault references instead).')
+type additionalAppConfigurationSettingType = {
+  @description('Required. App Configuration key name.')
+  name: string
+
+  @description('Required. Plaintext value. Do not put secrets here.')
+  value: string
+
+  @description('Optional. App Configuration label. Defaults to the landing zone appConfigLabel.')
+  label: string?
+
+  @description('Optional. Content type. Defaults to text/plain. Use application/json for JSON values.')
+  contentType: string?
+}
+
 @description('Optional. Public Application Gateway WAF v2 ingress in front of the internal Container Apps environment. Disabled by default. WARNING: enabling this deploys WAF_v2 and a Standard Public IP, which incur hourly charges even when idle. See README "Optional Public Ingress" for the post-deploy runbook.')
 param publicIngress publicIngressType = { enabled: false }
 
@@ -484,7 +503,7 @@ param enableAgenticRetrieval bool = false
 ])
 param retrievalBackend string = 'foundry_iq'
 
-@description('Foundry IQ knowledge pattern. azureBlob uses native Foundry IQ Blob or ADLS Gen2 ingestion and is the default. searchIndex registers the existing GPT-RAG Azure AI Search index as an opt-in legacy Pattern B knowledge source. managed is accepted as a compatibility alias for azureBlob.')
+@description('Deprecated: prefer publishing this via additionalAppConfigurationSettings so the landing zone stays workload-agnostic. Retained for backward compatibility. Foundry IQ knowledge pattern. azureBlob uses native Foundry IQ Blob or ADLS Gen2 ingestion and is the default. searchIndex registers the existing GPT-RAG Azure AI Search index as an opt-in legacy Pattern B knowledge source. managed is accepted as a compatibility alias for azureBlob.')
 @allowed([
   'azureBlob'
   'managed'
@@ -508,7 +527,7 @@ param knowledgeBaseName string = '${environmentName}-knowledge-base'
 @description('Dedicated Azure AI Foundry connection name used by the knowledge base. Do not reuse SEARCH_CONNECTION_ID.')
 param knowledgeBaseConnectionName string = '${environmentName}-knowledge-base-connection'
 
-@description('Foundry IQ knowledge source name. For azureBlob this is the native Blob or ADLS Gen2 source. For searchIndex this is the registered GPT-RAG Azure AI Search index source.')
+@description('Deprecated: prefer publishing this via additionalAppConfigurationSettings so the landing zone stays workload-agnostic. Retained for backward compatibility. Foundry IQ knowledge source name. For azureBlob this is the native Blob or ADLS Gen2 source. For searchIndex this is the registered GPT-RAG Azure AI Search index source.')
 param foundryIqKnowledgeSourceName string = '${environmentName}-blob-ks'
 
 @description('Foundry IQ knowledge source kind stamped into runtime configuration. Leave empty to derive it from foundryIqPattern. Set to azureBlob for native Blob/ADLS sources or searchIndex for Pattern B.')
@@ -546,7 +565,7 @@ param foundryIqIngestionPermissionOptions array = [
 @description('JSON array override for native Foundry IQ permission metadata, intended for azd environment substitution from FOUNDRY_IQ_INGESTION_PERMISSION_OPTIONS. Leave empty to use foundryIqIngestionPermissionOptions.')
 param foundryIqIngestionPermissionOptionsJson string = ''
 
-@description('Existing GPT-RAG Azure AI Search index name to register as a Pattern B Foundry IQ searchIndex knowledge source.')
+@description('Deprecated: prefer publishing this via additionalAppConfigurationSettings so the landing zone stays workload-agnostic. Retained for backward compatibility. Existing GPT-RAG Azure AI Search index name to register as a Pattern B Foundry IQ searchIndex knowledge source.')
 param foundryIqSearchIndexName string = 'gpt-rag-index'
 
 @description('Semantic configuration name on the GPT-RAG Azure AI Search index. Required by Azure AI Search agentic retrieval.')
@@ -566,10 +585,10 @@ param foundryIqSearchFields array = [
   'content'
 ]
 
-@description('Optional persisted baseFilter for the Pattern B searchIndex knowledge source. Keep security trimming in query-time filterAddOn unless a static tenant/corpus filter is required.')
+@description('Deprecated: prefer publishing this via additionalAppConfigurationSettings so the landing zone stays workload-agnostic. Retained for backward compatibility. Optional persisted baseFilter for the Pattern B searchIndex knowledge source. Keep security trimming in query-time filterAddOn unless a static tenant/corpus filter is required.')
 param foundryIqBaseFilter string = ''
 
-@description('Enable query-time Pattern B filterAddOn in the GPT-RAG orchestrator. Requires foundryIqApiVersion 2026-05-01-preview.')
+@description('Deprecated: prefer publishing this via additionalAppConfigurationSettings so the landing zone stays workload-agnostic. Retained for backward compatibility. Enable query-time Pattern B filterAddOn in the GPT-RAG orchestrator. Requires foundryIqApiVersion 2026-05-01-preview.')
 param foundryIqFilterAddOnEnabled bool = true
 
 @description('Collection field used by GPT-RAG for Pattern B security trimming filterAddOn.')
@@ -2634,6 +2653,25 @@ var _containerRuntimeEnv = [
   { name: 'APP_RUNTIME_CONFIGURATION_MODE', value: appRuntimeConfigurationMode }
 ]
 
+// Symmetric accelerator passthrough for the containerEnv runtime mode (Issue #89).
+// When the consumer opts out of App Configuration, the same accelerator-supplied
+// settings must reach the Container Apps as env vars. Container env vars have no
+// label or contentType, so only name/value are projected. Additional settings win
+// on a name collision (the base bootstrap entry is dropped) to keep the same
+// precedence as the App Configuration passthrough. With the default empty array
+// this is a no-op and the emitted env block is byte-identical.
+var _additionalContainerEnv = [
+  for s in additionalAppConfigurationSettings: {
+    name: s.name
+    value: s.value
+  }
+]
+var _additionalContainerEnvNames = map(_additionalContainerEnv, e => e.name)
+var _containerRuntimeEnvWithAdditional = concat(
+  filter(_containerRuntimeEnv, e => !contains(_additionalContainerEnvNames, e.name)),
+  _additionalContainerEnv
+)
+
 var _containerAppNames = [
   for app in containerAppsList: empty(app.name) ? '${const.abbrs.containers.containerApp}${resourceToken}-${app.service_name}' : app.name
 ]
@@ -2719,7 +2757,7 @@ module containerApps 'br/public:avm/res/app/container-app:0.18.1' = [
             ] : [],
             // Bootstrap runtime config when the consumer opts out of App Config
             // (Issue #89, `appRuntimeConfigurationMode == 'containerEnv'`).
-            _runtimeConfigIsContainerEnv ? _containerRuntimeEnv : []
+            _runtimeConfigIsContainerEnv ? _containerRuntimeEnvWithAdditional : []
           )
         }
       ]
@@ -3610,12 +3648,27 @@ module cosmosConfigKeyVaultPopulate 'modules/app-configuration/app-configuration
   }
 }
 
+// Normalize accelerator-supplied App Configuration passthrough entries so every item carries a label and contentType. The app-configuration module reads both unconditionally, so a missing label defaults to appConfigLabel and a missing contentType defaults to text/plain.
+var _normalizedAdditionalAppConfigSettings = [
+  for s in additionalAppConfigurationSettings: {
+    name: s.name
+    value: s.value
+    label: s.?label ?? appConfigLabel
+    contentType: s.?contentType ?? 'text/plain'
+  }
+]
+
+// Collision keys for the passthrough, derived exactly how the app-configuration module names each key-value resource (name$label, or name when the label is empty). Used to drop any landing-zone key the passthrough overrides, so the passthrough always wins without emitting a duplicate resource name.
+var _additionalAppConfigKeys = map(_normalizedAdditionalAppConfigSettings, s => empty(s.label) ? s.name : '${s.name}$${s.label}')
+
 module appConfigPopulate 'modules/app-configuration/app-configuration.bicep' = if (deployAppConfig && _runtimeConfigIsAppConfig && !_networkIsolation) {
   name: 'appConfigPopulate'
   params: {
     #disable-next-line BCP318
     storeName: appConfig.name
     keyValues: concat(
+      filter(
+      concat(
       #disable-next-line BCP318
       deployContainerApps ? containerAppsSettings.outputs.containerAppsEndpoints : [],
       #disable-next-line BCP318
@@ -3745,6 +3798,10 @@ module appConfigPopulate 'modules/app-configuration/app-configuration.bicep' = i
       { name: 'MODEL_DEPLOYMENTS', value: string(_modelDeploymentSettings), label: appConfigLabel, contentType: 'application/json' }
 
     ]
+      ),
+      kv => !contains(_additionalAppConfigKeys, empty(kv.label) ? kv.name : '${kv.name}$${kv.label}')
+      ),
+      _normalizedAdditionalAppConfigSettings
     )
   }
 }

--- a/main.parameters.json
+++ b/main.parameters.json
@@ -45,6 +45,8 @@
     "foundryIqContentExtractionMode":      { "value": "${FOUNDRY_IQ_CONTENT_EXTRACTION_MODE=standard}" },
     "foundryIqAiServicesEndpoint":         { "value": "${FOUNDRY_IQ_AI_SERVICES_ENDPOINT=}" },
 
+    "additionalAppConfigurationSettings":  { "value": [] },
+
     "aiSearchResourceId":                  { "value": null },
     "aiFoundryStorageAccountResourceId":   { "value": null },
     "aiFoundryCosmosDBAccountResourceId":  { "value": null },


### PR DESCRIPTION
## What

Adds a generic, workload-agnostic App Configuration passthrough to the landing zone so solution accelerators can publish their own runtime key-values without the template growing accelerator-specific parameters.

New parameter `additionalAppConfigurationSettings` (a typed array, default `[]`). Each entry is `{ name, value, label?, contentType? }` and is stamped verbatim into the App Configuration store. When the consumer uses the `containerEnv` runtime mode (Issue #89) instead of App Configuration, the same entries are injected into every Container App as env vars (name/value only).

## Why

Today the landing zone carries GPT-RAG-specific `foundryIq*` knowledge-source parameters. That couples the template to one accelerator. This change gives every accelerator a single generic contract to publish its own keys, so the landing zone stays workload-agnostic. GPT-RAG (and others) can move their Foundry IQ and file-upload keys onto the passthrough instead of adding more named parameters here.

## Behavior and safety

- Default empty array. With `[]`, the generated App Configuration and container env output is byte-identical to the current template (verified by comparing the compiled `main.json` against the baseline).
- Passthrough wins on a `name`+`label` collision with a landing-zone key: the built-in entry is filtered out before the passthrough is appended, so no duplicate key-value resource is generated (a duplicate would hard-fail ARM).
- Values are plaintext. Secrets must still go through Key Vault references. Reserved infra keys emitted by other modules (`COSMOS_DB_ACCOUNT_RESOURCE_ID`, `COSMOS_DB_ENDPOINT`, per-app `<APP>_APIKEY`) must not be redefined.
- App Configuration is only populated on non network-isolated deployments; isolated deployments stamp config from the accelerator post-provision step, so the passthrough documents that path.

## Deprecations (non-breaking)

Deprecation notes were added to the accelerator-specific `foundryIq*` knowledge-source parameters (`foundryIqPattern`, `foundryIqKnowledgeSourceName`, `foundryIqSearchIndexName`, `foundryIqBaseFilter`, `foundryIqFilterAddOnEnabled`). They still work unchanged; they are superseded by the passthrough. `retrievalBackend` is intentionally not deprecated because it gates real infrastructure (the AI Foundry knowledge-base connection and shared private links), not just configuration.

## Scope

Additive minor. No parameters removed, no resource, name, condition, or dependency changed. Targets `develop`; CHANGELOG updated under `[Unreleased]`.

## Validation

- `az bicep build --file main.bicep` passes (exit 0). Only pre-existing warnings remain.
- Compiled `main.json` delta vs baseline is ~5 KB (the new param, type, and vars).
- Docs updated in the same change set (README, CHANGELOG, `docs/v2-migration.md`).

Note on the size guard: `scripts/Measure-MainJsonSize.ps1` reports `main.json` above the 4 MB ARM ceiling, but this is a pre-existing condition on the base branch (baseline `main.json` is ~4.64 MB before this change). This PR adds ~5 KB and does not change the pass/fail state. Reducing the compiled template size is out of scope here and tracked separately.
