### PR TITLE
feat: organize Copilot engineering agents

### DIFF
--- a/.github/agents/architecture.agent.md
+++ b/.github/agents/architecture.agent.md
@@ -1,0 +1,25 @@
+---
+name: architecture
+description: Analyzes AI Landing Zone module boundaries, contracts, identity, networking, deployment topology, and trade-offs. Use for structural or hard-to-reverse IaC changes; do not use for local implementation with settled requirements.
+tools: ["read", "search", "edit", "web"]
+---
+
+# AI Landing Zone architecture
+
+Follow `AGENTS.md`. Load `engineering-principles` and
+`architecture-decision`.
+
+Start from the operator outcome, constraints, and measurable architecture
+characteristics. Compare alternatives against the existing standard and
+network-isolated topologies, managed identity and RBAC boundaries, private DNS
+and endpoint behavior, parameter compatibility, cost, operability, migration,
+and reversibility.
+
+Treat Bicep, parameter files, manifests, pipelines, and current Azure service
+contracts as executable sources of truth. Reuse existing AVM and local module
+boundaries. Do not turn a preferred Azure service or framework into a
+requirement without evidence.
+
+Output handoff to `implementation`: decision, affected modules and contracts,
+fitness functions, security and compatibility risks, migration and rollback,
+documentation impact, and open questions.

--- a/.github/agents/implementation.agent.md
+++ b/.github/agents/implementation.agent.md
@@ -1,0 +1,25 @@
+---
+name: implementation
+description: Implements, tests, and documents scoped AI Landing Zone changes after requirements are clear. Do not use to decide broad architecture, publish releases, or operate production.
+tools: ["read", "search", "edit", "execute"]
+---
+
+# AI Landing Zone implementation
+
+Follow `AGENTS.md`, `.github/copilot-instructions.md`, and every scoped
+instruction that applies to changed files. Load `engineering-principles`.
+
+Inspect the current Bicep, parameters, modules, scripts, tests, pipelines, and
+documentation before editing. Make the smallest coherent change. Preserve
+feature flags, module boundaries, parameter and output contracts, naming,
+identity, network isolation, and consumer-submodule compatibility by default.
+
+Add or adjust behavioral tests and documentation in the same change. Run the
+narrowest relevant validation before broader Bicep and deployment checks.
+
+Input handoff: an issue, plan, or architecture decision with high-impact choices
+resolved.
+
+Output handoff to `validation`: delivered behavior, changed files and contracts,
+commands and results, documentation status, Azure validation still required,
+and residual risks.

--- a/.github/agents/operations.agent.md
+++ b/.github/agents/operations.agent.md
@@ -1,0 +1,22 @@
+---
+name: operations
+description: Diagnoses and operates approved AI Landing Zone deployments, preflight checks, What-If previews, jumpbox bootstrap, and Azure DevOps deployment paths. Do not use for unapproved production changes or feature design.
+tools: ["read", "search", "execute", "web"]
+---
+
+# AI Landing Zone operations
+
+Follow `AGENTS.md`. Load `deployment-operations` and the security and validation
+references from `engineering-principles`.
+
+Start read-only: establish deployment mode, parameter source, identity, scope,
+current state, and the exact failing phase. Prefer preflight, What-If, resource
+state, and logs before mutation. Preserve evidence and redact secrets and
+private environment names.
+
+Use the least privilege and smallest scope. State the command, expected effect,
+rollback path, and approval boundary before any mutation. Never infer approval
+from a request to investigate or preview.
+
+Output handoff: affected scope, observed state, diagnosis, commands and evidence,
+changes performed or withheld, rollback status, and remaining operator action.

--- a/.github/agents/release.agent.md
+++ b/.github/agents/release.agent.md
@@ -1,0 +1,25 @@
+---
+name: release
+description: Prepares and validates AI Landing Zone semantic releases, manifest pins, changelog entries, tags, and release notes. Do not use for feature implementation or publish without explicit human approval.
+tools: ["read", "search", "edit", "execute", "web"]
+---
+
+# AI Landing Zone release
+
+Follow `AGENTS.md`, the scoped release instructions, and `release-management`.
+
+Read versions from current release artifacts. Keep `manifest.json` `tag` and
+`ailz_tag`, the changelog heading, Git tag, and GitHub Release title aligned.
+Verify the exact commit and validation evidence being released. Preserve the
+jumpbox bootstrap contract and document compatibility or migration impact.
+
+For major or minor changes, require an explicit Portal and Terraform landing-
+zone parity follow-up. Confirm repository runbooks and the public
+`Azure/AI-Landing-Zones` site are current when operator behavior changes.
+
+Never create or edit a tag, GitHub Release, package, or production deployment
+without explicit human approval.
+
+Output handoff: proposed version, release artifacts, validation evidence,
+documentation status, downstream parity actions, rollback path, and remaining
+approval actions.

--- a/.github/agents/validation.agent.md
+++ b/.github/agents/validation.agent.md
@@ -1,0 +1,22 @@
+---
+name: validation
+description: Validates AI Landing Zone declarative assets, Bicep, parameters, scripts, contracts, and deployment evidence. Use after implementation or for regression investigation; do not change product scope or approve production deployment.
+tools: ["read", "search", "execute"]
+---
+
+# AI Landing Zone validation
+
+Follow `AGENTS.md` and load `iac-validation` plus the relevant
+`engineering-principles` references.
+
+Build an evidence ladder from deterministic local checks to Azure-aware
+validation. Validate Copilot assets, changed PowerShell behavior, Bicep build
+and lint, compiled-template size, preflight rules, What-If, and deployment only
+as required by risk and authorization.
+
+Distinguish compilation from deployment correctness. Inspect warnings, skipped
+lookups, conditional paths, and both standard and network-isolated effects.
+Never hide a failed command or convert missing Azure access into success.
+
+Output handoff: acceptance criterion, command, result, environment-independent
+evidence, unexecuted checks with reason, residual risk, and release readiness.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,22 @@
+# AI Landing Zone engineering core
+
+Follow the repository-wide contract in `AGENTS.md`.
+
+Use progressive disclosure:
+
+- Load only `.github/instructions/*.instructions.md` files whose `applyTo`
+  patterns match the files being changed.
+- Load a procedure from `.github/skills/` when its description matches the task.
+- Use a specialist from `.github/agents/` when its role and exit condition match
+  the work.
+
+Before Azure or Bicep design or implementation, load the
+`engineering-principles` skill and obtain current Azure best-practice guidance
+from the available Azure tooling.
+
+These are GitHub Copilot engineering assets for maintaining this repository.
+They are not deployed Microsoft Foundry agents or Azure resources.
+
+Preserve existing deployment behavior by default. Do not change Bicep
+parameters, outputs, resources, scripts, or runtime contracts merely to support
+the engineering-agent framework.

--- a/.github/instructions/bicep.instructions.md
+++ b/.github/instructions/bicep.instructions.md
@@ -1,0 +1,18 @@
+---
+applyTo: "main.bicep,modules/**/*.bicep,constants/**/*.bicep,tests/**/*.bicep"
+---
+
+# Bicep implementation
+
+- Load `engineering-principles`.
+- Keep `main.bicep` as orchestrator and reusable resource bodies in focused
+  modules.
+- Reuse AVM and existing local module patterns before creating new resources.
+- Add descriptions and explicit types to public parameters and outputs.
+- Preserve feature-flag conditions, disabled-feature output fallbacks, module
+  dependencies, and idempotency.
+- Use `const.roles` and `const.abbrs` instead of duplicated literals.
+- Preserve CAF and legacy naming behavior and explicit-name overrides.
+- Treat identity, role scope, private DNS, private endpoints, subnet delegation,
+  routes, and public access as security-sensitive.
+- Run Bicep build and lint; run the size gate when compiled output changes.

--- a/.github/instructions/copilot-assets.instructions.md
+++ b/.github/instructions/copilot-assets.instructions.md
@@ -1,0 +1,16 @@
+---
+applyTo: "AGENTS.md,.github/copilot-instructions.md,.github/agents/**,.github/skills/**,.github/instructions/**,.github/scripts/Validate-CopilotAssets.ps1"
+---
+
+# GitHub Copilot engineering assets
+
+- Keep `AGENTS.md` concise and stable; move procedures to skills and file-scoped
+  rules to instructions.
+- Distinguish engineering agents from deployed Azure and Microsoft Foundry
+  agents.
+- Use lowercase kebab-case agent and skill names.
+- Keep agent roles non-overlapping and include explicit handoffs.
+- Keep skills reusable and load detailed references only when relevant.
+- Ensure `applyTo` patterns are specific enough to avoid unrelated context.
+- Validate YAML frontmatter, schemas, unique names, allowed tools, and local
+  links with `.github/scripts/Validate-CopilotAssets.ps1`.

--- a/.github/instructions/parameters-contracts.instructions.md
+++ b/.github/instructions/parameters-contracts.instructions.md
@@ -1,0 +1,19 @@
+---
+applyTo: "main.parameters.json,manifest.json,azure.yaml,constants/**/*.json"
+---
+
+# Parameters and contracts
+
+- Treat parameter names, values, defaults, manifest fields, constants, and azd
+  hook behavior as versioned compatibility surfaces.
+- Keep `main.bicep` and `main.parameters.json` aligned.
+- Use `${ENV_VAR=default}` substitution consistently and add a safe Bicep
+  fallback when substitution can yield empty.
+- Keep structured arrays and objects structured; never coerce them to strings.
+- Do not place secrets in parameter files. Preserve the established secret
+  indirection used by azd and Azure DevOps.
+- Preserve `manifest.json` because jumpbox bootstrap and consumer accelerators
+  depend on it.
+- Keep `manifest.json` release fields aligned during releases.
+- Update runtime configuration publication and outputs when consumers require a
+  new value.

--- a/.github/instructions/pipelines.instructions.md
+++ b/.github/instructions/pipelines.instructions.md
@@ -1,0 +1,17 @@
+---
+applyTo: ".github/workflows/**/*.yml,.github/workflows/**/*.yaml,pipelines/**/*.yml,pipelines/**/*.yaml"
+---
+
+# Validation and deployment pipelines
+
+- Preserve existing branch and path filters unless the change intentionally
+  alters coverage.
+- Pin validation dependencies and grant the minimum workflow permissions.
+- Keep Bicep build and lint aligned between GitHub Actions and Azure DevOps.
+- Keep What-If before deployment stages and preserve approval gates.
+- Treat Bash inside Azure DevOps templates and PowerShell scripts as separate
+  implementations that must agree on shared behavior.
+- Propagate native exit codes and surface resource-level failures.
+- Never print secrets, service-connection credentials, or private environment
+  names.
+- Validate edited workflow YAML and the command it invokes.

--- a/.github/instructions/powershell.instructions.md
+++ b/.github/instructions/powershell.instructions.md
@@ -1,0 +1,21 @@
+---
+applyTo: "**/*.ps1,azure.yaml"
+---
+
+# PowerShell and azd automation
+
+- Target PowerShell 7 for shared scripts unless `install.ps1` requires Windows
+  PowerShell compatibility under Custom Script Extension.
+- Keep azd Windows and POSIX hooks behaviorally identical through their shared
+  PowerShell command.
+- Quote paths and external input; do not print secrets or private validation
+  environment names.
+- Fail explicitly on unmet prerequisites and non-transient errors. Do not return
+  success-shaped fallbacks.
+- Preserve idempotency, `SupportsShouldProcess`, and `-WhatIf` behavior where
+  present.
+- Preserve `install.ps1` wall-clock budgets, bounded operations, process-tree
+  cleanup, and fatal-versus-optional step behavior.
+- Add deterministic tests for parsing, validation, and branching logic.
+- Load `documentation-consistency` when operator commands or deployment flow
+  change.

--- a/.github/instructions/release.instructions.md
+++ b/.github/instructions/release.instructions.md
@@ -1,0 +1,18 @@
+---
+applyTo: "CHANGELOG.md,manifest.json,README.md,docs/**,.github/pull_request_template.md"
+---
+
+# Documentation and release surfaces
+
+- Load `documentation-consistency`; load `release-management` for version or
+  publishing work.
+- Keep the changelog factual and classify compatibility impact.
+- Align `manifest.json` `tag` and `ailz_tag`, changelog version, Git tag, and
+  GitHub Release title.
+- Preserve the manifest bootstrap contract and pinned consumer reproducibility.
+- Major or minor changes require Portal and Terraform landing-zone parity
+  review.
+- Update relevant runbooks and the public `Azure/AI-Landing-Zones` source when
+  operator-facing behavior changes.
+- Never publish a tag, release, package, or production deployment without
+  explicit human approval.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,6 @@
-IMPORTANT:  Please open this Pull Request with the target branch set to develop. (remove this line)
+IMPORTANT: Open feature pull requests against `develop`. Target `main` only for
+an approved release or explicitly authorized direct-main exception. Remove this
+note before submitting.
 
 ## Purpose
 
@@ -17,12 +19,21 @@ Describe the intention of the proposed changes. What problem does it solve or wh
 
 If applicable, provide a link to the relevant backlog item or issue.
 
-## Documentation Link
+## Documentation
 
-If this change adds new functionality, provide a link to its documentation. Documentation should be updated in the `mkdocs` branch.
+List the in-repository documentation updated by this change. If the public
+Bicep landing-zone story changes, link the companion pull request to
+`Azure/AI-Landing-Zones` `main`.
+
+## Validation evidence
+
+List the exact commands run, their results, and any Azure-aware validation that
+was not run.
 
 ## Code quality checklist
 
 - [ ] I verified the changes locally to ensure they work as expected
 - [ ] I tested the new functionality and ensured existing features still work
+- [ ] I preserved parameter, output, naming, identity, and network-isolation contracts or documented the migration
+- [ ] I updated `CHANGELOG.md` and all affected documentation
 - [ ] I added at least one reviewer to this Pull Request

--- a/.github/scripts/Validate-CopilotAssets.ps1
+++ b/.github/scripts/Validate-CopilotAssets.ps1
@@ -1,0 +1,215 @@
+<#
+.SYNOPSIS
+    Validates repository GitHub Copilot agents, skills, and scoped instructions.
+
+.DESCRIPTION
+    Uses powershell-yaml for standards-compliant YAML frontmatter parsing, then
+    validates repository schemas, unique names, allowed tools, and local links.
+#>
+
+[CmdletBinding()]
+param(
+    [string]$Root = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$requiredYamlVersion = [version]'0.4.12'
+$yamlModule = Get-Module -ListAvailable powershell-yaml |
+    Where-Object Version -GE $requiredYamlVersion |
+    Sort-Object Version -Descending |
+    Select-Object -First 1
+
+if (-not $yamlModule) {
+    throw "powershell-yaml $requiredYamlVersion or later is required. Install it with: Install-Module powershell-yaml -RequiredVersion $requiredYamlVersion -Scope CurrentUser"
+}
+
+Import-Module $yamlModule.Path -Force
+
+$repoRoot = (Resolve-Path $Root).Path
+$allowedAgentTools = @('agent', 'edit', 'execute', 'read', 'search', 'web')
+$assetNamePattern = '^[a-z0-9]+(?:-[a-z0-9]+)*$'
+$localLinkPattern = '\[[^\]]+\]\((?!https?://|mailto:|#)([^)]+)\)'
+$errors = [System.Collections.Generic.List[string]]::new()
+$agentNames = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+$skillNames = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+
+function Get-RelativePath {
+    param([Parameter(Mandatory)][string]$Path)
+    [System.IO.Path]::GetRelativePath($repoRoot, $Path).Replace('\', '/')
+}
+
+function Add-ValidationError {
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [Parameter(Mandatory)][string]$Message
+    )
+    $errors.Add(('{0}: {1}' -f (Get-RelativePath $Path), $Message))
+}
+
+function Get-Frontmatter {
+    param([Parameter(Mandatory)][string]$Path)
+
+    $text = [System.IO.File]::ReadAllText($Path)
+    $lines = $text -split "\r?\n"
+    if ($lines.Count -eq 0 -or $lines[0].Trim() -ne '---') {
+        throw 'missing opening YAML frontmatter boundary'
+    }
+
+    $closingIndex = -1
+    for ($index = 1; $index -lt $lines.Count; $index++) {
+        if ($lines[$index].Trim() -eq '---') {
+            $closingIndex = $index
+            break
+        }
+    }
+    if ($closingIndex -lt 0) {
+        throw 'missing closing YAML frontmatter boundary'
+    }
+
+    $yaml = ($lines[1..($closingIndex - 1)] -join "`n")
+    try {
+        $metadata = ConvertFrom-Yaml -Yaml $yaml
+    }
+    catch {
+        throw "invalid YAML frontmatter: $($_.Exception.Message)"
+    }
+    if (-not ($metadata -is [System.Collections.IDictionary])) {
+        throw 'YAML frontmatter must be a string-keyed mapping'
+    }
+    foreach ($key in $metadata.Keys) {
+        if (-not ($key -is [string])) {
+            throw 'YAML frontmatter must be a string-keyed mapping'
+        }
+    }
+
+    [pscustomobject]@{
+        Metadata = $metadata
+        Text = $text
+    }
+}
+
+function Test-RequiredString {
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [Parameter(Mandatory)][System.Collections.IDictionary]$Metadata,
+        [Parameter(Mandatory)][string[]]$Fields
+    )
+    foreach ($field in $Fields) {
+        if (-not $Metadata.Contains($field) -or
+            -not ($Metadata[$field] -is [string]) -or
+            [string]::IsNullOrWhiteSpace($Metadata[$field])) {
+            Add-ValidationError $Path "'$field' must be a non-empty string"
+        }
+    }
+}
+
+function Test-LocalLinks {
+    param(
+        [Parameter(Mandatory)][string]$Path,
+        [Parameter(Mandatory)][string]$Text
+    )
+    foreach ($match in [regex]::Matches($Text, $localLinkPattern)) {
+        $target = $match.Groups[1].Value
+        $targetPath = ($target -split '#', 2)[0]
+        if ([string]::IsNullOrWhiteSpace($targetPath)) {
+            continue
+        }
+        $decodedTarget = [System.Uri]::UnescapeDataString($targetPath)
+        $resolved = [System.IO.Path]::GetFullPath((Join-Path (Split-Path $Path -Parent) $decodedTarget))
+        $relative = [System.IO.Path]::GetRelativePath($repoRoot, $resolved)
+        if ($relative.StartsWith('..') -or -not (Test-Path -LiteralPath $resolved)) {
+            Add-ValidationError $Path "local link does not exist: $target"
+        }
+    }
+}
+
+$groups = @(
+    @{ Directory = '.github/agents'; Pattern = '*.agent.md'; Kind = 'agent' },
+    @{ Directory = '.github/skills'; Pattern = 'SKILL.md'; Kind = 'skill' },
+    @{ Directory = '.github/instructions'; Pattern = '*.instructions.md'; Kind = 'instruction' }
+)
+
+foreach ($group in $groups) {
+    $directory = Join-Path $repoRoot $group.Directory
+    $paths = @(Get-ChildItem -Path $directory -Filter $group.Pattern -File -Recurse)
+    if ($paths.Count -eq 0) {
+        $errors.Add("$($group.Directory): no matching assets")
+        continue
+    }
+
+    foreach ($path in $paths) {
+        try {
+            $asset = Get-Frontmatter $path.FullName
+        }
+        catch {
+            Add-ValidationError $path.FullName $_.Exception.Message
+            continue
+        }
+
+        Test-LocalLinks $path.FullName $asset.Text
+        $metadata = $asset.Metadata
+
+        switch ($group.Kind) {
+            'agent' {
+                Test-RequiredString $path.FullName $metadata @('name', 'description')
+                $name = $metadata['name']
+                if ($name -is [string]) {
+                    if ($name -notmatch $assetNamePattern) {
+                        Add-ValidationError $path.FullName 'agent name must be lowercase kebab-case'
+                    }
+                    if (-not $agentNames.Add($name)) {
+                        Add-ValidationError $path.FullName "duplicate agent '$name'"
+                    }
+                }
+
+                $tools = @($metadata['tools'])
+                if ($tools.Count -eq 0 -or @($tools | Where-Object { -not ($_ -is [string]) -or [string]::IsNullOrWhiteSpace($_) }).Count -gt 0) {
+                    Add-ValidationError $path.FullName "'tools' must be a non-empty string list"
+                }
+                else {
+                    $unknownTools = @($tools | Where-Object { $_ -notin $allowedAgentTools } | Sort-Object -Unique)
+                    if ($unknownTools.Count -gt 0) {
+                        Add-ValidationError $path.FullName "unsupported tool aliases: $($unknownTools -join ', ')"
+                    }
+                    if (@($tools | Sort-Object -Unique).Count -ne $tools.Count) {
+                        Add-ValidationError $path.FullName 'duplicate tool aliases'
+                    }
+                }
+            }
+            'skill' {
+                Test-RequiredString $path.FullName $metadata @('name', 'description')
+                $name = $metadata['name']
+                if ($name -is [string]) {
+                    if ($name -notmatch $assetNamePattern) {
+                        Add-ValidationError $path.FullName 'skill name must be lowercase kebab-case'
+                    }
+                    if ($name -ne $path.Directory.Name) {
+                        Add-ValidationError $path.FullName 'skill name must match its directory'
+                    }
+                    if (-not $skillNames.Add($name)) {
+                        Add-ValidationError $path.FullName "duplicate skill '$name'"
+                    }
+                }
+            }
+            'instruction' {
+                Test-RequiredString $path.FullName $metadata @('applyTo')
+                $applyTo = $metadata['applyTo']
+                if ($applyTo -is [string] -and @($applyTo.Split(',') | Where-Object { [string]::IsNullOrWhiteSpace($_) }).Count -gt 0) {
+                    Add-ValidationError $path.FullName "'applyTo' has an empty pattern"
+                }
+            }
+        }
+    }
+}
+
+if ($errors.Count -gt 0) {
+    foreach ($validationError in $errors) {
+        Write-Error $validationError -ErrorAction Continue
+    }
+    exit 1
+}
+
+Write-Host "Validated $($agentNames.Count) agents, $($skillNames.Count) skills, and scoped instructions." -ForegroundColor Green
+exit 0

--- a/.github/skills/architecture-decision/SKILL.md
+++ b/.github/skills/architecture-decision/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: architecture-decision
+description: Conducts and records a verifiable AI Landing Zone architecture decision. Use when a choice alters module boundaries, contracts, identity, networking, deployment topology, or operation with meaningful reversal cost.
+---
+
+# AI Landing Zone architecture decision
+
+1. Load the relevant `engineering-principles` references and current Azure
+   best-practice guidance.
+2. Define operator outcome, constraints, affected modules and contracts, and up
+   to five prioritized characteristics with measures.
+3. Compare at least two viable alternatives and the option of not changing.
+4. Evaluate identity, RBAC, network isolation, parameter compatibility, Azure
+   limits, cost, operation, migration, consumer impact, and reversibility.
+5. Record the decision under `docs/adr/` using
+   [the ADR template](references/adr-template.md).
+6. Define fitness functions, adoption order, rollback or roll-forward, and a
+   review trigger.
+
+Do not turn a tool, service, or framework preference into an architecture
+requirement. Record a bounded investigation when evidence is missing.

--- a/.github/skills/architecture-decision/references/adr-template.md
+++ b/.github/skills/architecture-decision/references/adr-template.md
@@ -1,0 +1,68 @@
+# ADR-NNN: Decision title
+
+- Status: proposed
+- Date: YYYY-MM-DD
+- Owners:
+- Related issue or pull request:
+
+## Context
+
+Describe the operator outcome, current implementation, constraints, affected
+modules and contracts, and why a decision is required.
+
+## Prioritized characteristics
+
+| Characteristic | Priority | Measure |
+| --- | --- | --- |
+| Example: compatibility | 1 | Existing parameter files build unchanged |
+
+## Alternatives considered
+
+### Option A
+
+Describe benefits, costs, identity and networking impact, migration,
+reversibility, and validation.
+
+### Option B
+
+Describe benefits, costs, identity and networking impact, migration,
+reversibility, and validation.
+
+### Do not change
+
+Describe the consequence of retaining the current design.
+
+## Decision
+
+State the selected option and evidence.
+
+## Consequences
+
+List positive, negative, and neutral consequences, including cost and
+operational ownership.
+
+## Compatibility and migration
+
+Describe parameter, output, naming, manifest, consumer, and release impact.
+
+## Security and identity
+
+Describe managed identity, RBAC scope, secret handling, public access, private
+endpoint, DNS, and network-isolation implications.
+
+## Adoption and rollback
+
+Define implementation order, deployment sequencing, rollback or roll-forward,
+and data or resource cleanup.
+
+## Compliance verification
+
+List build, lint, test, preflight, What-If, and deployment fitness functions.
+
+## Documentation impact
+
+List repository and public documentation changes.
+
+## Review trigger
+
+Define the Azure contract, scale, cost, incident, or date that requires review.

--- a/.github/skills/deployment-operations/SKILL.md
+++ b/.github/skills/deployment-operations/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: deployment-operations
+description: Safely investigates and operates AI Landing Zone preflight, What-If, azd, Azure DevOps, and jumpbox bootstrap paths. Use for approved deployment operations or incident diagnosis.
+---
+
+# AI Landing Zone deployment operations
+
+1. Establish the approved subscription, resource group, deployment mode,
+   identity, source commit, and parameter source without exposing private data.
+2. Run deterministic preflight, then Azure-aware checks as authorization allows.
+3. Use What-If or `azd provision --preview`; inspect destructive changes,
+   replacements, role assignments, network access, and policy effects.
+4. For failures, isolate the phase: substitution, preflight, ARM validation,
+   resource deployment, data-plane setup, or jumpbox bootstrap.
+5. Preserve logs and exit codes. Do not retry non-transient failures or hide
+   resource-level errors behind a successful wrapper exit code.
+6. Before mutation, state expected effect and rollback or roll-forward.
+7. Record the exact command and resulting deployment or operation state.
+
+Production mutation requires explicit approval. A preview or diagnostic request
+is not approval to deploy.

--- a/.github/skills/documentation-consistency/SKILL.md
+++ b/.github/skills/documentation-consistency/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: documentation-consistency
+description: Keeps AI Landing Zone contributor, user, and operator documentation aligned with shipped Bicep behavior. Use for parameters, defaults, outputs, topology, deployment flow, operations, or releases.
+---
+
+# AI Landing Zone documentation consistency
+
+1. Identify the user, consumer, contributor, or operator behavior that changed.
+2. Search `README.md`, `CHANGELOG.md`, `docs/`, `pipelines/README.md`, examples,
+   and tests for the parameter, output, flag, topology, command, and old term.
+3. Update every affected in-repository source in the same change.
+4. When the public Bicep landing-zone narrative changes, update the MkDocs source
+   on `Azure/AI-Landing-Zones` `main` and link the companion pull request.
+5. Keep examples aligned with current defaults and both standard and network-
+   isolated modes.
+6. Classify semantic-version impact and record migration guidance for breaking
+   behavior.
+7. Report documentation status and any coordinated pull request in the handoff.
+
+Generated `gh-pages` content is not an editable documentation source. A user-
+visible change is incomplete until documentation is updated or a search proves
+that no published page is affected.

--- a/.github/skills/engineering-principles/SKILL.md
+++ b/.github/skills/engineering-principles/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: engineering-principles
+description: AI Landing Zone architecture and implementation principles. Use before Azure or Bicep design, review, meaningful refactoring, security, validation, release, or operational work.
+---
+
+# AI Landing Zone engineering principles
+
+Before generating Azure or Bicep guidance, obtain current Azure best-practice
+guidance from the available Azure tooling. Then load only the references needed:
+
+| When the task involves | Read |
+| --- | --- |
+| Repository purpose, module boundaries, or topology | [Architecture and boundaries](references/architecture-and-boundaries.md) |
+| Bicep style, parameters, outputs, or compatibility | [Bicep style and contracts](references/bicep-style-and-contracts.md) |
+| Identity, RBAC, secrets, networking, or private access | [Security and networking](references/security-and-networking.md) |
+| Tests, lint, build, What-If, deployment, or evidence | [Validation and evidence](references/validation-and-evidence.md) |
+| Operations, documentation, versioning, or release | [Operations and releases](references/operations-and-releases.md) |
+
+Use these principles as design questions, not dogma. Task requirements,
+executable configuration, current Azure contracts, and the implementation
+remain the sources of truth.

--- a/.github/skills/engineering-principles/references/architecture-and-boundaries.md
+++ b/.github/skills/engineering-principles/references/architecture-and-boundaries.md
@@ -1,0 +1,15 @@
+# Architecture and boundaries
+
+- `main.bicep` is the resource-group-scoped orchestrator; keep resource bodies
+  in focused AVM or local modules.
+- Reuse module families under `modules/ai-foundry`, `networking`, `security`,
+  `container-apps`, `app-configuration`, and `bing-search`.
+- Use `constants/constants.bicep` for role IDs, abbreviations, and shared types.
+- Drive infrastructure shape from typed lists rather than workload-specific
+  branches.
+- Preserve standard, standalone Zero Trust, and AI Landing Zone integrated
+  topology intent. Explicit operator choices remain authoritative.
+- Treat `azure.yaml`, pipeline templates, preflight, and integration fixtures as
+  architecture verification surfaces, not independent product implementations.
+- Evaluate reversibility, migration, consumer-submodule compatibility, Azure
+  limits, cost, and operational ownership before changing a boundary.

--- a/.github/skills/engineering-principles/references/bicep-style-and-contracts.md
+++ b/.github/skills/engineering-principles/references/bicep-style-and-contracts.md
@@ -1,0 +1,19 @@
+# Bicep style and contracts
+
+- Add `@description` to parameters and outputs; use typed objects and arrays.
+- Preserve existing parameter names, defaults, allowed values, nullable
+  semantics, and `SCREAMING_SNAKE_CASE` output names by default.
+- Guard values that azd substitution can resolve to empty before resource use.
+- Keep a new capability consistent across `main.bicep`,
+  `main.parameters.json`, runtime configuration publication, and outputs.
+- Reuse `const.roles` and `const.abbrs`; do not duplicate role GUIDs or naming
+  abbreviations.
+- Preserve CAF and legacy naming modes, length limits, deterministic tokens, and
+  explicit-name overrides.
+- Keep optional resources behind feature-flag conditions and return existing
+  empty or false output fallbacks when a feature is disabled.
+- Extend module interfaces additively where possible. Breaking parameter,
+  output, naming, or topology changes require migration guidance and semantic
+  version classification.
+- Run Bicep build and lint after contract changes; inspect warnings instead of
+  suppressing them without a documented reason.

--- a/.github/skills/engineering-principles/references/operations-and-releases.md
+++ b/.github/skills/engineering-principles/references/operations-and-releases.md
@@ -1,0 +1,17 @@
+# Operations and releases
+
+- Start operations with read-only evidence and establish subscription, resource
+  group, deployment mode, identity, and parameter source before mutation.
+- Preflight and What-If are required risk controls but do not grant deployment
+  approval.
+- Preserve PowerShell 7 behavior across azd Windows and POSIX hooks.
+- Preserve `install.ps1` timeout budgets, bounded external operations, and
+  fatal-versus-optional bootstrap steps.
+- Keep `README.md`, `CHANGELOG.md`, runbooks, pipeline guidance, and the public
+  AI Landing Zones documentation aligned with shipped behavior.
+- Use semantic versioning. Align manifest versions, changelog, tag, release
+  title, and exact release commit.
+- Major or minor changes require Portal and Terraform landing-zone parity
+  review.
+- Tags, releases, packages, and production changes require explicit human
+  approval and a rollback or roll-forward path.

--- a/.github/skills/engineering-principles/references/security-and-networking.md
+++ b/.github/skills/engineering-principles/references/security-and-networking.md
@@ -1,0 +1,16 @@
+# Security and networking
+
+- Prefer managed identity and least-privilege RBAC. Keep control-plane and
+  Cosmos DB data-plane assignments in their established security modules.
+- Never place credentials, access tokens, private keys, or environment-specific
+  secrets in Bicep, parameters, logs, tests, or examples.
+- Preserve private endpoint dependencies, DNS zone groups and links, policy-
+  managed DNS behavior, subnet delegation and sizing, route tables, and hub/
+  spoke peering responsibilities.
+- Keep `Microsoft.App/environments` delegation casing canonical.
+- Treat public network access and `allowedIpRanges` interactions as explicit
+  security decisions; not every Azure service supports native IP rules.
+- Validate standard and network-isolated paths when identity or networking
+  changes.
+- Security claims require Bicep evidence, deployment evidence, or current Azure
+  documentation. Compilation alone does not prove effective isolation.

--- a/.github/skills/engineering-principles/references/validation-and-evidence.md
+++ b/.github/skills/engineering-principles/references/validation-and-evidence.md
@@ -1,0 +1,16 @@
+# Validation and evidence
+
+Use the smallest applicable evidence ladder:
+
+1. Validate Copilot declarative assets and validator tests.
+2. Run targeted PowerShell tests for changed deterministic logic.
+3. Build and lint `main.bicep`.
+4. Run the compiled-template size gate when Bicep or modules change.
+5. Run preflight with deterministic checks, then Azure lookups when available.
+6. Use `azd provision --preview` or the Azure DevOps preview template.
+7. Provision only in an approved test scope when end-to-end evidence is needed.
+
+For each result, record the command, exit code, meaningful warnings, and what it
+proves. Test conditional and compatibility paths affected by the change. Do not
+claim that build, lint, or What-If proves a successful deployment. If a check
+cannot run, state the missing dependency or authorization and residual risk.

--- a/.github/skills/iac-validation/SKILL.md
+++ b/.github/skills/iac-validation/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: iac-validation
+description: Builds an evidence-based validation plan for AI Landing Zone Copilot assets, Bicep, parameters, scripts, and Azure deployment behavior. Use after implementation or during regression investigation.
+---
+
+# AI Landing Zone validation
+
+1. Map each acceptance criterion to an observable result.
+2. Identify changed declarative assets, Bicep contracts, scripts, and deployment
+   paths.
+3. Run Copilot asset validation and its fixture tests when `.github` engineering
+   assets change.
+4. Run targeted PowerShell tests for deterministic script logic.
+5. Build and lint Bicep; run the size gate when compiled output can change.
+6. Run preflight with the appropriate deterministic or Azure-aware scope.
+7. Use What-If and approved test deployment evidence according to risk.
+8. Report exact commands, results, warnings, skipped paths, and residual risk.
+
+Do not treat successful YAML parsing, Bicep compilation, or What-If as proof of
+runtime success. Do not mutate Azure merely to gather evidence without approval.

--- a/.github/skills/release-management/SKILL.md
+++ b/.github/skills/release-management/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: release-management
+description: Prepares and validates AI Landing Zone semantic releases. Use for changelog entries, manifest versions, release branches, tags, GitHub Releases, and post-release branch reconciliation.
+---
+
+# AI Landing Zone release management
+
+1. Read the release and branching rules in `AGENTS.md` and scoped instructions.
+2. Confirm `develop`, when used, includes the latest release from `main`.
+3. Determine semantic-version impact from compatibility and behavior.
+4. Keep `manifest.json` `tag` and `ailz_tag`, changelog version, Git tag, and
+   GitHub Release title equal to `vMAJOR.MINOR.PATCH`.
+5. Verify the exact commit with Copilot asset validation, targeted tests, Bicep
+   build and lint, preflight, and Azure evidence appropriate to the change.
+6. Confirm repository and public documentation status.
+7. For major or minor changes, record Portal and Terraform parity follow-up.
+8. Publish notes from the changelog and verify the created tag and release.
+9. Reconcile `develop` with `main` immediately after release.
+
+Never infer a version from stale prose. Never publish a tag, release, package,
+or production deployment without explicit human approval.

--- a/.github/workflows/bicep-validate.yml
+++ b/.github/workflows/bicep-validate.yml
@@ -8,6 +8,13 @@ on:
       - 'constants/**'
       - 'main.parameters.json'
       - 'scripts/Measure-MainJsonSize.ps1'
+      - 'AGENTS.md'
+      - '.github/agents/**'
+      - '.github/skills/**'
+      - '.github/instructions/**'
+      - '.github/copilot-instructions.md'
+      - '.github/scripts/Validate-CopilotAssets.ps1'
+      - 'tests/scripts/Validate-CopilotAssets.Tests.ps1'
       - '.github/workflows/bicep-validate.yml'
   push:
     branches:
@@ -18,12 +25,38 @@ on:
       - 'modules/**'
       - 'constants/**'
       - 'main.parameters.json'
+      - 'AGENTS.md'
+      - '.github/agents/**'
+      - '.github/skills/**'
+      - '.github/instructions/**'
+      - '.github/copilot-instructions.md'
+      - '.github/scripts/Validate-CopilotAssets.ps1'
+      - 'tests/scripts/Validate-CopilotAssets.Tests.ps1'
+      - '.github/workflows/bicep-validate.yml'
 
 permissions:
   contents: read
   pull-requests: write
 
 jobs:
+  validate-copilot-assets:
+    name: Copilot assets
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install YAML parser
+        shell: pwsh
+        run: Install-Module powershell-yaml -RequiredVersion 0.4.12 -Scope CurrentUser -Force
+
+      - name: Validate agents, skills, and scoped instructions
+        shell: pwsh
+        run: pwsh ./.github/scripts/Validate-CopilotAssets.ps1
+
+      - name: Test Copilot asset validator
+        shell: pwsh
+        run: pwsh ./tests/scripts/Validate-CopilotAssets.Tests.ps1
+
   build-and-measure:
     name: bicep build + size gate
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,410 +1,159 @@
-## Solution Overview
-
-This repository is an **AI Landing Zone implemented in Bicep** for Azure.
-It provides a reusable, production-oriented infrastructure baseline for AI workloads built on Microsoft Foundry and related Azure services.
-
-Primary goals:
-- Standardize secure, repeatable provisioning with `azd` + Bicep.
-- Offer modular deployment with feature flags and strong parameterization.
-- Support both quick-start and hardened network-isolated topologies.
-- Act as a reusable infra core for other accelerators and agent-based solutions.
-
-Repository:
-- https://github.com/azure/bicep-ptn-aiml-landing-zone
-
----
-
-## What To Understand First
-
-This is an IaC-first repository. Most work happens in:
-- `main.bicep`: orchestrates all resources, modules, conditions, identities, role assignments.
-- `main.parameters.json`: deployment topology, feature flags, model list, app list, networking options.
-- `modules/`: reusable custom Bicep modules for networking, security role assignment, AI Foundry connections, app config population.
-- `constants/constants.bicep`: role IDs and naming abbreviations.
-- `azure.yaml`: azd project definition (`infra.path: .`, `infra.module: main`).
-- `manifest.json`: release metadata + optional component repos + jumpbox install script source.
-- `install.ps1`: jumpbox bootstrap logic for isolated environments.
-
-If behavior changes, update Bicep and parameters consistently.
-
----
-
-## IaC Architecture and Design Patterns
-
-### 1) Single entrypoint orchestration
-- `main.bicep` is the deployment orchestrator.
-- It composes AVM modules and custom modules using feature-flag conditions (`if (...)`).
-
-### 2) Feature-flag driven composition
-Common toggles:
-- `deployAiFoundry`
-- `deployAppConfig`
-- `deployKeyVault`
-- `deploySearchService`
-- `deployStorageAccount`
-- `deployCosmosDb`
-- `deployContainerEnv`
-- `deployContainerApps`
-- `networkIsolation`
-- `useExistingVNet`
-
-Preserve this conditional model when adding resources.
-
-### 3) Strong parameterization + substitution model
-- `main.parameters.json` supports env var substitution (`"${ENV_NAME}"`) for `azd` workflows.
-- In Bicep, values that can come empty should have safe fallback handling.
-- Avoid hardcoding tenant/subscription/resource names in templates.
-
-### 4) Modular networking for Zero Trust
-- Supports public and isolated modes.
-- Isolated mode includes VNet/subnets, private DNS zones, private endpoints, and controlled dependencies.
-- PE creation is serialized in places to avoid parallel conflicts.
-
-### 5) Identity and RBAC by design
-- Supports system-assigned MI and optional UAI (`useUAI`).
-- Role assignments are explicit and centralized, including data-plane Cosmos assignments.
-
-### 6) App topology as data
-- `containerAppsList`, `modelDeploymentList`, `databaseContainersList`, `storageAccountContainersList` drive infra shape.
-- New app/model/service behavior should be added by extending these lists and mapping logic.
-
----
-
-## Current Container App Port Behavior
-
-Container app ingress and Dapr app port are parameterized per app entry:
-- `app.target_port` when provided.
-- fallback to `8080` when omitted.
-
-Pattern in `main.bicep`:
-- `ingressTargetPort: int(app.?target_port ?? 8080)`
-- `dapr.appPort: int(app.?target_port ?? 8080)`
-
-Implications:
-- If you add apps in `main.parameters.json`, you can set `target_port` explicitly.
-- If omitted, app config defaults to 8080.
-
----
-
-## Parameterization Guidance
-
-When adding new capability, follow this sequence:
-1. Add parameter in `main.bicep` with description and sensible default.
-2. Add corresponding value in `main.parameters.json` (literal or `"${ENV_VAR}"`).
-3. If substitution can resolve to empty, add fallback handling in Bicep.
-4. Wire the value to modules/resources.
-5. If runtime needs the value, publish it to App Configuration through `appConfigPopulate`.
-6. If downstream automation needs it, expose as Bicep output.
-
-Good practices:
-- Keep booleans as true/false semantics in Bicep.
-- Keep names deterministic (resource token + abbreviations).
-- Keep module params minimal but explicit.
-- Preserve idempotency.
-
----
-
-## Reusing This Landing Zone from Another Repository
-
-This section is critical for derived accelerators.
-
-### Recommended consumption model
-Use this repository as an **infra submodule** mounted at `infra/` in the consumer repo.
-
-Why:
-- Consumer gets a stable IaC core.
-- Consumer customizes only overlays (`main.parameters.json`, `manifest.json`, optional scripts).
-- Infra updates are versioned by submodule pin.
-
-### Pinning strategy for consistency
-Pin submodule to a specific landing zone release/tag.
-
-Example commands to add and pin the submodule to `v1.0.0`:
-```bash
-git submodule add https://github.com/Azure/bicep-ptn-aiml-landing-zone.git infra
-git -C infra fetch --tags
-git -C infra checkout tags/v1.0.0
-git config -f .gitmodules submodule.infra.branch v1.0.0
-git config -f .gitmodules submodule.infra.ignore dirty
-git add .gitmodules infra
-git commit -m "Add infra submodule pinned to v1.0.0"
-```
-
-Initialization command for consumers:
-```bash
-git submodule update --init --recursive
-```
-
-Example `.gitmodules` pattern:
-```ini
-[submodule "infra"]
-	path = infra
-	url = https://github.com/Azure/bicep-ptn-aiml-landing-zone.git
-	branch = v1.0.0
-	ignore = dirty
-```
-
-Notes:
-- Keep pin explicit to avoid drift between environments.
-- Treat infra version bumps as controlled upgrades.
-
-### Consumer `azure.yaml` pattern
-Use:
-- `infra.provider: bicep`
-- `infra.path: infra`
-- `infra.module: main`
-- `preprovision` hook to prepare submodule and overlays.
-
-### Preprovision mechanism (important)
-A robust preprovision hook should:
-1. Run `git submodule update --init --recursive`.
-2. Detect `azd init` ZIP scenario (no gitlink/submodule metadata in git index).
-3. If `infra/main.bicep` is missing, clone infra repo directly using `.gitmodules` URL + pinned ref.
-4. Copy consumer overlay files into `infra/`:
-   - `main.parameters.json`
-   - `manifest.json`
-
-Result:
-- Consumer-specific parameters override landing zone defaults.
-- Consumer controls component graph and release metadata without forking IaC templates.
-
----
-
-## `manifest.json` Contract and Jumpbox Bootstrap Pattern
-
-`manifest.json` in this repository currently contains:
-- landing zone release metadata (`tag`, `repo`)
-- `ailz_tag` — the landing zone release tag (used to construct the `install.ps1` URL and passed to the jumpbox script)
-- optional `components` array
-
-### Why this matters in network-isolated deployments
-When `deployVM` + `deploySoftware` are used, the VM custom script extension runs `install.ps1`.
-`install.ps1`:
-- installs tools (az, azd, git, etc.)
-- clones this repo by release
-- initializes azd environment
-- reads `manifest.json.components`
-- clones each component repo at pinned tags
-- copies `.azure` environment context into each component repo
-
-This enables post-provision work from the jumpbox where public access is constrained.
-
-### Consumer pattern for derived accelerators
-In a consumer repo, set `manifest.json` to:
-- set `ailz_tag` to the desired landing zone release tag
-- define component repos/tags the jumpbox should clone
-- keep all tags pinned for reproducibility
-
-Use this as the primary mechanism to bootstrap isolated deployments without reauthoring infra templates.
-
----
-
-## Module Map (High-Level)
-
-- `modules/ai-foundry/*`: AI Foundry account/project and service connections.
-- `modules/networking/*`: subnet, private endpoint, private DNS modules.
-- `modules/security/*`: role assignment wrappers (control-plane and Cosmos data-plane).
-- `modules/container-apps/*`: app list shaping for configuration publishing.
-- `modules/app-configuration/*`: key-value population in App Configuration.
-
-Rule:
-- Reuse existing module patterns before creating new module files.
-- Keep custom logic centralized and avoid duplicated resource blocks.
-
----
-
-## Deployment Modes
-
-### Standard mode
-- Faster setup.
-- Public networking where applicable.
-
-### Zero Trust mode
-- Enable network isolation.
-- Private DNS and private endpoints activated.
-- Jumpbox/Bastion workflow becomes central for post-provision operations.
-
-Do not mix assumptions between these modes.
-
----
-
-## Operational Commands
-
-Typical operator flow:
-```bash
-az login
-azd auth login
-azd provision
-```
-
-Parameter overrides:
-```bash
-azd env set NETWORK_ISOLATION true
-azd env set USE_UAI true
-azd env set ENABLE_AGENTIC_RETRIEVAL true
-```
-
-You can also update `main.parameters.json` directly instead of using `azd env set`.
-Use `azd env set` when you want per-environment values without editing files; use `main.parameters.json` when you want explicit, versioned defaults in source control.
-
----
-
-## Change Checklist
-
-Before submitting changes, verify:
-1. Feature flags still gate optional resources correctly.
-2. New params exist in both `main.bicep` and `main.parameters.json` when required.
-3. Network isolation path still works (private DNS/PE dependencies intact).
-4. Role assignments remain least-privilege and scoped correctly.
-5. App Configuration population includes any new runtime settings.
-6. Names remain deterministic and compliant.
-7. Changes are compatible with submodule consumer pattern.
-8. Documentation is updated for any user-visible change (see **Documentation Consistency**).
-
----
-
-## Documentation Consistency
-
-Documentation must always match the **current, shipped** implementation. Any
-change with a user-visible effect — a new/renamed feature flag or parameter, a
-changed default, new module behavior, a new deployment mode, an output
-consumers rely on, or a breaking change — MUST be documented **in the same
-change set**, never deferred.
-
-Where landing-zone documentation lives:
-
-- **In this repo (always update these in the same PR):**
-  - `README.md` — overview, parameters, feature flags, quick start.
-  - `CHANGELOG.md` — every change, under `[Unreleased]` on `develop` and the
-    versioned header on a release branch.
-  - `docs/` runbooks — `runbook-standalone.md`, `runbook-hub-spoke.md`,
-    `v2-migration.md`. Update the relevant runbook when the deployment flow,
-    topology, or migration steps change.
-- **Public AI Landing Zone site (separate repo):** the narrative published at
-  https://azure.github.io/AI-Landing-Zones/bicep is sourced from the
-  `Azure/AI-Landing-Zones` repository, where the documentation source now lives
-  on the `main` branch (the full MkDocs project under `docs/` and `mkdocs.yml`),
-  not in this repo. The site is built and published automatically to the
-  `gh-pages` branch on every push to `main`, so `gh-pages` is generated output,
-  not the source you edit. When a change alters the public bicep landing-zone
-  story (architecture, design areas, consumer-facing parameters/flags,
-  what's-new), open a **companion PR against `main` of `Azure/AI-Landing-Zones`**
-  and link it from this PR's description.
-
-Rules:
-- A change is **not done** until the matching docs are updated, or you have
-  confirmed none are affected.
-- When unsure, grep the docs/README for the flag, parameter, or output name
-  you touched and update every place it appears.
-- Treat any drift between the published site and the deployed behavior as a
-  bug, not a cosmetic issue.
-
----
-
-## Branching and Release Flow
-
-- `develop` is the integration branch for ongoing work; `main` holds released,
-  tagged versions.
-- Before starting any new work, sync `develop` with `main` first. Never branch
-  from a `develop` that is behind a shipped release. Merge or fast-forward `main`
-  into `develop`, then create your feature branch from the updated `develop`.
-- Cut releases from `main`: land the validated change on `main`, tag the exact
-  version (for example `v2.1.6`, with the tag and the GitHub release title equal
-  to the version and no product prefix), and publish notes from `CHANGELOG.md`.
-- Right after a release, reconcile `develop` so it contains everything on `main`.
-  The next feature branch must start from a state that already includes the
-  release.
-
----
-
-## Semantic Versioning and Downstream Signals
-
-This landing zone uses semantic versioning. For every change, classify the
-release impact with judgment:
-
-- **Major**: breaking parameter, output, naming, topology, or deployment
-  behavior changes.
-- **Minor**: backward-compatible features, new opt-in parameters, new modules,
-  or expanded supported scenarios.
-- **Patch**: bug fixes or internal refactors that do not add capabilities or
-  require consumers to change.
-
-When the impact is **major** or **minor**, explicitly call out that the public
-Portal experience and the Terraform landing-zone implementation need follow-up
-parity review or updates. Patch-only bug fixes do not require those downstream
-Portal/Terraform signals unless the fix changes a shared contract.
-
----
-
-## Do and Do Not
-
-Do:
-- Prefer extending parameter lists over hardcoded values.
-- Keep modules reusable and environment-agnostic.
-- Preserve compatibility for downstream repos consuming this as `infra/`.
-- Keep release pinning explicit in consumer patterns.
-
-Do not:
-- Assume a single workload topology.
-- Break fallback behavior for substituted params.
-- Couple consumer-specific app logic directly into landing zone core unless generic.
-- Remove the `manifest.json` bootstrap contract used by jumpbox automation.
-
----
-
-## External Reference for a Full Consumer Implementation
-
-For an end-to-end example of the submodule + preprovision override + manifest bootstrap pattern in practice, see:
-- https://github.com/azure/gpt-rag
-
-Use that reference to validate mechanics, but keep this repository generic and reusable.
-
-## Engineering Standards (Bicep / IaC)
-
-### Clean Code and Modularity
-
-This is an IaC-first repository in Bicep. Keep templates modular, readable, and
-reusable; avoid letting `main.bicep` or any module accumulate hardcoded,
-workload-specific logic.
-
-- Keep `main.bicep` as the orchestrator: compose AVM and custom modules under
-  feature-flag conditions (`if (...)`). Put reusable resource logic in focused
-  modules under `modules/` rather than inlining duplicated resource blocks.
-- Reuse existing module patterns and `constants/constants.bicep` (role IDs,
-  naming abbreviations) before creating new module files or literals. Avoid
-  duplication and speculative abstractions.
-- Drive infra shape from data, not branches: extend the topology lists
-  (`containerAppsList`, `modelDeploymentList`, `databaseContainersList`,
-  `storageAccountContainersList`) and their mapping logic instead of adding
-  per-workload conditionals.
-- Use clear, descriptive symbolic names for resources, modules, parameters, and
-  variables. Add a `@description` to every parameter; comment only non-obvious
-  decisions.
-- Keep module parameters minimal but explicit, and preserve idempotency.
-
-### Parameterization, Identity, and Safety
-
-- Never hardcode tenant/subscription/resource names; derive names
-  deterministically (resource token + abbreviations) and keep tenant/sub IDs
-  out of templates.
-- Add new capability in the documented sequence: parameter in `main.bicep`
-  (with description + sensible default) → value in `main.parameters.json`
-  (literal or `"${ENV_VAR}"`) → fallback handling if substitution can resolve
-  empty → wire to modules → publish to App Configuration via
-  `appConfigPopulate` if runtime needs it → expose as output if downstream
-  automation needs it.
-- Keep role assignments explicit, centralized, and least-privilege.
-- Preserve both deployment modes (Standard and Zero Trust / network isolation):
-  do not break private DNS / private endpoint dependencies or the substituted-
-  parameter fallback behavior. Keep changes compatible with the submodule
-  consumer pattern.
-
-### Validating Changes
-
-```bash
-az bicep build --file main.bicep   # lint/compile before submitting
-```
-
-End-to-end validation is `azd provision` from a consumer (e.g. the GPT-RAG
-core) with the appropriate `main.parameters.json`. Run through the **Change
-Checklist** and **Documentation Consistency** sections above before submitting.
+# AI Landing Zone engineering-agent contract
+
+This is the stable repository-wide contract for GitHub Copilot engineering
+agents. Detailed procedures belong in `.github/skills/`; file-specific rules
+belong in `.github/instructions/`.
+
+The assets under `.github/agents/` and `.github/skills/` guide engineers who
+develop and operate this repository. They do not define Microsoft Foundry
+agents, Container Apps, MCP servers, or any other deployed Azure resource.
+
+## Priority
+
+Follow, in this order:
+
+1. Security, privacy, authorization, and platform instructions.
+2. Task requirements and acceptance criteria.
+3. Executable Bicep, parameter, manifest, and pipeline contracts.
+4. `.github/copilot-instructions.md`, this contract, and applicable scoped
+   instructions.
+5. Local conventions observed in the affected files.
+
+Do not guess when missing information could affect identity, networking,
+compatibility, releases, or production. Record the uncertainty and obtain a
+human decision.
+
+## Repository purpose and boundaries
+
+This repository is a reusable Azure AI Landing Zone implemented in Bicep. It
+provides secure, parameterized infrastructure for Microsoft Foundry and related
+Azure services in standard and network-isolated deployment modes.
+
+- `main.bicep` is the resource-group-scoped orchestrator. It composes AVM and
+  local modules under feature-flag conditions.
+- `main.parameters.json` is the azd parameter and environment-substitution
+  surface.
+- `modules/` contains reusable resource logic:
+  - `ai-foundry/`: Foundry account, project, connections, and nested resources.
+  - `networking/`: VNets, subnets, NSGs, private DNS, private endpoints,
+    public ingress, Bastion, and Azure Firewall.
+  - `security/`: control-plane and Cosmos DB data-plane role assignments.
+  - `container-apps/`: app-list shaping and runtime configuration values.
+  - `app-configuration/`: App Configuration key-value population.
+  - `bing-search/`: Grounding with Bing resources.
+- `constants/` is the source for role IDs and resource abbreviations.
+- `scripts/` and `install.ps1` contain cross-platform PowerShell automation.
+- `pipelines/azuredevops/` and `.github/workflows/` contain validation and
+  deployment automation.
+- `tests/` contains deterministic preflight tests and the optional hub/spoke
+  integration fixture.
+- `manifest.json` is a release and jumpbox-bootstrap contract. Consumers may
+  extend its pinned `components` list.
+
+Keep `main.bicep` as the orchestrator. Add reusable resource bodies to focused
+modules rather than duplicating them inline. Drive deployment shape from
+`containerAppsList`, `modelDeploymentList`, `databaseContainersList`,
+`storageAccountContainersList`, and related data structures instead of
+workload-specific branches.
+
+## Compatibility and parameterization
+
+- Preserve feature-flag gating and the distinction between standard and Zero
+  Trust/network-isolated deployments.
+- Preserve nullable fallback behavior for substituted values. A value that azd
+  can replace with an empty string must have a safe Bicep fallback before it
+  reaches a resource property.
+- Add capabilities in this order: described Bicep parameter, matching parameter
+  file value, empty-substitution fallback when needed, module/resource wiring,
+  App Configuration publication when runtime consumers need it, and an output
+  when downstream automation needs it.
+- Treat parameter names, defaults, allowed values, output names, manifest
+  fields, App Configuration keys, and module interfaces as compatibility
+  contracts. Prefer additive changes and document migration for breaking ones.
+- Preserve `app.target_port` for ingress and Dapr, with `8080` as the fallback.
+- Preserve compatibility for consumers that mount this repository at `infra/`
+  and overlay `main.parameters.json` and `manifest.json`.
+
+## Identity, networking, and naming
+
+- Prefer managed identity and least-privilege RBAC. Keep role assignments
+  explicit and centralized through `modules/security/`.
+- Read role IDs and abbreviations from `constants/`; do not duplicate literals.
+- Never hardcode tenant IDs, subscription IDs, credentials, or environment-
+  specific resource names.
+- Preserve both CAF and legacy naming modes. Explicit resource-name parameters
+  override generated names in both modes.
+- Treat private DNS, private endpoint ordering, subnet delegation and sizing,
+  hub/spoke peering, route tables, and public-network-access decisions as
+  security-sensitive contracts.
+- Keep private endpoint creation and dependencies serialized where the existing
+  topology requires it.
+
+## PowerShell and deployment automation
+
+- PowerShell 7 is the shared script runtime on Windows and POSIX azd hooks.
+- Quote external input, avoid logging secrets, fail explicitly on unmet
+  prerequisites, and preserve idempotency.
+- `install.ps1` runs under the Windows Custom Script Extension's fixed timeout.
+  Preserve its wall-clock budgets, fatal/optional step distinction, and bounded
+  network operations.
+- Azure DevOps deploy steps use Bash inside pipeline YAML. When shared behavior
+  changes, keep pipeline and PowerShell semantics aligned where applicable.
+- What-If or `azd provision --preview` is evidence, not authorization to deploy.
+  Never provision, tag, release, or modify production without explicit approval.
+
+## Validation and evidence
+
+Run the narrowest existing validation that covers the change, then broaden with
+risk:
+
+- Copilot assets:
+  `pwsh ./.github/scripts/Validate-CopilotAssets.ps1`
+- Validator tests:
+  `pwsh ./tests/scripts/Validate-CopilotAssets.Tests.ps1`
+- Bicep compile/lint:
+  `az bicep build --file main.bicep` and
+  `az bicep lint --file main.bicep`
+- Compiled-template size:
+  `pwsh ./scripts/Measure-MainJsonSize.ps1`
+- Deterministic preflight tests:
+  `pwsh ./tests/scripts/Invoke-PreflightChecks.Tests.ps1`
+- Azure-aware preflight:
+  `pwsh ./scripts/Invoke-PreflightChecks.ps1`
+- Deployment preview:
+  `azd provision --preview`
+- End-to-end validation:
+  `azd provision` in an approved test environment.
+
+Do not invent validation commands or claim Azure behavior from compilation
+alone. Report commands, results, skipped validation, and residual risk.
+
+## Architecture, documentation, and releases
+
+Load `engineering-principles` for design, meaningful refactoring, Azure
+integration, security, testing, or operational changes. Load
+`architecture-decision` for hard-to-reverse changes to boundaries, contracts,
+identity, topology, or deployment behavior.
+
+Use `documentation-consistency` whenever behavior, parameters, defaults,
+outputs, deployment modes, or operator steps change. Keep `README.md`,
+`CHANGELOG.md`, relevant `docs/` runbooks, and the public
+`Azure/AI-Landing-Zones` documentation aligned with shipped behavior.
+
+This repository uses semantic versioning. `main` holds released versions and
+`develop` is the integration branch when present. Before feature work, ensure
+the integration branch includes the latest release from `main`. Release tags
+and GitHub Release titles use exactly `vMAJOR.MINOR.PATCH`; keep
+`manifest.json`, changelog, tag, and release title aligned. Major or minor
+changes require Portal and Terraform landing-zone parity review.
+
+## Collaboration and handoffs
+
+- Agents deliver decisions, changed contracts, evidence, documentation status,
+  rollback guidance, and residual risks rather than activity summaries.
+- Architecture hands implementation explicit boundaries, trade-offs, fitness
+  functions, migration constraints, and open questions.
+- Implementation hands validation the changed behavior, affected files,
+  expected compatibility, and required evidence.
+- Validation hands release reproducible commands and results, not assumptions.
+- Release and production operations require explicit human approval.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.  
 This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- **GitHub Copilot engineering-agent framework.** Added a concise repository
+  operating contract, specialized architecture, implementation, validation,
+  operations, and release agents, reusable Bicep/Azure-IaC skills, path-scoped
+  instructions, and PowerShell-native YAML frontmatter/link validation in CI.
+  These assets guide repository development and operations only; they do not
+  change deployed resources, Microsoft Foundry agents, Bicep contracts,
+  parameters, scripts, or landing-zone behavior.
+
 ## [v2.3.0] - 2026-07-02
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,3 +7,25 @@ This repository follows the [Microsoft Open Source Code of Conduct](https://open
 Before contributing, you may also be asked to sign a Contributor License Agreement (CLA). You can find more details at [https://cla.opensource.microsoft.com](https://cla.opensource.microsoft.com).
 
 If you are unsure whether your change fits the current roadmap or release train, start by reviewing the contributing guide above and then open a GitHub issue or discussion in this repository to validate your proposal.
+
+## Engineering guidance
+
+Repository-wide engineering rules are in [AGENTS.md](AGENTS.md). GitHub Copilot
+specialists, reusable skills, and file-scoped instructions live under
+`.github/`.
+
+For changes to these declarative engineering assets, install the pinned
+PowerShell YAML parser and run:
+
+```pwsh
+Install-Module powershell-yaml -RequiredVersion 0.4.12 -Scope CurrentUser
+pwsh ./.github/scripts/Validate-CopilotAssets.ps1
+pwsh ./tests/scripts/Validate-CopilotAssets.Tests.ps1
+```
+
+Bicep changes must also pass:
+
+```pwsh
+az bicep build --file main.bicep
+az bicep lint --file main.bicep
+```

--- a/tests/scripts/Validate-CopilotAssets.Tests.ps1
+++ b/tests/scripts/Validate-CopilotAssets.Tests.ps1
@@ -1,0 +1,84 @@
+<#
+.SYNOPSIS
+    Fixture tests for .github/scripts/Validate-CopilotAssets.ps1.
+#>
+
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+$validator = (Resolve-Path (Join-Path $PSScriptRoot '..\..\.github\scripts\Validate-CopilotAssets.ps1')).Path
+$tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("copilot-assets-{0}" -f [guid]::NewGuid())
+$failures = 0
+
+function Set-FixtureFile {
+    param([string]$RelativePath, [string]$Content)
+    $path = Join-Path $tempRoot $RelativePath
+    New-Item -ItemType Directory -Path (Split-Path $path -Parent) -Force | Out-Null
+    Set-Content -Path $path -Value $Content -Encoding utf8
+}
+
+function Invoke-Validator {
+    $output = & pwsh -NoProfile -File $validator -Root $tempRoot 2>&1 | Out-String
+    [pscustomobject]@{ ExitCode = $LASTEXITCODE; Output = $output }
+}
+
+function Assert-Result {
+    param([string]$Name, [bool]$Condition, [string]$Detail)
+    if ($Condition) {
+        Write-Host "  [PASS] $Name" -ForegroundColor Green
+    }
+    else {
+        Write-Host "  [FAIL] $Name - $Detail" -ForegroundColor Red
+        $script:failures++
+    }
+}
+
+try {
+    Set-FixtureFile '.github/agents/implementation.agent.md' @'
+---
+name: implementation
+description: Implements a fixture.
+tools: ["read", "edit"]
+---
+# Implementation
+'@
+    Set-FixtureFile '.github/skills/example/SKILL.md' @'
+---
+name: example
+description: Exercises a fixture.
+---
+# Example
+[Reference](references/example.md)
+'@
+    Set-FixtureFile '.github/skills/example/references/example.md' '# Reference'
+    Set-FixtureFile '.github/instructions/example.instructions.md' @'
+---
+applyTo: "**/*.bicep"
+---
+# Example
+'@
+
+    $valid = Invoke-Validator
+    Assert-Result 'Valid assets pass' ($valid.ExitCode -eq 0) $valid.Output
+
+    Set-FixtureFile '.github/agents/duplicate.agent.md' @'
+---
+name: implementation
+description: Duplicates a fixture.
+tools: ["read", "unknown"]
+---
+# Duplicate
+'@
+    $invalid = Invoke-Validator
+    Assert-Result 'Duplicate names fail' ($invalid.ExitCode -ne 0 -and $invalid.Output -match 'duplicate agent') $invalid.Output
+    Assert-Result 'Unsupported tools fail' ($invalid.ExitCode -ne 0 -and $invalid.Output -match 'unsupported tool aliases') $invalid.Output
+}
+finally {
+    Remove-Item -Path $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+if ($failures -gt 0) {
+    exit 1
+}
+exit 0


### PR DESCRIPTION
## Purpose

Adopt the GitHub Copilot engineering-agent framework merged into Azure/GPT-RAG by PR #577, adapted for this Bicep/Azure-IaC repository.

This change adds a concise operating contract, specialized engineering agents, reusable skills, scoped instructions, and PowerShell-native declarative asset validation. It does not change deployed resources, Bicep contracts, parameters, modules, scripts, or landing-zone product behavior.

This PR targets `main` under the explicitly authorized direct-main exception for this task.

## Validation

- `pwsh ./.github/scripts/Validate-CopilotAssets.ps1`
- `pwsh ./tests/scripts/Validate-CopilotAssets.Tests.ps1`
- `pwsh ./tests/scripts/Invoke-PreflightChecks.Tests.ps1` (34 passed)
- `bicep build main.bicep --stdout`
- `bicep lint main.bicep` (existing warnings only)
- Parsed `.github/workflows/bicep-validate.yml` with powershell-yaml 0.4.12
- `git diff --check`

## Documentation

Updated `AGENTS.md`, `CONTRIBUTING.md`, `CHANGELOG.md`, and the pull request template. No public landing-zone product documentation change is required because runtime and deployment behavior are unchanged.

## Release impact

Patch-level repository engineering/tooling change. No Portal or Terraform parity update is required.