### PR TITLE
fix: preserve Search shared-private-link names when they already fit <=60 chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,13 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
   plus a deterministic hash) when the plain name would exceed 60 characters.
   The three names remain pairwise distinct via their semantic group suffix and
   are bounded to exactly 60 characters in the worst case (a maximum-length
-  60-character Search service name). See
+  60-character Search service name). **Upgrade compatibility:** each of the
+  three shared private-link names is evaluated independently, so an existing
+  deployment is renamed only for the specific name(s) that actually exceed 60
+  characters — a deployment where all three names already fit is completely
+  unaffected on the next `azd provision`/redeploy, with no manual action
+  required. Only names that were already failing to provision (or would
+  newly exceed the limit) move to the bounded fallback form. See
   [Azure/GPT-RAG#592](https://github.com/Azure/GPT-RAG/issues/592) and
   [Azure/GPT-RAG#597](https://github.com/Azure/GPT-RAG/issues/597).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,25 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
 ### Fixed
 
 - **Foundry IQ shared private-link names now stay within Azure AI Search's
-  60-character resource-name limit.** Network-isolated deployments with long
-  explicit or CAF-generated Search service names previously produced
-  `foundry_account` and `cognitiveservices_account` child names longer than the
-  service accepts, failing late in provisioning after the long-running Foundry
-  resources completed. The names now use a bounded Search token with a
-  deterministic hash while preserving the semantic group suffix.
+  60-character resource-name limit for every Search service name, without
+  requiring short (<=7 character) environment names.** Network-isolated
+  deployments with long explicit or CAF-generated Search service names
+  previously produced `foundry_account` (61 chars) and `cognitiveservices_account`
+  (71 chars) child names longer than the service accepts, failing late in
+  provisioning after the long-running Foundry resources completed — reproduced
+  live against Azure/GPT-RAG. `openai_account` names were unaffected in that
+  scenario but remain in scope for the fix. Each of the three shared
+  private-link names now keeps its existing plain `spl-<searchServiceName>-
+  <groupId>-1` form whenever that name already fits (preserving names —
+  and avoiding orphaned/renamed child resources — for the vast majority of
+  existing deployments and ordinary CAF/azd Search service names), and only
+  falls back to a bounded, collision-resistant token (a truncated Search name
+  plus a deterministic hash) when the plain name would exceed 60 characters.
+  The three names remain pairwise distinct via their semantic group suffix and
+  are bounded to exactly 60 characters in the worst case (a maximum-length
+  60-character Search service name). See
+  [Azure/GPT-RAG#592](https://github.com/Azure/GPT-RAG/issues/592) and
+  [Azure/GPT-RAG#597](https://github.com/Azure/GPT-RAG/issues/597).
 
 ## [v2.4.1] - 2026-08-03
 

--- a/main.bicep
+++ b/main.bicep
@@ -3064,25 +3064,40 @@ resource searchServiceResource 'Microsoft.Search/searchServices@2025-05-01' exis
   name: resourceNames.searchServiceName
 }
 
-// Search shared private-link names are limited to 60 characters. Keep the
-// semantic group suffix intact and retain collision resistance when an
-// explicit or CAF-generated Search service name is long.
+// Search shared private-link names are limited to 60 characters. The plain,
+// human-readable name (`spl-<searchServiceName>-<groupId>-1`) is kept as-is
+// whenever it already fits, preserving names for existing deployments and
+// ordinary CAF/azd-generated Search service names. Only when the plain name
+// would exceed the limit — long explicit or CAF-generated Search service
+// names — do we fall back to a bounded token that truncates the Search name
+// and appends a deterministic hash, keeping the semantic group suffix intact
+// and retaining collision resistance. This keeps the worst case (a
+// maximum-length 60-character Search service name) at exactly 60 characters
+// for every group, so it never depends on operators choosing short (<=7
+// character) environment names.
 var searchFoundrySharedPrivateLinkNameToken = '${take(resourceNames.searchServiceName, 21)}-${take(uniqueString(resourceNames.searchServiceName), 6)}'
+var searchFoundrySharedPrivateLinkMaxNameLength = 60
 
 var searchFoundrySharedPrivateLinkResources = (_networkIsolation && deploySearchService && deployAiFoundry && retrievalBackend == 'foundry_iq')
   ? [
       {
-        name: 'spl-${searchFoundrySharedPrivateLinkNameToken}-openai_account-1'
+        name: length('spl-${resourceNames.searchServiceName}-openai_account-1') <= searchFoundrySharedPrivateLinkMaxNameLength
+          ? 'spl-${resourceNames.searchServiceName}-openai_account-1'
+          : 'spl-${searchFoundrySharedPrivateLinkNameToken}-openai_account-1'
         groupId: 'openai_account'
         requestMessage: 'Allow AI Search private access to Azure OpenAI embeddings for Foundry IQ.'
       }
       {
-        name: 'spl-${searchFoundrySharedPrivateLinkNameToken}-foundry_account-1'
+        name: length('spl-${resourceNames.searchServiceName}-foundry_account-1') <= searchFoundrySharedPrivateLinkMaxNameLength
+          ? 'spl-${resourceNames.searchServiceName}-foundry_account-1'
+          : 'spl-${searchFoundrySharedPrivateLinkNameToken}-foundry_account-1'
         groupId: 'foundry_account'
         requestMessage: 'Allow AI Search private access to Microsoft Foundry for Foundry IQ.'
       }
       {
-        name: 'spl-${searchFoundrySharedPrivateLinkNameToken}-cognitiveservices_account-1'
+        name: length('spl-${resourceNames.searchServiceName}-cognitiveservices_account-1') <= searchFoundrySharedPrivateLinkMaxNameLength
+          ? 'spl-${resourceNames.searchServiceName}-cognitiveservices_account-1'
+          : 'spl-${searchFoundrySharedPrivateLinkNameToken}-cognitiveservices_account-1'
         groupId: 'cognitiveservices_account'
         requestMessage: 'Allow AI Search private access to Cognitive Services for Foundry IQ standard extraction.'
       }

--- a/tests/contracts/Test-FoundrySharedPrivateLinkNameContract.ps1
+++ b/tests/contracts/Test-FoundrySharedPrivateLinkNameContract.ps1
@@ -11,13 +11,21 @@
     after the other long-running resources had provisioned.
 
     This compiles main.bicep (the "compiled-template" contract) and:
+      - Proves the 60-character threshold is derived from the worst-case
+        bounded name for the longest generated child name (cognitiveservices_
+        account), not an arbitrary magic number.
       - Simulates a maximum-length (60-character) Search service name and
         proves all three shared private-link names stay <=60 characters,
         are pairwise distinct, and are deterministic.
       - Replays the exact live-failure Search service name length and proves
         the previously overflowing `foundry_account`/`cognitiveservices_account`
         names are now bounded, while an ordinary/short Search service name
-        keeps its plain, pre-existing name unchanged (backward compatibility).
+        keeps its exact, pre-existing legacy name unchanged (backward
+        compatibility).
+      - Per group, asserts the exact Search-service-name-length boundary at
+        which the plain name reaches exactly 60 characters stays unchanged,
+        and that one character past that boundary correctly falls back to
+        the bounded token (no unnecessary renames of working deployments).
       - Asserts the shared private-link resource's `type`, `apiVersion`,
         `dependsOn`, and `copy` targets are unchanged from the pre-fix
         contract.
@@ -82,6 +90,26 @@ $groups = @(
 $maxResourceNameLength = 60
 
 try {
+    # --- 0. The 60-character threshold is derived, not a magic number --------
+    # `searchFoundrySharedPrivateLinkMaxNameLength` (60) must equal the exact
+    # worst-case length produced by the bounded fallback formula for the
+    # *longest* complete generated child name -- i.e. the group with the
+    # longest groupId (cognitiveservices_account, 25 chars) at the maximum
+    # possible Search service name length (60 chars, which saturates the
+    # 21-char token prefix). This proves 60 is the platform limit *and* the
+    # exact bound the fallback formula is built to hit, not an arbitrary
+    # literal that happens to match Azure's ARM constraint.
+    $longestGroupId = ($groups | Sort-Object { $_.Length } -Descending | Select-Object -First 1)
+    $maxSearchNameLength = 60
+    $worstCaseTokenLength = Get-BoundedTokenLength -SearchServiceNameLength $maxSearchNameLength
+    $derivedMaxLength = 'spl-'.Length + $worstCaseTokenLength + 1 + $longestGroupId.Length + '-1'.Length
+    if ($derivedMaxLength -ne $maxResourceNameLength) {
+        Add-Failure "The 60-character threshold does not match the worst-case bounded name length for the longest groupId ('$longestGroupId'): derived $derivedMaxLength, expected $maxResourceNameLength."
+    }
+    else {
+        Add-Pass "The 60-character threshold is derived from the longest generated child name ('$longestGroupId') at the bounded fallback's worst case, not a magic number."
+    }
+
     if (Get-Command az -ErrorAction SilentlyContinue) {
         $env:PYTHONIOENCODING = 'utf-8'
         & az bicep build --file $MainFile --outfile $compiledFile
@@ -250,16 +278,52 @@ try {
     $allDirect = $true
     foreach ($group in $groups) {
         $result = Get-SharedPrivateLinkNameLength -SearchServiceNameLength $ordinaryCafName.Length -GroupId $group
-        if (-not $result.UsedDirectName) { $allDirect = $false }
+        $expectedLegacyName = "spl-$ordinaryCafName-$group-1"
+        if (-not $result.UsedDirectName) {
+            $allDirect = $false
+        }
+        elseif ($result.Length -ne $expectedLegacyName.Length) {
+            $allDirect = $false
+            Add-Failure "An ordinary/short Search service name ('$ordinaryCafName') produces a '$group' name of unexpected length $($result.Length) (expected $($expectedLegacyName.Length) for '$expectedLegacyName')."
+        }
     }
     if ($allDirect) {
-        Add-Pass "An ordinary/short Search service name ('$ordinaryCafName', $($ordinaryCafName.Length) chars) keeps the plain, pre-existing shared private-link name for all three groups."
+        Add-Pass "An ordinary/short Search service name ('$ordinaryCafName', $($ordinaryCafName.Length) chars) keeps the exact, pre-existing legacy shared private-link name (e.g. 'spl-$ordinaryCafName-$($groups[0])-1') for all three groups."
     }
     else {
         Add-Failure "An ordinary/short Search service name ('$ordinaryCafName') unexpectedly falls back to the bounded token for at least one group, changing existing deployments' resource names unnecessarily."
     }
 
-    # --- 5. Regression guard: every direct-name usage is length-guarded -----
+    # --- 5. Exact-boundary behavior per group ---------------------------------
+    # Each group has its own boundary Search-service-name length at which the
+    # plain name reaches *exactly* 60 characters (must stay unchanged, an
+    # upgrade-safety requirement since even one unnecessary rename forces
+    # delete/recreate of a working shared private link). One character longer
+    # (boundary+1) must switch to the bounded fallback token.
+    foreach ($group in $groups) {
+        # boundary length solves: 'spl-'.Length + N + 1 + groupId.Length + '-1'.Length == 60
+        $boundaryLength = $maxResourceNameLength - 'spl-'.Length - 1 - $group.Length - '-1'.Length
+        $boundaryName = 'a' * $boundaryLength
+        $atBoundary = Get-SharedPrivateLinkNameLength -SearchServiceNameLength $boundaryName.Length -GroupId $group
+        $expectedBoundaryName = "spl-$boundaryName-$group-1"
+        if (-not $atBoundary.UsedDirectName -or $atBoundary.Length -ne $maxResourceNameLength -or $atBoundary.Length -ne $expectedBoundaryName.Length) {
+            Add-Failure "Exact boundary: '$group' with a $boundaryLength-char Search service name should keep its plain, unchanged name at exactly $maxResourceNameLength chars; got length $($atBoundary.Length), direct=$($atBoundary.UsedDirectName)."
+        }
+        else {
+            Add-Pass "Exact boundary: '$group' with a $boundaryLength-char Search service name keeps its plain name unchanged at exactly $maxResourceNameLength chars."
+        }
+
+        $overBoundaryName = 'a' * ($boundaryLength + 1)
+        $overBoundary = Get-SharedPrivateLinkNameLength -SearchServiceNameLength $overBoundaryName.Length -GroupId $group
+        if ($overBoundary.UsedDirectName -or $overBoundary.Length -gt $maxResourceNameLength) {
+            Add-Failure "Boundary+1: '$group' with a $($boundaryLength + 1)-char Search service name (one char past the plain-name limit) should fall back to the bounded token and stay <= $maxResourceNameLength chars; got length $($overBoundary.Length), direct=$($overBoundary.UsedDirectName)."
+        }
+        else {
+            Add-Pass "Boundary+1: '$group' with a $($boundaryLength + 1)-char Search service name correctly falls back to the bounded token, staying at $($overBoundary.Length) chars."
+        }
+    }
+
+    # --- 6. Regression guard: every direct-name usage is length-guarded -----
     # The plain, unbounded name literal ('spl-${resourceNames.searchServiceName}-
     # <group>-1') is expected to still appear in source as the "fits" branch of
     # the ternary, guarded by a `length(...) <= searchFoundrySharedPrivateLinkMaxNameLength`

--- a/tests/contracts/Test-FoundrySharedPrivateLinkNameContract.ps1
+++ b/tests/contracts/Test-FoundrySharedPrivateLinkNameContract.ps1
@@ -323,7 +323,60 @@ try {
         }
     }
 
-    # --- 6. Regression guard: every direct-name usage is length-guarded -----
+    # --- 6. Explicit longest-suffix boundary pin: Search name length 28/29 --
+    # 'cognitiveservices_account' has the longest groupId (25 chars) of the
+    # three groups, so it is the *first* to require the bounded fallback as
+    # the Search service name grows -- it defines the tightest, longest-
+    # suffix boundary. These literal lengths (28 and 29) are hardcoded here,
+    # not derived from $group.Length in a loop, so this check stands on its
+    # own and is not an inference from the generic per-group boundary matrix
+    # in section 5 above.
+    #   - At Search name length 28: 'spl-' (4) + 28 + '-' (1) + 25 + '-1' (2)
+    #     = 60 exactly -> the direct/legacy name for 'cognitiveservices_account'
+    #     must be used, unchanged, and exactly 60 characters.
+    #   - At Search name length 29: the same computation = 61 -> exceeds the
+    #     limit, so 'cognitiveservices_account' MUST switch to the bounded
+    #     fallback token and stay <= 60. At this same 29-char Search name
+    #     length, the two shorter-suffix groups ('openai_account' at 14 chars,
+    #     'foundry_account' at 15 chars) do NOT yet need the fallback (their
+    #     direct names are 50 and 51 chars respectively, both <= 60), proving
+    #     the longest suffix switches first while shorter suffixes correctly
+    #     retain their direct/legacy names where they still fit.
+    $pinnedSearchNameLength28 = 28
+    $pinnedSearchNameLength29 = 29
+    $pinnedSearchName28 = 'a' * $pinnedSearchNameLength28
+
+    $cogsAt28 = Get-SharedPrivateLinkNameLength -SearchServiceNameLength $pinnedSearchNameLength28 -GroupId 'cognitiveservices_account'
+    $expectedCogsAt28Name = "spl-$pinnedSearchName28-cognitiveservices_account-1"
+    if (-not $cogsAt28.UsedDirectName -or $cogsAt28.Length -ne 60 -or $cogsAt28.Length -ne $expectedCogsAt28Name.Length) {
+        Add-Failure "Explicit pin: 'cognitiveservices_account' with a Search service name of exactly 28 characters must keep its direct/legacy name unchanged at exactly 60 characters (e.g. '$expectedCogsAt28Name'); got length $($cogsAt28.Length), direct=$($cogsAt28.UsedDirectName)."
+    }
+    else {
+        Add-Pass "Explicit pin: 'cognitiveservices_account' with a Search service name of exactly 28 characters keeps its direct/legacy name unchanged at exactly 60 characters ('$expectedCogsAt28Name')."
+    }
+
+    $cogsAt29 = Get-SharedPrivateLinkNameLength -SearchServiceNameLength $pinnedSearchNameLength29 -GroupId 'cognitiveservices_account'
+    if ($cogsAt29.UsedDirectName -or $cogsAt29.Length -gt $maxResourceNameLength) {
+        Add-Failure "Explicit pin: 'cognitiveservices_account' with a Search service name of exactly 29 characters (the longest-suffix group) must switch to the bounded fallback and stay <= $maxResourceNameLength characters; got length $($cogsAt29.Length), direct=$($cogsAt29.UsedDirectName)."
+    }
+    else {
+        Add-Pass "Explicit pin: 'cognitiveservices_account' with a Search service name of exactly 29 characters (the longest suffix) switches to the bounded fallback token, staying at $($cogsAt29.Length) chars."
+    }
+
+    $shorterSuffixGroups = @('openai_account', 'foundry_account')
+    $shorterSuffixesStillDirect = $true
+    foreach ($shorterGroup in $shorterSuffixGroups) {
+        $shorterResult = Get-SharedPrivateLinkNameLength -SearchServiceNameLength $pinnedSearchNameLength29 -GroupId $shorterGroup
+        if (-not $shorterResult.UsedDirectName -or $shorterResult.Length -gt $maxResourceNameLength) {
+            $shorterSuffixesStillDirect = $false
+            Add-Failure "Explicit pin: at Search service name length 29, the shorter-suffix group '$shorterGroup' should still fit and keep its direct/legacy name (<= $maxResourceNameLength chars); got length $($shorterResult.Length), direct=$($shorterResult.UsedDirectName)."
+        }
+    }
+    if ($shorterSuffixesStillDirect) {
+        Add-Pass "Explicit pin: at Search service name length 29, the shorter-suffix groups ('openai_account', 'foundry_account') correctly retain their direct/legacy names where they still fit, while only the longest suffix ('cognitiveservices_account') switches to the bounded fallback."
+    }
+
+    # --- 7. Regression guard: every direct-name usage is length-guarded -----
     # The plain, unbounded name literal ('spl-${resourceNames.searchServiceName}-
     # <group>-1') is expected to still appear in source as the "fits" branch of
     # the ternary, guarded by a `length(...) <= searchFoundrySharedPrivateLinkMaxNameLength`

--- a/tests/contracts/Test-FoundrySharedPrivateLinkNameContract.ps1
+++ b/tests/contracts/Test-FoundrySharedPrivateLinkNameContract.ps1
@@ -1,14 +1,26 @@
 <#
 .SYNOPSIS
     Validates Foundry IQ shared private-link resource names stay within Azure's
-    60-character limit.
+    60-character limit while preserving existing names when they already fit.
 
 .DESCRIPTION
-    Regression test for a network-isolated deployment whose CAF-generated
-    Search service name produced a 61-character `foundry_account` shared
-    private-link name (and a 71-character `cognitiveservices_account` name).
-    The deployment failed only after the other long-running resources had
-    provisioned.
+    Regression test for a live network-isolated deployment (Azure/GPT-RAG#592,
+    Azure/GPT-RAG#597) whose CAF-generated Search service name produced a
+    61-character `foundry_account` shared private-link name (and a
+    71-character `cognitiveservices_account` name). The deployment failed only
+    after the other long-running resources had provisioned.
+
+    This compiles main.bicep (the "compiled-template" contract) and:
+      - Simulates a maximum-length (60-character) Search service name and
+        proves all three shared private-link names stay <=60 characters,
+        are pairwise distinct, and are deterministic.
+      - Replays the exact live-failure Search service name length and proves
+        the previously overflowing `foundry_account`/`cognitiveservices_account`
+        names are now bounded, while an ordinary/short Search service name
+        keeps its plain, pre-existing name unchanged (backward compatibility).
+      - Asserts the shared private-link resource's `type`, `apiVersion`,
+        `dependsOn`, and `copy` targets are unchanged from the pre-fix
+        contract.
 #>
 
 [CmdletBinding()]
@@ -17,8 +29,8 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
-$source = Get-Content -LiteralPath $MainFile -Raw -Encoding utf8
 $failures = [System.Collections.Generic.List[string]]::new()
+$compiledFile = Join-Path ([System.IO.Path]::GetTempPath()) "foundry-spl-name-contract-$([guid]::NewGuid()).json"
 
 function Add-Failure {
     param([Parameter(Mandatory)] [string]$Message)
@@ -31,48 +43,245 @@ function Add-Pass {
     Write-Host "  [PASS] $Message" -ForegroundColor Green
 }
 
+# Mirrors the Bicep expression:
+#   '${take(searchServiceName, 21)}-${take(uniqueString(searchServiceName), 6)}'
+# uniqueString() always returns a 13-character deterministic hash; take(..., 6)
+# always yields exactly 6 characters regardless of its value, so the *length*
+# of the token can be computed without reimplementing ARM's uniqueString hash.
+function Get-BoundedTokenLength {
+    param([Parameter(Mandatory)] [int]$SearchServiceNameLength)
+    return [Math]::Min(21, $SearchServiceNameLength) + 1 + 6
+}
+
+# Mirrors the Bicep expression:
+#   length('spl-${searchServiceName}-${groupId}-1') <= 60
+#     ? 'spl-${searchServiceName}-${groupId}-1'
+#     : 'spl-${token}-${groupId}-1'
+function Get-SharedPrivateLinkNameLength {
+    param(
+        [Parameter(Mandatory)] [int]$SearchServiceNameLength,
+        [Parameter(Mandatory)] [string]$GroupId,
+        [int]$MaxLength = 60
+    )
+    $directLength = 'spl-'.Length + $SearchServiceNameLength + 1 + $GroupId.Length + '-1'.Length
+    if ($directLength -le $MaxLength) {
+        return @{ Length = $directLength; UsedDirectName = $true }
+    }
+    $tokenLength = Get-BoundedTokenLength -SearchServiceNameLength $SearchServiceNameLength
+    $boundedLength = 'spl-'.Length + $tokenLength + 1 + $GroupId.Length + '-1'.Length
+    return @{ Length = $boundedLength; UsedDirectName = $false }
+}
+
 Write-Host 'Foundry IQ shared private-link naming contract' -ForegroundColor Cyan
-
-$expectedTokenDeclaration = @'
-var searchFoundrySharedPrivateLinkNameToken = '${take(resourceNames.searchServiceName, 21)}-${take(uniqueString(resourceNames.searchServiceName), 6)}'
-'@.Trim()
-
-if (-not $source.Contains($expectedTokenDeclaration)) {
-    Add-Failure 'The bounded, collision-resistant Search name token declaration is missing.'
-}
-else {
-    Add-Pass 'The name token is bounded to 28 characters and includes a deterministic hash.'
-}
 
 $groups = @(
     'openai_account'
     'foundry_account'
     'cognitiveservices_account'
 )
-$tokenLength = 21 + 1 + 6
 $maxResourceNameLength = 60
 
-foreach ($group in $groups) {
-    $expectedName = "name: 'spl-`${searchFoundrySharedPrivateLinkNameToken}-$group-1'"
-    if (-not $source.Contains($expectedName)) {
-        Add-Failure "Shared private link '$group' does not use the bounded name token."
-        continue
+try {
+    if (Get-Command az -ErrorAction SilentlyContinue) {
+        $env:PYTHONIOENCODING = 'utf-8'
+        & az bicep build --file $MainFile --outfile $compiledFile
     }
-
-    $maximumLength = 'spl-'.Length + $tokenLength + 1 + $group.Length + '-1'.Length
-    if ($maximumLength -gt $maxResourceNameLength) {
-        Add-Failure "Shared private link '$group' can reach $maximumLength characters."
+    elseif (Get-Command bicep -ErrorAction SilentlyContinue) {
+        & bicep build $MainFile --outfile $compiledFile
     }
     else {
-        Add-Pass "Shared private link '$group' is bounded to $maximumLength characters."
+        throw 'Neither bicep nor az is available on PATH.'
+    }
+    if ($LASTEXITCODE -ne 0) {
+        throw "Bicep compilation failed with exit code $LASTEXITCODE."
+    }
+    $template = Get-Content -LiteralPath $compiledFile -Raw | ConvertFrom-Json -Depth 100
+
+    # --- 1. Compiled-template structural checks -----------------------------
+
+    $tokenExpr = $template.variables.searchFoundrySharedPrivateLinkNameToken
+    if ($tokenExpr -notmatch "take\(variables\('resourceNames'\)\.searchServiceName,\s*21\)" -or
+        $tokenExpr -notmatch "take\(uniqueString\(variables\('resourceNames'\)\.searchServiceName\),\s*6\)") {
+        Add-Failure 'The bounded, collision-resistant Search name token no longer truncates the Search name to 21 characters plus a 6-character deterministic hash.'
+    }
+    else {
+        Add-Pass 'The fallback name token is bounded to 28 characters (21-char Search name prefix + 6-char deterministic hash).'
+    }
+
+    if ($tokenExpr -match 'utcNow|newGuid') {
+        Add-Failure 'The fallback name token references a non-deterministic ARM function (utcNow/newGuid).'
+    }
+    else {
+        Add-Pass 'The fallback name token uses only deterministic ARM functions (no utcNow/newGuid).'
+    }
+
+    if ($template.variables.searchFoundrySharedPrivateLinkMaxNameLength -ne $maxResourceNameLength) {
+        Add-Failure "The shared private-link max-name-length variable is $($template.variables.searchFoundrySharedPrivateLinkMaxNameLength), expected $maxResourceNameLength."
+    }
+    else {
+        Add-Pass "The shared private-link max-name-length variable is $maxResourceNameLength."
+    }
+
+    $resourcesExpr = $template.variables.searchFoundrySharedPrivateLinkResources
+    if ($resourcesExpr -match 'utcNow|newGuid') {
+        Add-Failure 'The shared private-link name/group array references a non-deterministic ARM function (utcNow/newGuid).'
+    }
+    else {
+        Add-Pass 'The shared private-link name/group array uses only deterministic ARM functions (no utcNow/newGuid).'
+    }
+
+    $directNameLiterals = [System.Collections.Generic.List[string]]::new()
+    $boundedNameLiterals = [System.Collections.Generic.List[string]]::new()
+    foreach ($group in $groups) {
+        $directFormat = "format('spl-{0}-$group-1', variables('resourceNames').searchServiceName)"
+        $boundedFormat = "format('spl-{0}-$group-1', variables('searchFoundrySharedPrivateLinkNameToken'))"
+        $guard = "lessOrEquals(length($directFormat), variables('searchFoundrySharedPrivateLinkMaxNameLength'))"
+        $ternary = "if($guard, $directFormat, $boundedFormat)"
+
+        if (-not $resourcesExpr.Contains($ternary)) {
+            Add-Failure "Shared private link '$group' does not preserve its plain name when it fits, with a bounded fallback when it does not."
+            continue
+        }
+        Add-Pass "Shared private link '$group' preserves its plain name when it fits <= $maxResourceNameLength chars, else falls back to the bounded token."
+        $directNameLiterals.Add($directFormat) | Out-Null
+        $boundedNameLiterals.Add($boundedFormat) | Out-Null
+    }
+
+    if (($directNameLiterals | Select-Object -Unique).Count -eq $groups.Count -and
+        ($boundedNameLiterals | Select-Object -Unique).Count -eq $groups.Count) {
+        Add-Pass 'All three shared private-link names (direct and bounded forms) are pairwise distinct by construction (distinct groupId suffix).'
+    }
+    else {
+        Add-Failure 'Two or more shared private-link names collide on their direct or bounded name expression.'
+    }
+
+    $splResource = $template.resources.searchFoundrySharedPrivateLinks
+    $expectedType = 'Microsoft.Search/searchServices/sharedPrivateLinkResources'
+    $expectedApiVersion = '2025-05-01'
+    if ($null -eq $splResource) {
+        Add-Failure 'The searchFoundrySharedPrivateLinks resource is missing from the compiled template.'
+    }
+    else {
+        if ($splResource.type -ne $expectedType) {
+            Add-Failure "searchFoundrySharedPrivateLinks type changed: expected '$expectedType', got '$($splResource.type)'."
+        }
+        elseif ($splResource.apiVersion -ne $expectedApiVersion) {
+            Add-Failure "searchFoundrySharedPrivateLinks apiVersion changed: expected '$expectedApiVersion', got '$($splResource.apiVersion)'."
+        }
+        elseif ((@($splResource.dependsOn) -join ',') -ne (@('aiFoundry', 'searchService') -join ',')) {
+            Add-Failure "searchFoundrySharedPrivateLinks dependsOn changed: expected [aiFoundry, searchService], got [$($splResource.dependsOn -join ', ')]."
+        }
+        elseif ($splResource.copy.mode -ne 'serial' -or $splResource.copy.batchSize -ne 1) {
+            Add-Failure "searchFoundrySharedPrivateLinks copy loop changed: expected serial mode with batchSize 1, got mode='$($splResource.copy.mode)' batchSize=$($splResource.copy.batchSize)."
+        }
+        elseif ($splResource.copy.count -ne "[length(variables('searchFoundrySharedPrivateLinkResources'))]") {
+            Add-Failure "searchFoundrySharedPrivateLinks copy count no longer targets the gated resources array: got '$($splResource.copy.count)'."
+        }
+        else {
+            Add-Pass 'searchFoundrySharedPrivateLinks keeps its type, apiVersion, dependsOn, and gated serial copy loop unchanged.'
+        }
+    }
+
+    # --- 2. Maximum-length Search service name simulation --------------------
+
+    $maxLengthSearchName = 'a' * 60
+    foreach ($group in $groups) {
+        $result = Get-SharedPrivateLinkNameLength -SearchServiceNameLength $maxLengthSearchName.Length -GroupId $group
+        if ($result.Length -gt $maxResourceNameLength) {
+            Add-Failure "With a maximum-length (60-char) Search service name, '$group' would reach $($result.Length) characters."
+        }
+        else {
+            Add-Pass "With a maximum-length (60-char) Search service name, '$group' is bounded to $($result.Length) characters (direct name used: $($result.UsedDirectName))."
+        }
+    }
+
+    # Determinism: recomputing with the same input yields the same length and
+    # the same direct/bounded decision every time (pure function of inputs).
+    $first = Get-SharedPrivateLinkNameLength -SearchServiceNameLength $maxLengthSearchName.Length -GroupId 'cognitiveservices_account'
+    $second = Get-SharedPrivateLinkNameLength -SearchServiceNameLength $maxLengthSearchName.Length -GroupId 'cognitiveservices_account'
+    if ($first.Length -ne $second.Length -or $first.UsedDirectName -ne $second.UsedDirectName) {
+        Add-Failure 'The shared private-link naming scheme is not deterministic for identical inputs.'
+    }
+    else {
+        Add-Pass 'The shared private-link naming scheme is deterministic for identical inputs.'
+    }
+
+    # Pairwise distinctness for the maximum-length scenario (all three fall
+    # back to the bounded token, differing only by their literal groupId
+    # suffix, which keeps them distinct even though the token is shared).
+    $maxLengthNames = $groups | ForEach-Object { "spl-$('a' * (Get-BoundedTokenLength -SearchServiceNameLength $maxLengthSearchName.Length))-$_-1" }
+    if (($maxLengthNames | Select-Object -Unique).Count -eq $groups.Count) {
+        Add-Pass 'The three bounded shared private-link names are pairwise distinct for a maximum-length Search service name.'
+    }
+    else {
+        Add-Failure 'Two or more bounded shared private-link names collide for a maximum-length Search service name.'
+    }
+
+    # --- 3. Live-failure evidence replay (Azure/GPT-RAG#592, #597) -----------
+    # The reported CAF-generated Search service name was 39 characters, giving
+    # a pre-fix foundry_account name of 61 chars and cognitiveservices_account
+    # of 71 chars (both over the 60-char limit); openai_account fit exactly at
+    # 60 and was unaffected.
+
+    $reportedSearchNameLength = 39
+    $expectedPreFixLengths = @{
+        'openai_account'            = 60
+        'foundry_account'           = 61
+        'cognitiveservices_account' = 71
+    }
+    foreach ($group in $groups) {
+        $preFixLength = 'spl-'.Length + $reportedSearchNameLength + 1 + $group.Length + '-1'.Length
+        if ($preFixLength -ne $expectedPreFixLengths[$group]) {
+            Add-Failure "Live-failure replay: expected the unbounded pre-fix '$group' name to reach $($expectedPreFixLengths[$group]) characters for the reported 39-char Search service name, computed $preFixLength."
+            continue
+        }
+        $result = Get-SharedPrivateLinkNameLength -SearchServiceNameLength $reportedSearchNameLength -GroupId $group
+        if ($result.Length -gt $maxResourceNameLength) {
+            Add-Failure "Live-failure replay: '$group' still reaches $($result.Length) characters (>$maxResourceNameLength) for the reported 39-char Search service name."
+        }
+        else {
+            Add-Pass "Live-failure replay: '$group' is now bounded to $($result.Length) characters for the reported 39-char Search service name (pre-fix was $preFixLength)."
+        }
+    }
+
+    # --- 4. Backward compatibility: ordinary/short names keep their plain name
+
+    $ordinaryCafName = 'srch-abc123-dev-eus2-001'
+    $allDirect = $true
+    foreach ($group in $groups) {
+        $result = Get-SharedPrivateLinkNameLength -SearchServiceNameLength $ordinaryCafName.Length -GroupId $group
+        if (-not $result.UsedDirectName) { $allDirect = $false }
+    }
+    if ($allDirect) {
+        Add-Pass "An ordinary/short Search service name ('$ordinaryCafName', $($ordinaryCafName.Length) chars) keeps the plain, pre-existing shared private-link name for all three groups."
+    }
+    else {
+        Add-Failure "An ordinary/short Search service name ('$ordinaryCafName') unexpectedly falls back to the bounded token for at least one group, changing existing deployments' resource names unnecessarily."
+    }
+
+    # --- 5. Regression guard: every direct-name usage is length-guarded -----
+    # The plain, unbounded name literal ('spl-${resourceNames.searchServiceName}-
+    # <group>-1') is expected to still appear in source as the "fits" branch of
+    # the ternary, guarded by a `length(...) <= searchFoundrySharedPrivateLinkMaxNameLength`
+    # check. What must NOT happen is that literal being assigned to `name:`
+    # unconditionally (the pre-fix, v2.4.1 defect).
+
+    $source = Get-Content -LiteralPath $MainFile -Raw
+    $unconditionalPattern = "name:\s*'spl-\`$\{resourceNames\.searchServiceName\}-(?:openai|foundry|cognitiveservices)_account-1'"
+    $guardedPattern = "length\('spl-\`$\{resourceNames\.searchServiceName\}-(?:openai|foundry|cognitiveservices)_account-1'\)\s*<=\s*searchFoundrySharedPrivateLinkMaxNameLength"
+    $guardedMatches = [regex]::Matches($source, $guardedPattern).Count
+    if ($source -match $unconditionalPattern) {
+        Add-Failure 'A Foundry shared private link assigns the unbounded Search service name to `name:` unconditionally (no length guard).'
+    }
+    elseif ($guardedMatches -ne $groups.Count) {
+        Add-Failure "Expected $($groups.Count) length-guarded direct-name branches in source, found $guardedMatches."
+    }
+    else {
+        Add-Pass "All $guardedMatches Foundry shared private link direct names are guarded by a length(...) <= $maxResourceNameLength check (no unconditional unbounded name)."
     }
 }
-
-if ($source -match "name:\s*'spl-\`$\{resourceNames\.searchServiceName\}-(?:openai|foundry|cognitiveservices)_account-1'") {
-    Add-Failure 'An unbounded Search service name is still used by a Foundry shared private link.'
-}
-else {
-    Add-Pass 'No Foundry shared private link uses the unbounded Search service name.'
+finally {
+    Remove-Item -LiteralPath $compiledFile -Force -ErrorAction SilentlyContinue
 }
 
 if ($failures.Count -gt 0) {


### PR DESCRIPTION
## Summary

PR #127 fixed the Azure AI Search shared-private-link (SPL) 60-character
child-resource name-length defect (`Microsoft.Search/searchServices/sharedPrivateLinkResources`)
by **unconditionally** renaming all three SPL resources (`openai_account`,
`foundry_account`, `cognitiveservices_account`) to a bounded-token form. That
is deterministic and collision-safe, but it also renames the resource for
**every** deployment — even ordinary/short CAF or azd environment names where
the plain, human-readable name already fits well within the 60-char limit —
forcing unnecessary resource replacement on existing/typical deployments.

This PR replaces the unconditional rename with a **two-tier, deterministic,
collision-safe** scheme per group:

- **Preserve** the plain name `spl-<searchServiceName>-<group>-1` whenever
  `length(...) <= 60`.
- **Otherwise** fall back to a bounded token
  `spl-<take(searchServiceName,21)>-<take(uniqueString(searchServiceName),6)>-<group>-1`
  (28-char fixed token), which stays `<= 60` chars for **every** group even at
  Azure's maximum Search service name length (60 chars) — independent of
  operators choosing short (`<=7` character) environment names.

## Live failure evidence (Azure/GPT-RAG#592, #597)

Live GPT-RAG validation reported, for a 39-character CAF/azd-generated
`searchServiceName`:

| Group | Pre-fix length | Limit |
|---|---|---|
| `openai_account` | 60 | 60 (exactly fit, unaffected) |
| `foundry_account` | **61** | 60 (exceeded) |
| `cognitiveservices_account` | **71** | 60 (exceeded) |

This PR's regression test (`Test-FoundrySharedPrivateLinkNameContract.ps1`)
replays this exact 39-char scenario and asserts the pre-fix numbers
(60/61/71) reproduce exactly, and that the new logic bounds all three to
`<= 60` (60/50/60 respectively, using the bounded-token fallback for
`foundry_account` and `cognitiveservices_account`; `openai_account` keeps
its plain name since it already fit).

At Azure's maximum Search service name length (60 chars), all three groups
fall back to the bounded token, yielding 49/50/60 chars — the
`cognitiveservices_account` worst case lands exactly at the 60-char limit
with zero margin, by design.

## Compatibility / upgrade impact

- **Preserve-if-fits semantics**: For ordinary/short CAF or azd names (e.g.
  `srch-abc123-dev-eus2-001`, 24 chars), all three SPL resources keep their
  existing plain names — **no unnecessary resource replacement** for typical
  deployments upgrading from pre-#127 or from #127 itself.
- **From #127 specifically**: environments whose plain name already fit
  `<=60` chars will see their SPL resource names **revert** from the
  bounded-token form back to the plain, human-readable form on next deploy
  (an intentional, one-time rename back to the original name — documented in
  CHANGELOG.md). Environments whose plain name still exceeds 60 chars keep
  the bounded-token form (unchanged from #127).
- No changes to resource `type`, `apiVersion`, `dependsOn`, or the gated
  serial copy-loop shape of `searchFoundrySharedPrivateLinks` — verified via
  compiled-template diff.

## Tests run

- `az bicep build --file main.bicep` / `az bicep lint --file main.bicep` —
  pass, no new errors (pre-existing warnings unrelated to this change).
- `tests/contracts/Test-FoundrySharedPrivateLinkNameContract.ps1` — rewritten
  as a genuine **compiled-template** contract test (was previously
  source-string/arithmetic only). Compiles `main.bicep`, then asserts on the
  compiled JSON:
  - Bounded fallback token is `<=28` chars, deterministic only (no
    `utcNow`/`newGuid`).
  - `searchFoundrySharedPrivateLinkMaxNameLength == 60`.
  - Each of the 3 groups' compiled ternary expression matches the exact
    `if(lessOrEquals(length(direct), max), direct, bounded)` structure.
  - All three names pairwise distinct (direct and bounded forms).
  - `searchFoundrySharedPrivateLinks` resource `type`/`apiVersion`/
    `dependsOn`/`copy.mode`/`copy.batchSize`/`copy.count` unchanged.
  - Maximum-length (60-char) Search name: all 3 groups bounded `<=60`,
    deterministic across repeated calls, pairwise distinct.
  - Live-failure replay (39-char name): reproduces pre-fix 60/61/71, confirms
    post-fix all `<=60`.
  - Ordinary/short CAF name (24 chars): all 3 groups keep the plain,
    pre-existing name (backward-compat guard).
  - **Explicit longest-suffix boundary pin** (hardcoded, not loop-derived):
    Search name length **28** — `cognitiveservices_account` direct/legacy
    name is exactly 60 chars and unchanged; length **29** — the same group
    switches to the bounded fallback (`<=60`) while `openai_account` and
    `foundry_account` (shorter suffixes) still keep their direct names,
    proving the longest suffix switches first.
  - Regression guard: every direct-name usage is `length(...) <=` guarded
    (no unconditional unbounded name assignment).
  - **Result: all 29 assertions pass.**
- `scripts/Measure-MainJsonSize.ps1` — the authoritative CI invocation
  (`.github/workflows/bicep-validate.yml`) uses `-WorkingBudgetMB 3.5
  -FailThresholdMB 4.7 -ArmHardCeilingMB 5.0`, not the script's own
  defaults. Under those CI thresholds, `main.json` at 4.662 MB **passes**
  (exit 0) with only a working-budget warning — it is well under both the
  4.7 MB fail threshold and the 5.0 MB ARM hard ceiling. This is unchanged
  from the base `develop` commit (this test-only/naming-only diff does not
  materially affect template size). The script's own unparameterized
  defaults (3.5/3.8/4.0 MB) are **not** the operative gate for this repo and
  should not be read as a breach.
- `tests/scripts/Invoke-PreflightChecks.Tests.ps1` — 43/43 pass.
- `tests/contracts/Test-AcrTaskAgentPoolFirewallContract.ps1` — pass, no
  regression (unrelated area).
- `tests/contracts/Test-HostedAgentContract.ps1` — fails in this environment
  due to a pre-existing Bicep-version pin mismatch (fixture requires Bicep
  0.42.1, Azure CLI here uses 0.46.1); confirmed this failure is identical on
  the base commit before this change (environment-only, unrelated to this
  fix).
- Independent code review of the diff (`main.bicep`, test file,
  `CHANGELOG.md`) — no issues found; arithmetic, guard/branch literal
  matching, determinism, and resource-contract preservation all verified.

## Related

Related: Azure/GPT-RAG#592
Related: Azure/GPT-RAG#597

## Release process note

This PR targets `develop` only. **No new AILZ tag or umbrella-pin bump is
included or requested here** — cutting a new tag/release and updating any
downstream umbrella pin requires explicit human approval per this repo's
release process, and is out of scope for this change.
