### PR TITLE
fix: bound Foundry private link names

### DIFF
--- a/.github/workflows/bicep-validate.yml
+++ b/.github/workflows/bicep-validate.yml
@@ -104,6 +104,10 @@ jobs:
         shell: pwsh
         run: pwsh ./tests/contracts/Test-AcrTaskAgentPoolFirewallContract.ps1
 
+      - name: Validate Foundry shared private-link names
+        shell: pwsh
+        run: pwsh ./tests/contracts/Test-FoundrySharedPrivateLinkNameContract.ps1
+
       - name: Run deterministic preflight tests
         shell: pwsh
         run: pwsh ./tests/scripts/Invoke-PreflightChecks.Tests.ps1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
 
 ## [Unreleased]
 
+### Fixed
+
+- **Foundry IQ shared private-link names now stay within Azure AI Search's
+  60-character resource-name limit.** Network-isolated deployments with long
+  explicit or CAF-generated Search service names previously produced
+  `foundry_account` and `cognitiveservices_account` child names longer than the
+  service accepts, failing late in provisioning after the long-running Foundry
+  resources completed. The names now use a bounded Search token with a
+  deterministic hash while preserving the semantic group suffix.
+
 ## [v2.4.1] - 2026-08-03
 
 ### Fixed

--- a/main.bicep
+++ b/main.bicep
@@ -3064,20 +3064,25 @@ resource searchServiceResource 'Microsoft.Search/searchServices@2025-05-01' exis
   name: resourceNames.searchServiceName
 }
 
+// Search shared private-link names are limited to 60 characters. Keep the
+// semantic group suffix intact and retain collision resistance when an
+// explicit or CAF-generated Search service name is long.
+var searchFoundrySharedPrivateLinkNameToken = '${take(resourceNames.searchServiceName, 21)}-${take(uniqueString(resourceNames.searchServiceName), 6)}'
+
 var searchFoundrySharedPrivateLinkResources = (_networkIsolation && deploySearchService && deployAiFoundry && retrievalBackend == 'foundry_iq')
   ? [
       {
-        name: 'spl-${resourceNames.searchServiceName}-openai_account-1'
+        name: 'spl-${searchFoundrySharedPrivateLinkNameToken}-openai_account-1'
         groupId: 'openai_account'
         requestMessage: 'Allow AI Search private access to Azure OpenAI embeddings for Foundry IQ.'
       }
       {
-        name: 'spl-${resourceNames.searchServiceName}-foundry_account-1'
+        name: 'spl-${searchFoundrySharedPrivateLinkNameToken}-foundry_account-1'
         groupId: 'foundry_account'
         requestMessage: 'Allow AI Search private access to Microsoft Foundry for Foundry IQ.'
       }
       {
-        name: 'spl-${resourceNames.searchServiceName}-cognitiveservices_account-1'
+        name: 'spl-${searchFoundrySharedPrivateLinkNameToken}-cognitiveservices_account-1'
         groupId: 'cognitiveservices_account'
         requestMessage: 'Allow AI Search private access to Cognitive Services for Foundry IQ standard extraction.'
       }

--- a/tests/README.md
+++ b/tests/README.md
@@ -27,6 +27,7 @@ tests/
 ├── contracts/
 │   ├── Test-HostedAgentContract.ps1
 │   ├── Test-AcrTaskAgentPoolFirewallContract.ps1
+│   ├── Test-FoundrySharedPrivateLinkNameContract.ps1
 │   └── fixtures/
 │       └── hosted-agent-resource-graph.json
 ├── hub/
@@ -45,6 +46,7 @@ Run from the repository root:
 ```pwsh
 pwsh tests/contracts/Test-HostedAgentContract.ps1
 pwsh tests/contracts/Test-AcrTaskAgentPoolFirewallContract.ps1
+pwsh tests/contracts/Test-FoundrySharedPrivateLinkNameContract.ps1
 pwsh tests/scripts/Invoke-PreflightChecks.Tests.ps1
 ```
 

--- a/tests/contracts/Test-FoundrySharedPrivateLinkNameContract.ps1
+++ b/tests/contracts/Test-FoundrySharedPrivateLinkNameContract.ps1
@@ -1,0 +1,84 @@
+<#
+.SYNOPSIS
+    Validates Foundry IQ shared private-link resource names stay within Azure's
+    60-character limit.
+
+.DESCRIPTION
+    Regression test for a network-isolated deployment whose CAF-generated
+    Search service name produced a 61-character `foundry_account` shared
+    private-link name (and a 71-character `cognitiveservices_account` name).
+    The deployment failed only after the other long-running resources had
+    provisioned.
+#>
+
+[CmdletBinding()]
+param(
+    [string]$MainFile = (Join-Path (Split-Path -Parent (Split-Path -Parent $PSScriptRoot)) 'main.bicep')
+)
+
+$ErrorActionPreference = 'Stop'
+$source = Get-Content -LiteralPath $MainFile -Raw -Encoding utf8
+$failures = [System.Collections.Generic.List[string]]::new()
+
+function Add-Failure {
+    param([Parameter(Mandatory)] [string]$Message)
+    $failures.Add($Message) | Out-Null
+    Write-Host "  [FAIL] $Message" -ForegroundColor Red
+}
+
+function Add-Pass {
+    param([Parameter(Mandatory)] [string]$Message)
+    Write-Host "  [PASS] $Message" -ForegroundColor Green
+}
+
+Write-Host 'Foundry IQ shared private-link naming contract' -ForegroundColor Cyan
+
+$expectedTokenDeclaration = @'
+var searchFoundrySharedPrivateLinkNameToken = '${take(resourceNames.searchServiceName, 21)}-${take(uniqueString(resourceNames.searchServiceName), 6)}'
+'@.Trim()
+
+if (-not $source.Contains($expectedTokenDeclaration)) {
+    Add-Failure 'The bounded, collision-resistant Search name token declaration is missing.'
+}
+else {
+    Add-Pass 'The name token is bounded to 28 characters and includes a deterministic hash.'
+}
+
+$groups = @(
+    'openai_account'
+    'foundry_account'
+    'cognitiveservices_account'
+)
+$tokenLength = 21 + 1 + 6
+$maxResourceNameLength = 60
+
+foreach ($group in $groups) {
+    $expectedName = "name: 'spl-`${searchFoundrySharedPrivateLinkNameToken}-$group-1'"
+    if (-not $source.Contains($expectedName)) {
+        Add-Failure "Shared private link '$group' does not use the bounded name token."
+        continue
+    }
+
+    $maximumLength = 'spl-'.Length + $tokenLength + 1 + $group.Length + '-1'.Length
+    if ($maximumLength -gt $maxResourceNameLength) {
+        Add-Failure "Shared private link '$group' can reach $maximumLength characters."
+    }
+    else {
+        Add-Pass "Shared private link '$group' is bounded to $maximumLength characters."
+    }
+}
+
+if ($source -match "name:\s*'spl-\`$\{resourceNames\.searchServiceName\}-(?:openai|foundry|cognitiveservices)_account-1'") {
+    Add-Failure 'An unbounded Search service name is still used by a Foundry shared private link.'
+}
+else {
+    Add-Pass 'No Foundry shared private link uses the unbounded Search service name.'
+}
+
+if ($failures.Count -gt 0) {
+    Write-Host "`n$($failures.Count) shared private-link naming contract check(s) failed." -ForegroundColor Red
+    exit 1
+}
+
+Write-Host "`nFoundry IQ shared private-link naming contract checks passed." -ForegroundColor Green
+exit 0


### PR DESCRIPTION
## Summary
- bound the Search service token used by Foundry IQ shared private-link names
- preserve the semantic group suffix and add a deterministic hash for collision resistance
- add a regression contract and run it in Bicep validation CI

## Live reproduction
A fresh network-isolated GPT-RAG deployment reached the Foundry stage and then Azure AI Search rejected a generated `foundry_account` shared private-link name at 61 characters (service maximum: 60). The `cognitiveservices_account` variant would reach 71 characters.

## Validation
- `pwsh tests/contracts/Test-FoundrySharedPrivateLinkNameContract.ps1` (5 checks passed)
- Existing Bicep build/lint and hosted resource-contract checks are wired in the PR workflow

No production resources or public-network workaround were used.