### PR TITLE
chore(release): v2.4.1

### DIFF
--- a/.github/workflows/bicep-validate.yml
+++ b/.github/workflows/bicep-validate.yml
@@ -100,6 +100,10 @@ jobs:
           az bicep install --version v0.42.1
           pwsh ./tests/contracts/Test-HostedAgentContract.ps1
 
+      - name: Validate ACR Task agent pool firewall contract
+        shell: pwsh
+        run: pwsh ./tests/contracts/Test-AcrTaskAgentPoolFirewallContract.ps1
+
       - name: Run deterministic preflight tests
         shell: pwsh
         run: pwsh ./tests/scripts/Invoke-PreflightChecks.Tests.ps1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
 
 ## [Unreleased]
 
+### Fixed
+
+- **ACR Task agent pool now provisions successfully with VNet injection under `NETWORK_ISOLATION=true`.** The Azure Firewall Policy on the devops build agents subnet only allowed Application/FQDN rules, but ACR Tasks dedicated agent pools require unconditional outbound Network Rules for their own platform bootstrap traffic (not just the task's own build-time egress). Added a `deployAcrTaskAgentPool`-gated Network Rule Collection Group granting the pool's subnet outbound access to `AzureKeyVault`, `Storage`, `EventHub`, `AzureActiveDirectory` (443), and `AzureMonitor` (443, 12000), matching Microsoft's documented ACR Tasks agent pool network requirements. Previously the pool failed to provision every time when VNet-injected (6/6 in the reporter's environment); confirmed live in a disposable network-isolated deployment that the pool now reaches `Succeeded` on first attempt, with the private endpoint reachable (DNS + TCP 443) from its subnet and all FQDN rules required for a private build (base image pulls, ACR data plane, task dispatch) already present and correctly scoped. See [Azure/GPT-RAG#597](https://github.com/Azure/GPT-RAG/issues/597).
+- **Firewall policy rule collection groups no longer race the Azure Firewall resource's own provisioning.** The chained `ruleCollectionGroups` (Default → ACS media → ACR Task agent pool) only depended on each other and on the firewall policy, not on the `azureFirewall` resource itself, which can take 10–25 minutes to finish associating on a fresh deployment. On cold deployments the last group in the chain could reach Azure Resource Manager before the firewall finished provisioning and be rejected with `FirewallPolicyUpdateFailed` ("faulted referenced firewalls"), leaving the policy — and the newly added ACR Task agent pool rules — in a `Failed` state even though the pool itself could still show `Succeeded`. The ACR Task agent pool rule collection group now also depends on `azureFirewall`, guaranteeing deterministic, first-attempt success. Confirmed live in a disposable network-isolated deployment: the policy and rule collection group both reached `Succeeded` after the fix, versus `Failed` before it.
+
 ## [v2.4.0] - 2026-07-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
 
 ## [Unreleased]
 
+## [v2.4.1] - 2026-08-03
+
 ### Fixed
 
 - **ACR Task agent pool now provisions successfully with VNet injection under `NETWORK_ISOLATION=true`.** The Azure Firewall Policy on the devops build agents subnet only allowed Application/FQDN rules, but ACR Tasks dedicated agent pools require unconditional outbound Network Rules for their own platform bootstrap traffic (not just the task's own build-time egress). Added a `deployAcrTaskAgentPool`-gated Network Rule Collection Group granting the pool's subnet outbound access to `AzureKeyVault`, `Storage`, `EventHub`, `AzureActiveDirectory` (443), and `AzureMonitor` (443, 12000), matching Microsoft's documented ACR Tasks agent pool network requirements. Previously the pool failed to provision every time when VNet-injected (6/6 in the reporter's environment); confirmed live in a disposable network-isolated deployment that the pool now reaches `Succeeded` on first attempt, with the private endpoint reachable (DNS + TCP 443) from its subnet and all FQDN rules required for a private build (base image pulls, ACR data plane, task dispatch) already present and correctly scoped. See [Azure/GPT-RAG#597](https://github.com/Azure/GPT-RAG/issues/597).

--- a/README.md
+++ b/README.md
@@ -231,6 +231,22 @@ If your application build needs additional HTTPS endpoints, add them to the `add
 
 Set `extendFirewallForJumpboxBootstrap=false` to skip the jumpbox-scoped rules when egress is managed centrally by another policy.
 
+##### ACR Task agent pool platform Network Rules
+
+The table above lists Application (FQDN) rules. The dedicated ACR Tasks agent
+pool additionally requires unconditional outbound **Network Rules** (service
+tags, not FQDNs) for its own platform bootstrap traffic — this is a
+requirement of the agent pool control plane itself, independent of what a
+build script does. When `networkIsolation`, `deployAzureFirewall`, and
+`deployAcrTaskAgentPool` are all enabled, the landing zone adds a
+`AllowAcrTaskAgentPoolPlatform` Network Rule Collection scoped to
+`devopsBuildAgentsSubnetPrefix`, allowing outbound TCP 443 to `AzureKeyVault`,
+`Storage`, `EventHub`, and `AzureActiveDirectory`, and TCP 443/12000 to
+`AzureMonitor`, matching the [documented ACR Tasks agent pool network
+requirements](https://learn.microsoft.com/en-us/azure/container-registry/tasks-agent-pools).
+Without these Network Rules the agent pool fails to provision when
+VNet-injected (see [Azure/GPT-RAG#597](https://github.com/Azure/GPT-RAG/issues/597)).
+
 ### AI Foundry deployment modes
 
 `deployAiFoundry` controls the base AI Foundry account, project, and model deployments. `deployAAfAgentSvc` controls the Agent Service Standard Setup and its associated AI Search, Storage, Cosmos DB, and Key Vault resources. `deploySearchService` controls only the workload/RAG Azure AI Search service used by applications.

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
-  "tag": "v2.4.0",
+  "tag": "v2.4.1",
   "repo": "https://github.com/azure/bicep-ptn-aiml-landing-zone.git",
-  "ailz_tag": "v2.4.0",
+  "ailz_tag": "v2.4.1",
   "components": []
 }

--- a/modules/networking/azure-firewall.bicep
+++ b/modules/networking/azure-firewall.bicep
@@ -401,6 +401,81 @@ var _firewallAcsMediaRuleCollections = [
   }
 ]
 
+// ACR Task agent pool platform-bootstrap network rules (fixes Azure/GPT-RAG#597
+// Defect C). These are required for the agent pool itself to provision and
+// scale inside the VNet — independent of what a queued build later needs
+// (see the AllowAcrTasks / AllowAcrTaskDevRuntimes / AllowAcrTaskOsPackages
+// ApplicationRules above, which only cover build-time egress). Per Microsoft
+// Learn "Run an Azure Container Registry task on a dedicated agent pool >
+// Create pool in a virtual network > Add firewall rules", the pool's own
+// platform bootstrap requires outbound TCP 443 (plus 12000 for Azure Monitor
+// diagnostics) to five service tags: AzureKeyVault, Storage, EventHub,
+// AzureActiveDirectory, AzureMonitor.
+// https://learn.microsoft.com/azure/container-registry/tasks-agent-pools#add-firewall-rules
+//
+// These are IP/service-tag-based control-plane calls, not FQDN-addressable
+// HTTP(S) application traffic, so Azure Firewall ApplicationRules (which only
+// inspect HTTP(S) FQDNs) cannot express them — they require NetworkRules
+// with `destinationAddresses` set to service tags. Without this collection,
+// the agent pool's platform bootstrap traffic is silently dropped by the
+// firewall's default-deny and the VNet-injected pool never reaches
+// Succeeded, while the same pool without VNet injection (no route through
+// this firewall) provisions immediately.
+var _firewallAcrTaskAgentPoolNetworkRules = [
+  {
+    ruleType: 'NetworkRule'
+    name: 'AllowAcrTaskAgentPoolKeyVault'
+    ipProtocols: ['TCP']
+    sourceAddresses: [devopsBuildAgentsSubnetPrefix]
+    destinationAddresses: ['AzureKeyVault']
+    destinationPorts: ['443']
+  }
+  {
+    ruleType: 'NetworkRule'
+    name: 'AllowAcrTaskAgentPoolStorage'
+    ipProtocols: ['TCP']
+    sourceAddresses: [devopsBuildAgentsSubnetPrefix]
+    destinationAddresses: ['Storage']
+    destinationPorts: ['443']
+  }
+  {
+    ruleType: 'NetworkRule'
+    name: 'AllowAcrTaskAgentPoolEventHub'
+    ipProtocols: ['TCP']
+    sourceAddresses: [devopsBuildAgentsSubnetPrefix]
+    destinationAddresses: ['EventHub']
+    destinationPorts: ['443']
+  }
+  {
+    ruleType: 'NetworkRule'
+    name: 'AllowAcrTaskAgentPoolAzureAD'
+    ipProtocols: ['TCP']
+    sourceAddresses: [devopsBuildAgentsSubnetPrefix]
+    destinationAddresses: ['AzureActiveDirectory']
+    destinationPorts: ['443']
+  }
+  {
+    ruleType: 'NetworkRule'
+    name: 'AllowAcrTaskAgentPoolMonitor'
+    ipProtocols: ['TCP']
+    sourceAddresses: [devopsBuildAgentsSubnetPrefix]
+    destinationAddresses: ['AzureMonitor']
+    destinationPorts: ['443', '12000']
+  }
+]
+
+var _firewallAcrTaskAgentPoolRuleCollections = [
+  {
+    ruleCollectionType: 'FirewallPolicyFilterRuleCollection'
+    name: 'AllowAcrTaskAgentPoolPlatform'
+    priority: 100
+    action: {
+      type: 'Allow'
+    }
+    rules: _firewallAcrTaskAgentPoolNetworkRules
+  }
+]
+
 // Azure Firewall for egress traffic control
 ///////////////////////////////////////////////////////////////////////////
 
@@ -461,6 +536,45 @@ resource firewallPolicyAcsMediaRuleCollectionGroup 'Microsoft.Network/firewallPo
   }
   dependsOn: [
     firewallPolicyDefaultRuleCollectionGroup
+  ]
+}
+
+// ACR Task agent pool platform-bootstrap network rules — separate rule
+// collection group (mirrors the AcsMedia pattern) so it toggles independently
+// via `deployAcrTaskAgentPool` without shifting the default group's priority.
+// Chained after both prior groups: concurrent PUTs against sibling
+// ruleCollectionGroups under the same firewallPolicy can 409
+// (AnotherOperationInProgress), so every group in this module is serialized.
+// The AcsMedia dependency is unconditional here by design — Azure Resource
+// Manager automatically drops an explicit dependsOn entry at deployment time
+// when the referenced resource's own `if` condition evaluates to false (see
+// https://learn.microsoft.com/azure/azure-resource-manager/bicep/conditional-resource-deployment#new-or-existing-resource),
+// so no ternary/null-guard is needed even when `enableAcsMediaEgress` is false.
+//
+// Explicit `azureFirewall` dependency: on a fresh/cold deployment, without
+// this, ARM has no ordering constraint between the ruleCollectionGroup chain
+// and the azureFirewall resource itself (both only depend on firewallPolicy),
+// so the chain can race the firewall's own ~10-25 minute provisioning. Live
+// validation of this fix (disposable eastus2 deployment, Azure/GPT-RAG#597)
+// observed exactly this: this group's PUT was rejected with
+// `FirewallPolicyUpdateFailed` / "1 faulted referenced firewalls" because the
+// azureFirewall resource hadn't finished associating yet, even though the
+// chained DefaultRuleCollectionGroup PUT ahead of it happened to complete in
+// time. Depending directly on azureFirewall guarantees this group's rules are
+// only applied once the firewall itself is fully provisioned, so the pool's
+// platform-bootstrap traffic is reliably unblocked on the very first
+// deployment attempt.
+resource firewallPolicyAcrTaskAgentPoolRuleCollectionGroup 'Microsoft.Network/firewallPolicies/ruleCollectionGroups@2024-07-01' = if (deployAzureFirewall && networkIsolation && deployAcrTaskAgentPool) {
+  parent: firewallPolicy
+  name: 'AcrTaskAgentPoolRuleCollectionGroup'
+  properties: {
+    priority: 250
+    ruleCollections: _firewallAcrTaskAgentPoolRuleCollections
+  }
+  dependsOn: [
+    firewallPolicyDefaultRuleCollectionGroup
+    firewallPolicyAcsMediaRuleCollectionGroup
+    azureFirewall
   ]
 }
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -26,6 +26,7 @@ tests/
 ├── README.md                 (this file)
 ├── contracts/
 │   ├── Test-HostedAgentContract.ps1
+│   ├── Test-AcrTaskAgentPoolFirewallContract.ps1
 │   └── fixtures/
 │       └── hosted-agent-resource-graph.json
 ├── hub/
@@ -43,6 +44,7 @@ Run from the repository root:
 
 ```pwsh
 pwsh tests/contracts/Test-HostedAgentContract.ps1
+pwsh tests/contracts/Test-AcrTaskAgentPoolFirewallContract.ps1
 pwsh tests/scripts/Invoke-PreflightChecks.Tests.ps1
 ```
 
@@ -51,7 +53,12 @@ fixture and proves that the default-disabled feature preserves every symbolic
 resource from the merge base. It permits changes only in the two centralized
 RBAC deployment payloads and checks that those additions are
 `deployHostedAgent`-gated, least privilege, and accompanied by the stable
-Foundry/registry handoff. The deterministic preflight tests cover disabled,
+Foundry/registry handoff. The ACR Task agent pool firewall contract test
+(Azure/GPT-RAG#597) asserts that the VNet-injected ACR Tasks dedicated agent
+pool's required outbound platform-bootstrap Network Rules (AzureKeyVault,
+Storage, EventHub, AzureActiveDirectory, AzureMonitor) are present, correctly
+gated, ordered, and scoped to the devops build agents subnet — independent of
+the opaque hash check above. The deterministic preflight tests cover disabled,
 valid, mutable-image, and missing-prerequisite configurations without accessing
 Azure.
 

--- a/tests/contracts/Test-AcrTaskAgentPoolFirewallContract.ps1
+++ b/tests/contracts/Test-AcrTaskAgentPoolFirewallContract.ps1
@@ -1,0 +1,207 @@
+<#
+.SYNOPSIS
+    Validates the ACR Task agent pool VNet-injection firewall contract.
+
+.DESCRIPTION
+    Regression test for the defect reported in Azure/GPT-RAG#597: an ACR Tasks
+    dedicated agent pool injected into `devopsBuildAgentsSubnet` failed to
+    provision 6/6 times behind Azure Firewall, because the subnet's firewall
+    policy contained only Application (FQDN) rules and no Network Rules for
+    the agent pool's own platform-bootstrap traffic. ACR Tasks agent pools
+    require unconditional outbound Network Rules to five Azure service tags
+    (AzureKeyVault, Storage, EventHub, AzureActiveDirectory, AzureMonitor) —
+    see https://learn.microsoft.com/azure/container-registry/tasks-agent-pools.
+
+    This test compiles main.bicep and asserts, independent of the hosted-agent
+    hash fixture, that:
+      - A dedicated `ruleCollectionGroups` child resource exists for the ACR
+        Task agent pool platform-bootstrap rules, gated on
+        `deployAzureFirewall && networkIsolation && deployAcrTaskAgentPool`.
+      - It is chained (via dependsOn) after the default and ACS-media groups
+        to serialize concurrent rule-collection-group PUTs against the same
+        firewall policy (avoids AnotherOperationInProgress 409s).
+      - Its rule collection contains exactly five `NetworkRule` entries (not
+        ApplicationRule/FQDN rules), sourced from the devops build agents
+        subnet, targeting the five required service tags on the required
+        ports (443 for all; 443+12000 for AzureMonitor).
+#>
+
+[CmdletBinding()]
+param(
+    [string]$MainFile = (Join-Path (Split-Path -Parent (Split-Path -Parent $PSScriptRoot)) 'main.bicep')
+)
+
+$ErrorActionPreference = 'Stop'
+$failures = [System.Collections.Generic.List[string]]::new()
+$compiledFile = Join-Path ([System.IO.Path]::GetTempPath()) "acr-task-agent-pool-firewall-contract-$([guid]::NewGuid()).json"
+
+function Add-Failure {
+    param([Parameter(Mandatory)] [string]$Message)
+    $failures.Add($Message) | Out-Null
+    Write-Host "  [FAIL] $Message" -ForegroundColor Red
+}
+
+function Add-Pass {
+    param([Parameter(Mandatory)] [string]$Message)
+    Write-Host "  [PASS] $Message" -ForegroundColor Green
+}
+
+try {
+    if (Get-Command az -ErrorAction SilentlyContinue) {
+        $env:PYTHONIOENCODING = 'utf-8'
+        & az bicep build --file $MainFile --outfile $compiledFile
+    }
+    elseif (Get-Command bicep -ErrorAction SilentlyContinue) {
+        & bicep build $MainFile --outfile $compiledFile
+    }
+    else {
+        throw 'Neither bicep nor az is available on PATH.'
+    }
+    if ($LASTEXITCODE -ne 0) {
+        throw "Bicep compilation failed with exit code $LASTEXITCODE."
+    }
+    $template = Get-Content -LiteralPath $compiledFile -Raw | ConvertFrom-Json -Depth 100
+
+    Write-Host 'ACR Task agent pool firewall contract (Azure/GPT-RAG#597)' -ForegroundColor Cyan
+
+    $firewallModule = $template.resources.firewall
+    if ($null -eq $firewallModule) {
+        Add-Failure "Symbolic resource 'firewall' not found in the compiled template."
+    }
+    else {
+        $nestedResources = $firewallModule.properties.template.resources
+        $ruleCollectionGroup = $nestedResources.firewallPolicyAcrTaskAgentPoolRuleCollectionGroup
+
+        if ($null -eq $ruleCollectionGroup) {
+            Add-Failure "Resource 'firewallPolicyAcrTaskAgentPoolRuleCollectionGroup' is missing from the firewall module."
+        }
+        else {
+            $condition = [string]$ruleCollectionGroup.condition
+            $requiredConditionTokens = @(
+                "parameters('deployAzureFirewall')",
+                "parameters('networkIsolation')",
+                "parameters('deployAcrTaskAgentPool')"
+            )
+            $missingConditionTokens = @($requiredConditionTokens | Where-Object { -not $condition.Contains($_) })
+            if ($missingConditionTokens.Count -gt 0) {
+                Add-Failure "Rule collection group condition is missing required gating on: $($missingConditionTokens -join ', ')."
+            }
+            else {
+                Add-Pass 'Rule collection group is gated on deployAzureFirewall, networkIsolation, and deployAcrTaskAgentPool.'
+            }
+
+            $dependsOn = @($ruleCollectionGroup.dependsOn)
+            $requiredDependencies = @('firewallPolicyDefaultRuleCollectionGroup', 'firewallPolicyAcsMediaRuleCollectionGroup')
+            $missingDependencies = @($requiredDependencies | Where-Object { $_ -notin $dependsOn })
+            if ($missingDependencies.Count -gt 0) {
+                Add-Failure "Rule collection group is missing serialization dependsOn entries: $($missingDependencies -join ', ')."
+            }
+            else {
+                Add-Pass 'Rule collection group is chained after the default and ACS-media groups to serialize firewall policy PUTs.'
+            }
+
+            $priority = [int]$ruleCollectionGroup.properties.priority
+            if ($priority -lt 200) {
+                Add-Failure "Rule collection group priority must be a distinct integer greater than the default group's priority (200); got $priority."
+            }
+            else {
+                Add-Pass "Rule collection group priority ($priority) is distinct and ordered after the default group."
+            }
+
+            $ruleCollectionsExpr = [string]$ruleCollectionGroup.properties.ruleCollections
+            if ($ruleCollectionsExpr -notmatch "variables\('(?<varName>[^']+)'\)") {
+                Add-Failure "Unable to resolve the rule collections variable reference from: $ruleCollectionsExpr"
+            }
+            else {
+                $ruleCollectionsVarName = $Matches.varName
+                $ruleCollectionsValue = $firewallModule.properties.template.variables.$ruleCollectionsVarName
+                if ($null -eq $ruleCollectionsValue) {
+                    Add-Failure "Rule collections variable '$ruleCollectionsVarName' not found in the firewall module."
+                }
+                else {
+                    $collection = if ($ruleCollectionsValue -is [System.Collections.IEnumerable] -and $ruleCollectionsValue -isnot [string]) {
+                        @($ruleCollectionsValue)[0]
+                    }
+                    else {
+                        $ruleCollectionsValue
+                    }
+                    if ($collection.ruleCollectionType -ne 'FirewallPolicyFilterRuleCollection') {
+                        Add-Failure "Expected a FirewallPolicyFilterRuleCollection, got '$($collection.ruleCollectionType)'."
+                    }
+                    elseif ($collection.action.type -ne 'Allow') {
+                        Add-Failure "Expected the rule collection action to be 'Allow', got '$($collection.action.type)'."
+                    }
+                    else {
+                        Add-Pass "Rule collection '$($collection.name)' is a FirewallPolicyFilterRuleCollection with an Allow action."
+                    }
+
+                    $rulesExpr = [string]$collection.rules
+                    if ($rulesExpr -notmatch "variables\('(?<varName>[^']+)'\)") {
+                        Add-Failure "Unable to resolve the network rules variable reference from: $rulesExpr"
+                    }
+                    else {
+                        $rules = @($firewallModule.properties.template.variables.($Matches.varName))
+
+                        $expectedDestinations = [ordered]@{
+                            AzureKeyVault         = @('443')
+                            Storage               = @('443')
+                            EventHub              = @('443')
+                            AzureActiveDirectory  = @('443')
+                            AzureMonitor          = @('443', '12000')
+                        }
+
+                        $nonNetworkRules = @($rules | Where-Object { $_.ruleType -ne 'NetworkRule' })
+                        if ($nonNetworkRules.Count -gt 0) {
+                            Add-Failure "All ACR Task agent pool platform rules must be NetworkRule (not Application/FQDN) rules; found: $($nonNetworkRules.ruleType -join ', ')."
+                        }
+                        else {
+                            Add-Pass "All $($rules.Count) platform-bootstrap rules are NetworkRule (service-tag/IP) rules, not Application/FQDN rules."
+                        }
+
+                        $rulesBySourceOk = @($rules | Where-Object {
+                                @($_.sourceAddresses) -notcontains "[parameters('devopsBuildAgentsSubnetPrefix')]"
+                            })
+                        if ($rulesBySourceOk.Count -gt 0) {
+                            Add-Failure "$($rulesBySourceOk.Count) rule(s) do not source from the devops build agents subnet prefix parameter."
+                        }
+                        else {
+                            Add-Pass 'All platform-bootstrap rules source from the devops build agents subnet prefix.'
+                        }
+
+                        $missingDestinations = [System.Collections.Generic.List[string]]::new()
+                        foreach ($destination in $expectedDestinations.Keys) {
+                            $matchingRule = $rules | Where-Object { @($_.destinationAddresses) -contains $destination } | Select-Object -First 1
+                            if ($null -eq $matchingRule) {
+                                $missingDestinations.Add($destination)
+                                continue
+                            }
+                            $expectedPorts = $expectedDestinations[$destination]
+                            $actualPorts = @($matchingRule.destinationPorts)
+                            $missingPorts = @($expectedPorts | Where-Object { $_ -notin $actualPorts })
+                            if ($missingPorts.Count -gt 0) {
+                                Add-Failure "Service tag '$destination' is missing required destination port(s): $($missingPorts -join ', ')."
+                            }
+                        }
+                        if ($missingDestinations.Count -gt 0) {
+                            Add-Failure "Missing required ACR Task agent pool platform service tag(s): $($missingDestinations -join ', ')."
+                        }
+                        elseif (-not ($failures | Where-Object { $_ -like "Service tag*" })) {
+                            Add-Pass "All 5 required service tags (AzureKeyVault, Storage, EventHub, AzureActiveDirectory, AzureMonitor) are present with correct ports."
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+finally {
+    Remove-Item -LiteralPath $compiledFile -Force -ErrorAction SilentlyContinue
+}
+
+if ($failures.Count -gt 0) {
+    Write-Host "`n$($failures.Count) ACR Task agent pool firewall contract check(s) failed." -ForegroundColor Red
+    exit 1
+}
+
+Write-Host "`nACR Task agent pool firewall contract checks passed." -ForegroundColor Green
+exit 0

--- a/tests/contracts/fixtures/hosted-agent-resource-graph.json
+++ b/tests/contracts/fixtures/hosted-agent-resource-graph.json
@@ -44,7 +44,7 @@
     "cosmosUAI": "bff222fc0b7eff680da379f9d77a5e1c3a51a6989cf7fed2dfb78e281500a0c8",
     "cse": "ae0154aeb6b82cd73676fac0cff574759fec6ca9826a8802a6e251b81fbaf7d7",
     "defaultRoute": "c8d5c02dd7d46498383ec26a6223b65d5ced5ce16dac040c3d021dd09de037f4",
-    "firewall": "f64a6e8a0e6d4fc7bf56df45db4bfe8f7822ca097f1401dc87f993d23dbdfe5c",
+    "firewall": "ed09d0945553c012d6e64eb30bbb739f5e5054de40c4e5b05d89c69a80dcb250",
     "keyVault": "2ee3646d319840a1f11019fc0d16ce4ab65913ccec4a9434e924905e78ce4e64",
     "logAnalytics": "ad997382b80ed1ebe60ad1ba2d08be63d5938d1fa3ae494f93097294f44988ad",
     "natGateway": "87b0b3a51cdc91f58b8a973bdf980b32e82f88065af140a4f5bc0d73a6517985",


### PR DESCRIPTION
## Purpose

Publish v2.4.1 from the reconciled release line. This backward-compatible **patch** release fixes the ACR Task agent pool VNet-injection provisioning failure reported in Azure/GPT-RAG#597 (merged to develop in #124).

The release commit changes only CHANGELOG.md and manifest.json; 	ag and ilz_tag are aligned to 2.4.1.

## Type of change

- [x] Bug fix
- [x] Other: semantic release artifacts

## Related Backlog Item or Issue

- #124
- Azure/GPT-RAG#597

## Summary of fix (from #124)

Two root causes were found and fixed in \modules/networking/azure-firewall.bicep\:

1. **Missing ACR Task agent pool platform Network Rules.** ACR Tasks dedicated agent pools require unconditional outbound Network Rules (not Application/FQDN rules) to 5 Azure service tags (\AzureKeyVault\, \Storage\, \EventHub\, \AzureActiveDirectory\, \AzureMonitor\) for their own platform bootstrap traffic, per [Microsoft's documented requirements](https://learn.microsoft.com/en-us/azure/container-registry/tasks-agent-pools). Added a \deployAcrTaskAgentPool\-gated Network Rule Collection Group.
2. **Firewall Policy rule-collection-group provisioning race.** Chained \uleCollectionGroups\ depended on each other and the firewall policy, but not on the \zureFirewall\ resource itself, which can take 10–25 minutes to associate on a fresh deployment — causing an intermittent \Failed\ policy state. Added \dependsOn: [azureFirewall]\ on the new rule collection group.

## Validation evidence

- \z bicep build --file main.bicep\ — PASS.
- \pwsh ./tests/contracts/Test-AcrTaskAgentPoolFirewallContract.ps1\ — PASS (7/7).
- \pwsh ./tests/contracts/Test-HostedAgentContract.ps1\ — PASS.
- \pwsh ./scripts/Measure-MainJsonSize.ps1 -WorkingBudgetMB 3.5 -FailThresholdMB 4.7 -ArmHardCeilingMB 5.0\ — PASS; 4.661 MB, below fail threshold and ceiling.
- \pwsh ./tests/scripts/Invoke-PreflightChecks.Tests.ps1\ — PASS; 43 tests.
- \pwsh ./.github/scripts/Validate-CopilotAssets.ps1\ — PASS.
- **Live disposable Azure validation** (rg-ailz-acrfix-08031905, eastus2, network-isolated deployment): VNet-injected ACR Task agent pool reached \Succeeded\ on first attempt (previously failed 6/6 in the reporter's environment); firewall policy and rule collection groups reached \Succeeded\ (previously intermittently \Failed\); private endpoint DNS/TCP-443 reachability confirmed from the pool's subnet. Full details in #124. Validation resources fully cleaned up after evidence capture.

## Documentation

- \README.md\ documents the new ACR Task agent pool platform Network Rules.
- \	ests/README.md\ documents the new contract test.
- \CHANGELOG.md\ stamps v2.4.1 and preserves prior history.
- No Portal/Terraform parity review required — this is a patch-level bug fix with no new parameters, outputs, or behavior changes for existing deployments (only additive, feature-flag-gated fix for an existing broken path).

## Code quality checklist

- [x] I verified the changes locally to ensure they work as expected
- [x] I tested the new functionality and ensured existing features still work
- [x] I preserved parameter, output, naming, identity, and network-isolation contracts or documented the migration
- [x] I updated \CHANGELOG.md\ and all affected documentation
- [ ] I added at least one reviewer to this Pull Request — release is explicitly authorized for administrative review and merge