### PR TITLE
feat: separate hosted-agent preparation from deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
 
 ## [Unreleased]
 
+### Added
+
+- **Two-phase Microsoft Foundry hosted-agent preparation and deployment.**
+  Added the backward-compatible `prepareHostedAgent` flag (azd environment
+  variable `PREPARE_HOSTED_AGENT`), defaulting to `false`. Preparation now
+  provisions the existing generic Foundry project and selected-registry RBAC and
+  exposes the Foundry, ACR, network, and private-build handoff before an image
+  exists, without requiring `hostedAgent.version` or enabling an agent payload.
+  `deployHostedAgent=true` remains a superset, still fails closed unless
+  `hostedAgent.version` is an immutable `sha256:<64 lowercase hex>` digest, and
+  continues to represent downstream `azure.ai.agent` deployment intent. Existing
+  deployments with both flags omitted or `false` retain the previous resource
+  graph and empty hosted-agent outputs. Private ACR, VNet-injected ACR Task agent
+  pool, firewall, private endpoint, and DNS topology remain controlled by their
+  existing flags. This additive public contract is a **minor** release change;
+  Portal and Terraform landing-zone parity require follow-up review.
+
 ### Fixed
 
 - **Foundry IQ shared private-link names now stay within Azure AI Search's

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A handful of other quality-of-life additions:
 - **AI Foundry project naming** — `aiFoundryProjectName`, `aiFoundryProjectDisplayName`, and `aiFoundryProjectDescription` let consumers customize the deployed AI Foundry project instead of using a hardcoded default.
 - **Workload App Configuration passthrough** — `additionalAppConfigurationSettings` lets a solution accelerator publish its own runtime key-values into the App Configuration store without adding template-specific parameters. See [Workload App Configuration passthrough](#workload-app-configuration-passthrough).
 - **Foundry IQ groundwork for GPT-RAG:** set `RETRIEVAL_BACKEND=foundry_iq` to stamp the orchestrator settings for a Foundry IQ knowledge base. See [Foundry IQ for GPT-RAG](#foundry-iq-for-gpt-rag) for parameters, security expectations, billing, and the post-provision script.
-- **Hosted-agent deployment prerequisites** — `deployHostedAgent` exposes a typed, disabled-by-default handoff for a downstream Microsoft Foundry `azure.ai.agent` service. It adds only generic project/registry RBAC and outputs; it never removes or changes existing Container Apps or data resources. See [Hosted-agent deployment prerequisites](#hosted-agent-deployment-prerequisites).
+- **Two-phase hosted-agent preparation and deployment** — `prepareHostedAgent` provisions the generic project/registry prerequisites and build handoff before an image exists; `deployHostedAgent` remains the immutable-digest deployment intent and implies preparation. Both flags default to `false` and never remove or change existing Container Apps or data resources. See [Hosted-agent preparation and deployment](#hosted-agent-preparation-and-deployment).
 
 **Pick a runbook to deploy:**
 
@@ -260,25 +260,39 @@ VNet-injected (see [Azure/GPT-RAG#597](https://github.com/Azure/GPT-RAG/issues/5
 
 Use `DEPLOY_AAF_AGENT_SVC=false` when an external app only needs hosted model inference from Foundry and does not need Agent Service capability hosts or their associated state resources.
 
-### Hosted-agent deployment prerequisites
+### Hosted-agent preparation and deployment
 
-`deployHostedAgent` enables an accelerator-neutral infrastructure handoff for a
-downstream Microsoft Foundry hosted agent. It is **not** a workload topology
-switch. It does not create an agent version, application UI, or replacement
-workload, and it does not modify `containerAppsList`, Cosmos DB, Storage, Search,
-App Configuration, or any other existing workload resource. Those resources
-remain controlled exclusively by their existing parameters.
+Hosted-agent infrastructure uses two additive, accelerator-neutral phases:
 
-When the flag is `false` (the default), no hosted-agent RBAC is added and the
-compiled symbolic resource graph is identical to the pre-feature graph. When it
-is `true`, the landing zone adds only:
+- `prepareHostedAgent=true` provisions the shared prerequisites and exposes the
+  project, registry, network, and private-build handoff before an image or digest
+  exists. It does not request agent deployment.
+- `deployHostedAgent=true` implies preparation and additionally enables the typed
+  agent payload. It continues to require an immutable
+  `sha256:<64 lowercase hex characters>` image digest.
+
+Both flags default to `false`, so existing parameter files and deployments remain
+unchanged. The flags are **not** workload topology switches: they do not create
+an application UI or replacement workload, and they do not modify
+`containerAppsList`, Cosmos DB, Storage, Search, App Configuration, or any other
+existing workload resource.
+
+| `prepareHostedAgent` | `deployHostedAgent` | Prerequisite RBAC and handoff | Agent payload |
+|---|---|---|---|
+| `false` | `false` | Disabled | Disabled |
+| `true` | `false` | Enabled | Disabled; no image digest required |
+| `false` | `true` | Enabled | Enabled; immutable digest required |
+| `true` | `true` | Enabled | Enabled; immutable digest required |
+
+When either flag is enabled, the landing zone adds only:
 
 - `Foundry Project Manager` for the deployment principal on the Foundry project;
 - the registry-mode-compatible pull role for the Foundry project managed
   identity on the selected registry (`AcrPull` for RBAC-only registries or
   `Container Registry Repository Reader` for ABAC-enabled registries); and
-- a typed output handoff containing the project, registry, image, startup
-  command, runtime resources, protocols, agent subnet, and private-build context.
+- a typed output handoff containing the project, registry, agent subnet, and
+  private-build context. Image, startup command, runtime, and protocol values are
+  added only when deployment is requested.
 
 The downstream `azure.ai.agent` service remains responsible for `azd deploy`.
 That data-plane operation creates the immutable agent version, dedicated
@@ -297,10 +311,11 @@ that identity needs.
 
 | Parameter | Default | Purpose |
 |---|---|---|
-| `deployHostedAgent` | `false` | Enables only the generic RBAC and deployment handoff. |
+| `prepareHostedAgent` | `false` | Enables prerequisite RBAC and project/registry/private-build outputs without requiring an image or enabling the agent payload. |
+| `deployHostedAgent` | `false` | Implies preparation and enables the downstream agent deployment payload. |
 | `hostedAgent.name` | empty | Stable hosted-agent name; downstream deploys create immutable versions under this name. |
 | `hostedAgent.image` | empty | Repository path inside the selected ACR, without tag or digest. |
-| `hostedAgent.version` | empty | Required immutable OCI digest in `sha256:<64 hex>` form. |
+| `hostedAgent.version` | empty | Required only when `deployHostedAgent=true`; must be an immutable OCI digest in `sha256:<64 lowercase hex>` form. |
 | `hostedAgent.startupCommand` | empty | Optional container startup command, mapped to `startupCommand` in `azure.ai.agent`. |
 | `hostedAgent.runtime` | `1` CPU, `1Gi` | CPU (`0.25`–`4.0`) and memory (`0.5Gi`–`8Gi`) mapped to `container.resources`. |
 | `hostedAgent.protocols` | Responses `2.0.0` | Typed `responses`, `invocations`, `invocations_ws`, or `a2a` contracts. |
@@ -308,7 +323,21 @@ that identity needs.
 | `hostedAgentContainerRegistryEndpoint` | empty | Existing ACR login endpoint when `deployContainerRegistry=false`. |
 | `hostedAgentContainerRegistryRoleAssignmentMode` | `rbac` | Existing ACR permissions mode: `rbac` uses `AcrPull`; `rbac-abac` uses `Container Registry Repository Reader`. Ignored for the landing-zone registry, which is RBAC-only. |
 
-Example infrastructure handoff for an image already built, scanned, and pushed:
+For a fresh deployment, provision the prerequisites first:
+
+```bash
+azd env set PREPARE_HOSTED_AGENT true
+azd env set DEPLOY_HOSTED_AGENT false
+azd provision
+```
+
+At this point `HOSTED_AGENT_PREPARED=true`,
+`HOSTED_AGENT_DEPLOYMENT.enabled=false`, and
+`HOSTED_AGENT_DEPLOYMENT.agent=null`. The exact Foundry and registry outputs are
+available so a separate pipeline or VNet-connected build path can build, scan,
+sign, push, and resolve the immutable digest.
+
+After the image exists, enable deployment intent and pin that digest:
 
 ```bash
 azd env set DEPLOY_HOSTED_AGENT true
@@ -319,15 +348,23 @@ azd env set HOSTED_AGENT_STARTUP_COMMAND "python main.py"
 azd provision
 ```
 
+`PREPARE_HOSTED_AGENT` may remain `true` or be reset to `false`;
+`DEPLOY_HOSTED_AGENT=true` is always a superset.
+
 After provisioning, map `HOSTED_AGENT_DEPLOYMENT` (or the exact Foundry and ACR
 outputs) into the accelerator's `azure.ai.agent` service and run `azd deploy`
 from that accelerator. Preflight rejects mutable image tags and missing Foundry
-or registry prerequisites.
+or registry prerequisites. It validates the canonical digest syntax but does not
+query the registry for manifest existence or signature authenticity; keep those
+checks in the image build, scan, signing, and promotion pipeline.
 
 **Private registry:** the landing-zone ACR retains its existing Zero Trust
 behavior: Premium SKU, private endpoint and DNS integration, and disabled public
 network access when `networkIsolation=true`. Building or pushing an image in
 that mode must happen from a VNet-connected runner, build agent, or jumpbox.
+Set `DEPLOY_ACR_TASK_AGENT_POOL=true` when using the landing-zone VNet-injected
+ACR Tasks pool; its subnet, firewall, private endpoint, and DNS topology remain
+independently controlled by the existing registry/isolation/pool flags.
 For an existing ACR, set
 `HOSTED_AGENT_CONTAINER_REGISTRY_ROLE_ASSIGNMENT_MODE=rbac-abac` when its role
 assignment permissions mode is **RBAC Registry + ABAC Repository Permissions**;
@@ -343,10 +380,11 @@ and [hosted-agent permissions](https://learn.microsoft.com/azure/foundry/agents/
 
 | Output | Description |
 |---|---|
-| `DEPLOY_HOSTED_AGENT` | Effective enablement value. |
-| `AZURE_AI_PROJECT_RESOURCE_ID` / `AZURE_AI_PROJECT_ENDPOINT` | Exact Foundry project handoff. |
-| `AZURE_CONTAINER_REGISTRY_RESOURCE_ID` / `AZURE_CONTAINER_REGISTRY_ENDPOINT` | Exact selected-registry handoff. |
-| `HOSTED_AGENT_DEPLOYMENT` | Consolidated typed agent, Foundry, registry, network, and private-build contract. |
+| `DEPLOY_HOSTED_AGENT` | Deployment intent; remains `false` in prepare-only mode. |
+| `HOSTED_AGENT_PREPARED` | Effective prerequisite enablement (`prepareHostedAgent || deployHostedAgent`). It does not claim an agent version exists. |
+| `AZURE_AI_PROJECT_RESOURCE_ID` / `AZURE_AI_PROJECT_ENDPOINT` | Exact Foundry project handoff in prepare and deploy modes. |
+| `AZURE_CONTAINER_REGISTRY_RESOURCE_ID` / `AZURE_CONTAINER_REGISTRY_ENDPOINT` | Exact selected-registry handoff in prepare and deploy modes. |
+| `HOSTED_AGENT_DEPLOYMENT` | Consolidated contract. Foundry, registry, network, and private-build values are populated in prepare mode; `enabled` and `agent` remain deployment-only. |
 
 ### Workload App Configuration passthrough
 

--- a/docs/adr/0001-hosted-agent-preparation-and-deployment.md
+++ b/docs/adr/0001-hosted-agent-preparation-and-deployment.md
@@ -1,0 +1,174 @@
+# ADR-0001: Separate hosted-agent preparation from deployment intent
+
+- Status: proposed
+- Date: 2026-08-05
+- Owners: AI Landing Zone maintainers
+- Related issue or pull request: Azure/GPT-RAG downstream ADR-0001 and this implementation pull request
+
+## Context
+
+The AI Landing Zone exposes an accelerator-neutral Microsoft Foundry hosted-agent
+handoff. In v2.4.1, `deployHostedAgent=true` enables the prerequisite RBAC and
+outputs, but preflight also requires an immutable image digest. A fresh
+deployment cannot obtain the private registry and Foundry outputs needed to build
+that image until provisioning succeeds, which creates a circular dependency.
+
+Setting `deployHostedAgent=false` avoids the digest requirement but also removes
+the executor's Azure AI Project Manager assignment, the Foundry project
+identity's registry pull assignment, and the Foundry/registry/private-build
+outputs needed by a later build and deployment.
+
+The affected contracts are `main.bicep`, `main.parameters.json`, hosted-agent
+preflight, the two centralized RBAC payloads, output names and shapes, and the
+standard and network-isolated registry build topology. The Bicep template does
+not create a hosted-agent version. The downstream `azure.ai.agent` service
+creates the version, dedicated agent identity, and endpoint during `azd deploy`.
+
+## Prioritized characteristics
+
+| Characteristic | Priority | Measure |
+| --- | --- | --- |
+| Backward compatibility | 1 | Existing parameter files compile and both omitted flags preserve the prior resource graph and outputs. |
+| Two-phase operability | 2 | Preparation succeeds before an image exists and exports the values required to build it. |
+| Fail-closed deployment | 3 | Deployment still rejects missing, mutable, or malformed image digests. |
+| Least privilege | 4 | Preparation adds only the existing project-manager and registry-pull assignments at their existing scopes. |
+| Network topology stability | 5 | Private ACR, agent-pool, firewall, subnet, endpoint, and DNS gates remain unchanged. |
+
+## Alternatives considered
+
+### Add `prepareHostedAgent` beside `deployHostedAgent`
+
+An additive Boolean preserves all current callers. The effective prerequisite
+condition is `prepareHostedAgent || deployHostedAgent`, while image and agent
+payload validation remain gated only by `deployHostedAgent`. This is easy to
+adopt and reverse, and it does not introduce new resources or identities.
+
+### Replace the flags with a mode enum
+
+A `disabled`, `prepare`, or `deploy` enum would make invalid states
+unrepresentable, but replacing the existing flag is breaking. Keeping both an
+enum and the legacy Boolean would require precedence rules and make the public
+contract harder to operate. This option is suitable only for a future major
+version.
+
+### Treat an empty digest as preparation
+
+Overloading `deployHostedAgent=true` would weaken the immutable deployment
+contract, make `HOSTED_AGENT_DEPLOYMENT.enabled` ambiguous, and allow an
+accidental mutable or incomplete deployment path. This option is rejected.
+
+### Do not change
+
+Fresh deployments retain the provisioning/build cycle and must use a manual
+bootstrap or temporary unrelated configuration to obtain the prerequisite
+outputs.
+
+## Decision
+
+Add `prepareHostedAgent bool = false` and the matching
+`PREPARE_HOSTED_AGENT=false` azd parameter substitution.
+
+Define `_hostedAgentPrerequisitesEnabled` as
+`prepareHostedAgent || deployHostedAgent`. Use it for:
+
+- Azure AI Project Manager on the Foundry project for the deployment principal;
+- the registry-mode-compatible pull role on the selected registry for the
+  Foundry project identity;
+- the Foundry, registry, network, and private-build handoff outputs.
+
+Continue to use only `deployHostedAgent` for hosted-agent name, image, digest,
+runtime, and protocol validation and for `HOSTED_AGENT_DEPLOYMENT.enabled` and
+`.agent`. Add `HOSTED_AGENT_PREPARED` as the effective prerequisite signal
+without changing the meaning of `DEPLOY_HOSTED_AGENT`.
+
+## Consequences
+
+Preparation can complete before a registry image exists, after which a separate
+pipeline or VNet-connected builder can push an image and resolve its digest.
+Deployment remains a second explicit step.
+
+No new Azure resource type, identity, private endpoint, DNS zone, subnet, or
+hourly-cost resource is introduced. An operator who independently enables the
+existing ACR Task agent pool continues to incur that pool's existing cost.
+
+The two public flags can both be true. This is intentional because deployment is
+a prerequisite superset. A future major version may consolidate them into a mode
+enum if operational evidence justifies the migration.
+
+## Compatibility and migration
+
+Both flags default to `false`. Existing callers that set only
+`deployHostedAgent=true` keep the previous RBAC, output, and digest-validation
+behavior because deployment implies preparation. Existing callers that omit the
+feature retain the disabled graph and output fallbacks.
+
+New callers use this sequence:
+
+1. Set `prepareHostedAgent=true` and provision.
+2. Consume the Foundry, registry, network, and private-build outputs.
+3. Build, scan, sign, and push the image, then capture its SHA-256 digest.
+4. Set `deployHostedAgent=true` and the typed hosted-agent values.
+5. Provision the handoff and run the downstream accelerator's `azd deploy`.
+
+This is an additive minor-version contract. The Portal and Terraform landing
+zones require parity review before release.
+
+## Security and identity
+
+Preparation reuses the Foundry project system-assigned identity and the existing
+deployment principal. It does not create or predict the dedicated per-agent
+identity. RBAC remains centralized and scoped to the Foundry project and selected
+registry. Registry role selection remains `AcrPull` for RBAC-only registries and
+Container Registry Repository Reader for ABAC-enabled registries.
+
+No credential, mutable image tag, malformed value, or placeholder digest is
+accepted. Deployment preflight requires exactly `sha256:` followed by 64
+lowercase hexadecimal characters, without surrounding whitespace. This
+deterministic check does not query the registry for manifest existence or
+signature authenticity; those checks remain the responsibility of the image
+build, promotion, and downstream deployment pipeline.
+
+Network-isolated deployments retain Premium ACR, disabled public access, private
+endpoint and DNS behavior, and the existing VNet-injected ACR Task agent-pool
+topology. Existing registries retain consumer-owned endpoint, DNS, and
+reachability responsibilities.
+
+## Adoption and rollback
+
+Adopt preparation first, then build and deploy from the immutable digest.
+`prepareHostedAgent` may remain true after deployment or be reset because
+`deployHostedAgent` implies it.
+
+Setting both flags to `false` stops emitting the handoff; disabling only
+`deployHostedAgent` leaves preparation RBAC and outputs enabled while
+`prepareHostedAgent` remains true. Disabling the contract does not guarantee
+deletion of role assignments under incremental ARM deployment. Operators must
+explicitly remove no-longer-required assignments. A downstream hosted-agent
+version is outside this template and requires downstream cleanup. When pinning
+to v2.4.1, remove `prepareHostedAgent` from caller parameter files.
+
+## Compliance verification
+
+- Compile and lint `main.bicep`.
+- Enforce the compiled-template size gate.
+- Prove both flags default to false and the default resource graph is stable.
+- Prove prerequisite RBAC and outputs use the effective OR condition.
+- Prove the agent payload remains deployment-only and no hosted resource exists.
+- Exercise prepare-only, immutable, mutable, missing-digest, and missing-
+  prerequisite preflight behavior.
+- Re-run the private ACR Task agent-pool firewall contract.
+- Use What-If and a live disposable deployment only with explicit approval.
+
+## Documentation impact
+
+Update the repository README, test harness documentation, and Unreleased
+changelog. No hosted-agent content currently exists in the public
+`Azure/AI-Landing-Zones` documentation repository, so no companion public-doc
+change is required for this decision.
+
+## Review trigger
+
+Review this decision when Microsoft Foundry exposes a stable ARM hosted-agent
+resource, changes private ACR identity or networking requirements, graduates the
+hosted-agent service from preview, or when a future major release can replace the
+two flags with a single mode without breaking consumers.

--- a/main.bicep
+++ b/main.bicep
@@ -386,10 +386,13 @@ param deployAzureFirewall bool = true
 @description('Deploy an ACR Task agent pool so image builds can run inside the VNet when the registry has public access disabled. Requires a Premium container registry (auto-selected when networkIsolation is true) and is gated on both deployContainerRegistry and networkIsolation.')
 param deployAcrTaskAgentPool bool = true
 
-@description('Enable accelerator-neutral prerequisites and deployment contracts for a Microsoft Foundry hosted agent. The landing zone does not create the data-plane agent version and never changes Container Apps or data resources. Defaults to false.')
+@description('Prepare accelerator-neutral Microsoft Foundry hosted-agent prerequisites without requesting downstream agent deployment. Provisions the required project and registry RBAC and exposes project, registry, network, and private-build handoff values. deployHostedAgent implies this behavior. Defaults to false.')
+param prepareHostedAgent bool = false
+
+@description('Request the downstream Microsoft Foundry hosted-agent deployment handoff. Implies prepareHostedAgent behavior and requires hostedAgent.version to be an immutable OCI digest. The landing zone does not create the data-plane agent version and never changes Container Apps or data resources. Defaults to false.')
 param deployHostedAgent bool = false
 
-@description('Typed hosted-agent deployment handoff consumed by a downstream `azure.ai.agent` service. `image` is the repository path within the selected registry, `version` must be an immutable OCI digest (`sha256:...`), optional `startupCommand` maps to the official azure.yaml field, and `runtime` maps to `container.resources`. Values are validated only when deployHostedAgent is true.')
+@description('Typed hosted-agent deployment handoff consumed by a downstream `azure.ai.agent` service. `image` is the repository path within the selected registry, `version` must be an immutable OCI digest (`sha256:` plus 64 lowercase hex characters), optional `startupCommand` maps to the official azure.yaml field, and `runtime` maps to `container.resources`. Values are validated only when deployHostedAgent is true.')
 param hostedAgent hostedAgentConfigurationType = {
   name: ''
   image: ''
@@ -524,7 +527,7 @@ type hostedAgentConfigurationType = {
   @description('Container image repository path inside the selected registry, without a tag or digest.')
   image: string
 
-  @description('Immutable OCI image digest in `sha256:<64 hex characters>` form.')
+  @description('Immutable OCI image digest in `sha256:<64 lowercase hex characters>` form.')
   version: string
 
   @description('Optional command that starts the agent server. Maps to `startupCommand` in the official `azure.ai.agent` service contract.')
@@ -1033,11 +1036,12 @@ var _extraRepoTags  = [for c in _manifestComponents: c.?tag ?? 'main']
 var _extraRepoNames = [for c in _manifestComponents: c.?name ?? replace(last(split(c.repo, '/')), '.git', '')]
 
 var _networkIsolation = empty(string(networkIsolation)) ? false : bool(networkIsolation)
+var _hostedAgentPrerequisitesEnabled = prepareHostedAgent || deployHostedAgent
 
 #disable-next-line BCP318
 var _hostedAgentContainerRegistryResourceId = deployContainerRegistry ? containerRegistry.id : hostedAgentContainerRegistryResourceId
 var _hostedAgentContainerRegistryEndpoint = deployContainerRegistry ? '${resourceNames.containerRegistryName}.${acrDnsSuffix}' : hostedAgentContainerRegistryEndpoint
-var _hostedAgentImageReference = '${_hostedAgentContainerRegistryEndpoint}/${hostedAgent.image}@${hostedAgent.version}'
+var _hostedAgentImageReference = deployHostedAgent ? '${_hostedAgentContainerRegistryEndpoint}/${hostedAgent.image}@${hostedAgent.version}' : ''
 var _containerRegistryRepositoryReaderRoleId = 'b93aa761-3e63-49ed-ac28-beffa264f7ac'
 var _hostedAgentContainerRegistryPullRoleId = deployContainerRegistry || hostedAgentContainerRegistryRoleAssignmentMode == 'rbac'
   ? const.roles.AcrPull.guid
@@ -3345,7 +3349,7 @@ var _executorRoles = concat(
         principalType: principalType
       }
     ],
-    deployHostedAgent ? [
+    _hostedAgentPrerequisitesEnabled ? [
       {
         principalId: principalId
         roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', const.roles.AzureAIProjectManager.guid)
@@ -3567,7 +3571,7 @@ var _crossServiceRoleAssignments = concat(
   // Registry-mode-compatible pull role -> AI Foundry project identity.
   // The dedicated hosted-agent identity and its runtime roles are created by
   // `azd deploy`; the landing zone must not invent or replace that identity.
-  (deployHostedAgent && deployAiFoundry) ? [
+  (_hostedAgentPrerequisitesEnabled && deployAiFoundry) ? [
     {
       principalId: aiFoundry!.outputs.aiProjectPrincipalId
       roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', _hostedAgentContainerRegistryPullRoleId)
@@ -3577,7 +3581,7 @@ var _crossServiceRoleAssignments = concat(
   ] : []
 )
 
-module assignCrossServiceRoles 'modules/security/resource-role-assignment.bicep' = if ((deployAiFoundry && deploySearchService) || (deployStorageAccount && deploySearchService) || (deployAiFoundry && deployStorageAccount) || (deployHostedAgent && deployAiFoundry)) {
+module assignCrossServiceRoles 'modules/security/resource-role-assignment.bicep' = if ((deployAiFoundry && deploySearchService) || (deployStorageAccount && deploySearchService) || (deployAiFoundry && deployStorageAccount) || (_hostedAgentPrerequisitesEnabled && deployAiFoundry)) {
   name: 'assignCrossServiceRoles'
   params: {
     name: 'assignCrossServiceRoles'
@@ -4033,10 +4037,12 @@ output CONTAINER_APP_INTERNAL_FQDN string = (deployContainerApps && length(conta
 // dedicated agent identity, and invocation endpoint are data-plane resources
 // created by the downstream `azure.ai.agent` service during `azd deploy`.
 output DEPLOY_HOSTED_AGENT bool = deployHostedAgent
-output AZURE_AI_PROJECT_RESOURCE_ID string = deployHostedAgent ? aiFoundryProjectResourceId : ''
-output AZURE_AI_PROJECT_ENDPOINT string = deployHostedAgent ? aiFoundryProjectEndpoint : ''
-output AZURE_CONTAINER_REGISTRY_RESOURCE_ID string = deployHostedAgent ? _hostedAgentContainerRegistryResourceId : ''
-output AZURE_CONTAINER_REGISTRY_ENDPOINT string = deployHostedAgent ? _hostedAgentContainerRegistryEndpoint : ''
+@description('True when hosted-agent prerequisites were selected through prepareHostedAgent or deployHostedAgent. This does not indicate that a hosted agent version exists.')
+output HOSTED_AGENT_PREPARED bool = _hostedAgentPrerequisitesEnabled
+output AZURE_AI_PROJECT_RESOURCE_ID string = _hostedAgentPrerequisitesEnabled ? aiFoundryProjectResourceId : ''
+output AZURE_AI_PROJECT_ENDPOINT string = _hostedAgentPrerequisitesEnabled ? aiFoundryProjectEndpoint : ''
+output AZURE_CONTAINER_REGISTRY_RESOURCE_ID string = _hostedAgentPrerequisitesEnabled ? _hostedAgentContainerRegistryResourceId : ''
+output AZURE_CONTAINER_REGISTRY_ENDPOINT string = _hostedAgentPrerequisitesEnabled ? _hostedAgentContainerRegistryEndpoint : ''
 #disable-next-line BCP318
 output HOSTED_AGENT_DEPLOYMENT object = {
   enabled: deployHostedAgent
@@ -4048,20 +4054,20 @@ output HOSTED_AGENT_DEPLOYMENT object = {
     runtime: hostedAgent.runtime
     protocols: hostedAgent.protocols
   } : null
-  foundry: deployHostedAgent ? {
+  foundry: _hostedAgentPrerequisitesEnabled ? {
     projectResourceId: aiFoundryProjectResourceId
     projectEndpoint: aiFoundryProjectEndpoint
     projectPrincipalId: aiFoundry!.outputs.aiProjectPrincipalId
     agentSubnetResourceId: _agentSubnetId
   } : null
-  containerRegistry: deployHostedAgent ? {
+  containerRegistry: _hostedAgentPrerequisitesEnabled ? {
     resourceId: _hostedAgentContainerRegistryResourceId
     endpoint: _hostedAgentContainerRegistryEndpoint
   } : null
   privateBuild: {
-    required: deployHostedAgent && _networkIsolation
-    subnetResourceId: (deployHostedAgent && _networkIsolation) ? '${virtualNetworkResourceId}/subnets/${devopsBuildAgentsSubnetName}' : ''
-    jumpboxResourceId: (deployHostedAgent && _networkIsolation) ? (_deployJumpbox ? testVm!.outputs.resourceId : (existingJumpboxResourceId ?? '')) : ''
-    acrTaskAgentPoolName: (deployHostedAgent && _deployAcrTaskAgentPool) ? acrTaskAgentPoolName : ''
+    required: _hostedAgentPrerequisitesEnabled && _networkIsolation
+    subnetResourceId: (_hostedAgentPrerequisitesEnabled && _networkIsolation) ? '${virtualNetworkResourceId}/subnets/${devopsBuildAgentsSubnetName}' : ''
+    jumpboxResourceId: (_hostedAgentPrerequisitesEnabled && _networkIsolation) ? (_deployJumpbox ? testVm!.outputs.resourceId : (existingJumpboxResourceId ?? '')) : ''
+    acrTaskAgentPoolName: (_hostedAgentPrerequisitesEnabled && _deployAcrTaskAgentPool) ? acrTaskAgentPoolName : ''
   }
 }

--- a/main.parameters.json
+++ b/main.parameters.json
@@ -73,6 +73,7 @@
     "publicIngress":                        { "value": { "enabled": false } },
     "deployMcp":                            { "value": "${DEPLOY_MCP=true}" },
     "deployGroundingWithBing":              { "value": "${DEPLOY_GROUNDING_WITH_BING=false}" },
+    "prepareHostedAgent":                   { "value": "${PREPARE_HOSTED_AGENT=false}" },
     "deployHostedAgent":                    { "value": "${DEPLOY_HOSTED_AGENT=false}" },
     "hostedAgent":                          { "value": {
       "name": "${HOSTED_AGENT_NAME=}",

--- a/scripts/Invoke-PreflightChecks.ps1
+++ b/scripts/Invoke-PreflightChecks.ps1
@@ -404,12 +404,14 @@ function Test-Topology {
 function Test-HostedAgentConfiguration {
     param([hashtable]$P)
 
-    if (-not (Resolve-DeployFlag -P $P -Key 'deployHostedAgent' -Default $false)) { return }
+    $prepareHostedAgent = Resolve-DeployFlag -P $P -Key 'prepareHostedAgent' -Default $false
+    $deployHostedAgent = Resolve-DeployFlag -P $P -Key 'deployHostedAgent' -Default $false
+    if (-not ($prepareHostedAgent -or $deployHostedAgent)) { return }
 
     $deployAiFoundry = Resolve-DeployFlag -P $P -Key 'deployAiFoundry' -Default $true
     if (-not $deployAiFoundry) {
         Add-Finding -Severity FAIL -Code 'HOSTED_AGENT_FOUNDRY_REQUIRED' `
-            -Message 'deployHostedAgent=true requires deployAiFoundry=true.' `
+            -Message 'Hosted-agent preparation or deployment requires deployAiFoundry=true.' `
             -Hint 'Enable the shared Foundry account/project or disable hosted-agent prerequisites.'
     }
 
@@ -427,9 +429,16 @@ function Test-HostedAgentConfiguration {
     }
     if (-not $deployRegistry -and ([string]::IsNullOrWhiteSpace($existingRegistryId) -or [string]::IsNullOrWhiteSpace($existingRegistryEndpoint))) {
         Add-Finding -Severity FAIL -Code 'HOSTED_AGENT_REGISTRY_REQUIRED' `
-            -Message 'deployHostedAgent=true requires the landing-zone registry or both existing registry inputs.' `
+            -Message 'Hosted-agent preparation or deployment requires the landing-zone registry or both existing registry inputs.' `
             -Hint 'Enable DEPLOY_CONTAINER_REGISTRY, or set HOSTED_AGENT_CONTAINER_REGISTRY_RESOURCE_ID and HOSTED_AGENT_CONTAINER_REGISTRY_ENDPOINT.'
     }
+
+    if ((ConvertTo-Bool $P['networkIsolation'])) {
+        Add-Finding -Severity INFO -Code 'HOSTED_AGENT_PRIVATE_BUILD_REQUIRED' `
+            -Message 'The hosted-agent registry is private. Build and push from a VNet-connected runner/agent or the jumpbox fallback; shared ACR Tasks do not bypass private endpoint access.'
+    }
+
+    if (-not $deployHostedAgent) { return }
 
     $agent = $P['hostedAgent']
     if ($null -eq $agent) {
@@ -446,7 +455,7 @@ function Test-HostedAgentConfiguration {
     $envValues = Get-AzdEnvValues
     $name = (Get-StringValue (Expand-ParamValue -Raw $agent.name -EnvValues $envValues)).Trim()
     $image = (Get-StringValue (Expand-ParamValue -Raw $agent.image -EnvValues $envValues)).Trim()
-    $version = (Get-StringValue (Expand-ParamValue -Raw $agent.version -EnvValues $envValues)).Trim()
+    $version = Get-StringValue (Expand-ParamValue -Raw $agent.version -EnvValues $envValues)
     $startupCommand = (Get-StringValue (Expand-ParamValue -Raw $agent.startupCommand -EnvValues $envValues)).Trim()
     $cpu = (Get-StringValue (Expand-ParamValue -Raw $agent.runtime.cpu -EnvValues $envValues)).Trim()
     $memory = (Get-StringValue (Expand-ParamValue -Raw $agent.runtime.memory -EnvValues $envValues)).Trim()
@@ -463,9 +472,9 @@ function Test-HostedAgentConfiguration {
         }
     }
 
-    if ($version -notmatch '^sha256:[0-9a-fA-F]{64}$') {
+    if ($version -cnotmatch '\Asha256:[0-9a-f]{64}\z') {
         Add-Finding -Severity FAIL -Code 'HOSTED_AGENT_IMAGE_NOT_IMMUTABLE' `
-            -Message 'hostedAgent.version must be an immutable OCI digest in sha256:<64 hex characters> form.' `
+            -Message 'hostedAgent.version must use the exact immutable OCI digest syntax sha256:<64 lowercase hex characters>, without surrounding whitespace.' `
             -Hint 'Build and push the image first, then pin the digest rather than using a mutable tag.'
     }
 
@@ -509,10 +518,6 @@ function Test-HostedAgentConfiguration {
         }
     }
 
-    if ((ConvertTo-Bool $P['networkIsolation'])) {
-        Add-Finding -Severity INFO -Code 'HOSTED_AGENT_PRIVATE_BUILD_REQUIRED' `
-            -Message 'The hosted-agent registry is private. Build and push from a VNet-connected runner/agent or the jumpbox fallback; shared ACR Tasks do not bypass private endpoint access.'
-    }
 }
 
 function Test-AllowedIpRanges {

--- a/tests/README.md
+++ b/tests/README.md
@@ -53,9 +53,12 @@ pwsh tests/scripts/Invoke-PreflightChecks.Tests.ps1
 The hosted-agent contract test compiles with the Bicep version recorded in its
 fixture and proves that the default-disabled feature preserves every symbolic
 resource from the merge base. It permits changes only in the two centralized
-RBAC deployment payloads and checks that those additions are
-`deployHostedAgent`-gated, least privilege, and accompanied by the stable
-Foundry/registry handoff. The ACR Task agent pool firewall contract test
+RBAC deployment payloads and checks that those additions are gated by
+`prepareHostedAgent || deployHostedAgent`, least privilege, and accompanied by
+the stable Foundry/registry handoff. It also proves both flags default to
+`false`, prepare mode never enables the agent payload or creates a hosted-agent
+resource, deployment remains digest-gated, and private ACR agent-pool topology
+stays independently controlled. The ACR Task agent pool firewall contract test
 (Azure/GPT-RAG#597) asserts that the VNet-injected ACR Tasks dedicated agent
 pool's required outbound platform-bootstrap Network Rules (AzureKeyVault,
 Storage, EventHub, AzureActiveDirectory, AzureMonitor) are present, correctly
@@ -63,8 +66,9 @@ gated, ordered, and scoped to the devops build agents subnet — independent of
 the opaque hash check above. The Foundry shared private-link naming contract
 proves valid legacy child IDs remain unchanged, both long suffix variants stay
 within 60 characters, output is deterministic, and distinct tested long inputs
-do not collide. The deterministic preflight tests cover disabled, valid,
-mutable-image, and missing-prerequisite configurations without accessing Azure.
+do not collide. The deterministic preflight tests cover disabled, prepare-only,
+valid immutable deployment, mutable/missing image digest, private build, and
+missing-prerequisite configurations without accessing Azure.
 
 ## End-to-end test flow
 

--- a/tests/contracts/Test-HostedAgentContract.ps1
+++ b/tests/contracts/Test-HostedAgentContract.ps1
@@ -6,7 +6,7 @@
     Compiles main.bicep and compares its symbolic ARM resource graph with the
     merge-base fixture. All pre-existing deployment semantics must remain stable.
     Only the two centralized RBAC deployment payloads may change, and both
-    changes must be gated by deployHostedAgent.
+    changes must be gated by prepareHostedAgent or deployHostedAgent.
 #>
 
 [CmdletBinding()]
@@ -126,11 +126,25 @@ try {
 
     Write-Host "Hosted-agent resource contract (baseline $($fixture.mergeBase))" -ForegroundColor Cyan
 
-    if ($template.parameters.deployHostedAgent.defaultValue -ne $false) {
-        Add-Failure 'deployHostedAgent must default to false.'
+    foreach ($parameterName in 'prepareHostedAgent', 'deployHostedAgent') {
+        if ($template.parameters.$parameterName.defaultValue -ne $false) {
+            Add-Failure "$parameterName must default to false."
+        }
+        else {
+            Add-Pass "$parameterName defaults to false."
+        }
+    }
+
+    $prerequisiteExpression = [string]$template.variables._hostedAgentPrerequisitesEnabled
+    $missingPrerequisiteTokens = @(
+        "parameters('prepareHostedAgent')",
+        "parameters('deployHostedAgent')"
+    ) | Where-Object { -not $prerequisiteExpression.Contains($_) }
+    if ($missingPrerequisiteTokens.Count -gt 0 -or -not $prerequisiteExpression.Contains('or(')) {
+        Add-Failure "Hosted-agent prerequisites must be enabled by prepareHostedAgent OR deployHostedAgent. Expression: $prerequisiteExpression"
     }
     else {
-        Add-Pass 'deployHostedAgent defaults to false.'
+        Add-Pass 'deployHostedAgent is a superset of prepareHostedAgent prerequisites.'
     }
 
     $expectedNames = @($fixture.resourceHashes.PSObject.Properties.Name) + @($fixture.allowedHostedMutations)
@@ -169,14 +183,14 @@ try {
     $crossServiceJson = $template.resources.assignCrossServiceRoles | ConvertTo-Json -Depth 100 -Compress
     foreach ($check in @(
             @{
-                Name = 'Executor receives Foundry Project Manager only when hosted enablement is selected.'
+                Name = 'Executor receives Foundry Project Manager when preparation or deployment is selected.'
                 Json = $executorJson
-                Required = @("parameters('deployHostedAgent')", 'AzureAIProjectManager')
+                Required = @("variables('_hostedAgentPrerequisitesEnabled')", 'AzureAIProjectManager')
             },
             @{
-                Name = 'Foundry project identity receives a registry-mode-compatible pull role only when hosted enablement is selected.'
+                Name = 'Foundry project identity receives a registry-mode-compatible pull role when preparation or deployment is selected.'
                 Json = $crossServiceJson
-                Required = @("parameters('deployHostedAgent')", "variables('_hostedAgentContainerRegistryPullRoleId')")
+                Required = @("variables('_hostedAgentPrerequisitesEnabled')", "variables('_hostedAgentContainerRegistryPullRoleId')")
             }
         )) {
         $missing = @($check.Required | Where-Object { -not $check.Json.Contains($_) })
@@ -216,6 +230,7 @@ try {
             'AZURE_AI_PROJECT_ENDPOINT',
             'AZURE_CONTAINER_REGISTRY_RESOURCE_ID',
             'AZURE_CONTAINER_REGISTRY_ENDPOINT',
+            'HOSTED_AGENT_PREPARED',
             'HOSTED_AGENT_DEPLOYMENT'
         )) {
         if ($outputName -notin $template.outputs.PSObject.Properties.Name) {
@@ -224,6 +239,81 @@ try {
     }
     if (-not ($failures | Where-Object { $_ -like "Required hosted-agent handoff output*" })) {
         Add-Pass 'Stable Foundry, registry, image/runtime, network, and private-build outputs are present.'
+    }
+
+    foreach ($outputName in @(
+            'AZURE_AI_PROJECT_RESOURCE_ID',
+            'AZURE_AI_PROJECT_ENDPOINT',
+            'AZURE_CONTAINER_REGISTRY_RESOURCE_ID',
+            'AZURE_CONTAINER_REGISTRY_ENDPOINT'
+        )) {
+        $outputJson = $template.outputs.$outputName | ConvertTo-Json -Depth 20 -Compress
+        if (-not $outputJson.Contains("variables('_hostedAgentPrerequisitesEnabled')")) {
+            Add-Failure "$outputName must be available in prepare and deploy modes."
+        }
+    }
+    if (-not ($failures | Where-Object { $_ -like '*must be available in prepare and deploy modes*' })) {
+        Add-Pass 'Foundry and registry handoff outputs are available in both preparation and deployment modes.'
+    }
+
+    $preparedOutputJson = $template.outputs.HOSTED_AGENT_PREPARED | ConvertTo-Json -Depth 20 -Compress
+    if (-not $preparedOutputJson.Contains("variables('_hostedAgentPrerequisitesEnabled')")) {
+        Add-Failure 'HOSTED_AGENT_PREPARED must expose effective prerequisite enablement.'
+    }
+    else {
+        Add-Pass 'HOSTED_AGENT_PREPARED distinguishes prepared infrastructure from deployment intent.'
+    }
+
+    $deploymentOutput = $template.outputs.HOSTED_AGENT_DEPLOYMENT.value
+    $deploymentOnlyJson = @(
+        $deploymentOutput.enabled,
+        $deploymentOutput.agent
+    ) | ConvertTo-Json -Depth 30 -Compress
+    if (-not $deploymentOnlyJson.Contains("parameters('deployHostedAgent')") -or
+        $deploymentOnlyJson.Contains("parameters('prepareHostedAgent')") -or
+        $deploymentOnlyJson.Contains("variables('_hostedAgentPrerequisitesEnabled')")) {
+        Add-Failure 'HOSTED_AGENT_DEPLOYMENT.enabled and agent must remain gated only by deployHostedAgent.'
+    }
+    else {
+        Add-Pass 'Preparation does not enable or populate the hosted-agent deployment payload.'
+    }
+
+    $prerequisiteOutputJson = @(
+        $deploymentOutput.foundry,
+        $deploymentOutput.containerRegistry,
+        $deploymentOutput.privateBuild
+    ) | ConvertTo-Json -Depth 30 -Compress
+    if (-not $prerequisiteOutputJson.Contains("variables('_hostedAgentPrerequisitesEnabled')")) {
+        Add-Failure 'HOSTED_AGENT_DEPLOYMENT prerequisite handoff must be available in prepare and deploy modes.'
+    }
+    else {
+        Add-Pass 'The consolidated handoff exposes Foundry, registry, and private-build prerequisites in prepare mode.'
+    }
+
+    $resourceJson = $template.resources | ConvertTo-Json -Depth 100 -Compress
+    $hostedResourceTokens = @('azure.ai.agent', 'Microsoft.CognitiveServices/accounts/projects/agents')
+    $unexpectedHostedResourceTokens = @($hostedResourceTokens | Where-Object { $resourceJson.Contains($_) })
+    if ($unexpectedHostedResourceTokens.Count -gt 0) {
+        Add-Failure "Preparation must not create a hosted-agent resource. Found: $($unexpectedHostedResourceTokens -join ', ')."
+    }
+    else {
+        Add-Pass 'No hosted-agent resource exists in the compiled preparation template.'
+    }
+
+    $agentPoolExpression = [string]$template.variables._deployAcrTaskAgentPool
+    $requiredAgentPoolTokens = @(
+        "parameters('deployContainerRegistry')",
+        "variables('_networkIsolation')",
+        "parameters('deployAcrTaskAgentPool')"
+    )
+    $missingAgentPoolTokens = @($requiredAgentPoolTokens | Where-Object { -not $agentPoolExpression.Contains($_) })
+    if ($missingAgentPoolTokens.Count -gt 0 -or
+        $agentPoolExpression.Contains("parameters('prepareHostedAgent')") -or
+        $agentPoolExpression.Contains("parameters('deployHostedAgent')")) {
+        Add-Failure "Private ACR agent-pool topology changed unexpectedly. Expression: $agentPoolExpression"
+    }
+    else {
+        Add-Pass 'Private ACR agent-pool topology remains independently gated by registry, isolation, and pool selection.'
     }
 
     $registryJson = $template.resources.containerRegistry | ConvertTo-Json -Depth 100 -Compress

--- a/tests/scripts/Invoke-PreflightChecks.Tests.ps1
+++ b/tests/scripts/Invoke-PreflightChecks.Tests.ps1
@@ -4,7 +4,8 @@
 
 .DESCRIPTION
     Synthetic-input tests that exercise the deterministic checks (Test-Topology,
-    Test-AllowedIpRanges, Test-LocalCidrSanity) without touching Azure.
+    Test-HostedAgentConfiguration, Test-AllowedIpRanges, Test-LocalCidrSanity)
+    without touching Azure.
 
     Usage:
         pwsh ./tests/scripts/Invoke-PreflightChecks.Tests.ps1
@@ -209,14 +210,29 @@ Assert-True 'WARN ISO_NO_INGRESS raised' (Test-FindingPresent 'ISO_NO_INGRESS')
 Write-Host 'Hosted agent: disabled contract is inert' -ForegroundColor Cyan
 Reset-Findings
 Test-HostedAgentConfiguration -P @{
+    prepareHostedAgent = $false
     deployHostedAgent = $false
 }
 Assert-True 'Disabled hosted-agent contract emits no findings' (@($script:Findings).Count -eq 0)
 
 # --------------------------------------------------------------------------
-Write-Host 'Hosted agent: valid additive contract passes' -ForegroundColor Cyan
+Write-Host 'Hosted agent: prepare-only contract does not require an image digest' -ForegroundColor Cyan
 Reset-Findings
 Test-HostedAgentConfiguration -P @{
+    prepareHostedAgent    = $true
+    deployHostedAgent     = $false
+    deployAiFoundry       = $true
+    deployContainerRegistry = $true
+    networkIsolation      = $false
+}
+Assert-True 'Prepare-only hosted-agent contract has no failures without hostedAgent.version' (@($script:Findings | Where-Object Severity -eq 'FAIL').Count -eq 0)
+Assert-True 'Prepare-only hosted-agent contract skips immutable image validation' (Test-FindingAbsent 'HOSTED_AGENT_IMAGE_NOT_IMMUTABLE')
+
+# --------------------------------------------------------------------------
+Write-Host 'Hosted agent: deploy is a superset and accepts an immutable digest' -ForegroundColor Cyan
+Reset-Findings
+Test-HostedAgentConfiguration -P @{
+    prepareHostedAgent      = $false
     deployHostedAgent       = $true
     deployAiFoundry         = $true
     deployContainerRegistry = $true
@@ -231,25 +247,32 @@ Test-HostedAgentConfiguration -P @{
     }
 }
 Assert-True 'Valid hosted-agent contract has no failures' (@($script:Findings | Where-Object Severity -eq 'FAIL').Count -eq 0)
+Assert-True 'Immutable hosted-agent image digest is accepted' (Test-FindingAbsent 'HOSTED_AGENT_IMAGE_NOT_IMMUTABLE')
+
+# --------------------------------------------------------------------------
+Write-Host 'Hosted agent: private preparation reports the VNet build requirement' -ForegroundColor Cyan
+Reset-Findings
+Test-HostedAgentConfiguration -P @{
+    prepareHostedAgent      = $true
+    deployHostedAgent       = $false
+    deployAiFoundry         = $true
+    deployContainerRegistry = $true
+    networkIsolation        = $true
+}
+Assert-True 'Prepare-only private registry requires an in-VNet build path' (Test-FindingPresent 'HOSTED_AGENT_PRIVATE_BUILD_REQUIRED')
+Assert-True 'Prepare-only private registry has no failures' (@($script:Findings | Where-Object Severity -eq 'FAIL').Count -eq 0)
 
 # --------------------------------------------------------------------------
 Write-Host 'Hosted agent: registry role assignment mode is validated' -ForegroundColor Cyan
 Reset-Findings
 Test-HostedAgentConfiguration -P @{
-    deployHostedAgent                               = $true
+    prepareHostedAgent                              = $true
+    deployHostedAgent                               = $false
     deployAiFoundry                                 = $true
     deployContainerRegistry                         = $false
     hostedAgentContainerRegistryResourceId         = '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.ContainerRegistry/registries/acr'
     hostedAgentContainerRegistryEndpoint           = 'acr.azurecr.io'
     hostedAgentContainerRegistryRoleAssignmentMode = 'unsupported'
-    hostedAgent                                     = [pscustomobject]@{
-        name           = 'sample-agent'
-        image          = 'agents/sample'
-        version        = "sha256:$('a' * 64)"
-        startupCommand = ''
-        runtime        = [pscustomobject]@{ cpu = '1'; memory = '1Gi' }
-        protocols      = @([pscustomobject]@{ protocol = 'responses'; version = '2.0.0' })
-    }
 }
 Assert-True 'FAIL HOSTED_AGENT_REGISTRY_ROLE_MODE_INVALID raised' (Test-FindingPresent 'HOSTED_AGENT_REGISTRY_ROLE_MODE_INVALID')
 
@@ -310,22 +333,60 @@ Test-HostedAgentConfiguration -P @{
 Assert-True 'FAIL HOSTED_AGENT_IMAGE_NOT_IMMUTABLE raised' (Test-FindingPresent 'HOSTED_AGENT_IMAGE_NOT_IMMUTABLE')
 
 # --------------------------------------------------------------------------
-Write-Host 'Hosted agent: Foundry and registry prerequisites are enforced' -ForegroundColor Cyan
+Write-Host 'Hosted agent: missing image digest is rejected during deployment' -ForegroundColor Cyan
 Reset-Findings
 Test-HostedAgentConfiguration -P @{
-    deployHostedAgent                       = $true
-    deployAiFoundry                         = $false
-    deployContainerRegistry                 = $false
-    hostedAgentContainerRegistryResourceId = ''
-    hostedAgentContainerRegistryEndpoint   = ''
-    hostedAgent                             = [pscustomobject]@{
+    prepareHostedAgent      = $true
+    deployHostedAgent       = $true
+    deployAiFoundry         = $true
+    deployContainerRegistry = $true
+    hostedAgent             = [pscustomobject]@{
         name           = 'sample-agent'
         image          = 'agents/sample'
-        version        = "sha256:$('b' * 64)"
+        version        = ''
         startupCommand = 'python main.py'
         runtime        = [pscustomobject]@{ cpu = '1'; memory = '1Gi' }
         protocols      = @([pscustomobject]@{ protocol = 'responses'; version = '2.0.0' })
     }
+}
+Assert-True 'FAIL HOSTED_AGENT_IMAGE_NOT_IMMUTABLE raised for missing digest' (Test-FindingPresent 'HOSTED_AGENT_IMAGE_NOT_IMMUTABLE')
+
+# --------------------------------------------------------------------------
+Write-Host 'Hosted agent: noncanonical and placeholder digests are rejected' -ForegroundColor Cyan
+foreach ($invalidDigest in @(
+        " SHA256:$('d' * 64) ",
+        "sha256:$('A' * 64)",
+        "sha256:$('e' * 64)`n",
+        'sha256:<64-hex-digest>'
+    )) {
+    Reset-Findings
+    Test-HostedAgentConfiguration -P @{
+        prepareHostedAgent      = $false
+        deployHostedAgent       = $true
+        deployAiFoundry         = $true
+        deployContainerRegistry = $true
+        hostedAgent             = [pscustomobject]@{
+            name           = 'sample-agent'
+            image          = 'agents/sample'
+            version        = $invalidDigest
+            startupCommand = 'python main.py'
+            runtime        = [pscustomobject]@{ cpu = '1'; memory = '1Gi' }
+            protocols      = @([pscustomobject]@{ protocol = 'responses'; version = '2.0.0' })
+        }
+    }
+    Assert-True "FAIL HOSTED_AGENT_IMAGE_NOT_IMMUTABLE raised for '$invalidDigest'" (Test-FindingPresent 'HOSTED_AGENT_IMAGE_NOT_IMMUTABLE')
+}
+
+# --------------------------------------------------------------------------
+Write-Host 'Hosted agent: Foundry and registry prerequisites are enforced during preparation' -ForegroundColor Cyan
+Reset-Findings
+Test-HostedAgentConfiguration -P @{
+    prepareHostedAgent                      = $true
+    deployHostedAgent                       = $false
+    deployAiFoundry                         = $false
+    deployContainerRegistry                 = $false
+    hostedAgentContainerRegistryResourceId = ''
+    hostedAgentContainerRegistryEndpoint   = ''
 }
 Assert-True 'FAIL HOSTED_AGENT_FOUNDRY_REQUIRED raised' (Test-FindingPresent 'HOSTED_AGENT_FOUNDRY_REQUIRED')
 Assert-True 'FAIL HOSTED_AGENT_REGISTRY_REQUIRED raised' (Test-FindingPresent 'HOSTED_AGENT_REGISTRY_REQUIRED')


### PR DESCRIPTION
## Purpose

Remove the fresh-deployment cycle between hosted-agent prerequisite provisioning and immutable image selection without weakening the existing deployment gate.

This adds a backward-compatible two-phase contract:

| `prepareHostedAgent` | `deployHostedAgent` | Prerequisite RBAC and outputs | Agent payload |
|---|---|---|---|
| `false` | `false` | Disabled | Disabled |
| `true` | `false` | Enabled | Disabled; no digest required |
| `false` | `true` | Enabled | Enabled; canonical immutable digest required |
| `true` | `true` | Enabled | Enabled; canonical immutable digest required |

`prepareHostedAgent || deployHostedAgent` now gates the executor's Azure AI Project Manager assignment, the Foundry project identity's registry pull assignment, and the Foundry/ACR/network/private-build handoff. `deployHostedAgent` alone still controls `HOSTED_AGENT_DEPLOYMENT.enabled` and `.agent`, and preflight requires exactly `sha256:` plus 64 lowercase hexadecimal characters with no surrounding whitespace.

The Bicep template still does not fabricate a hosted-agent ARM resource. The downstream `azure.ai.agent` service creates the immutable version, dedicated identity, and endpoint during `azd deploy`.

## Type of change

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Documentation content changes
- [ ] Other (please describe):

## Related Backlog Item or Issue

Downstream coordination: Azure/GPT-RAG hosted-agent-as-default ADR-0001.

## Documentation

- Updated `README.md` with the two-phase operator flow, behavior matrix, outputs, immutable digest boundary, and private ACR guidance.
- Added `docs/adr/0001-hosted-agent-preparation-and-deployment.md` with alternatives, security, migration, rollback, fitness functions, and review triggers.
- Updated `tests/README.md` and `CHANGELOG.md` Unreleased.
- No hosted-agent content currently exists in `Azure/AI-Landing-Zones`, so no companion public-doc PR is required.

## Validation evidence

All commands completed locally without provisioning or modifying Azure resources:

- `az bicep build --file main.bicep --no-restore` — passed.
- `az bicep lint --file main.bicep --no-restore` — passed; only six pre-existing warnings on unchanged lines/files.
- `pwsh ./scripts/Measure-MainJsonSize.ps1 -WorkingBudgetMB 3.5 -FailThresholdMB 4.7 -ArmHardCeilingMB 5.0` — 4.663 MB, below the 4.7 MB failure threshold and 5.0 MB ARM ceiling.
- `pwsh ./tests/contracts/Test-HostedAgentContract.ps1` with fixture-pinned standalone Bicep 0.42.1 — 17/17 checks passed; 65-resource graph and 63 unchanged resource definitions preserved.
- `pwsh ./tests/scripts/Invoke-PreflightChecks.Tests.ps1` — 53/53 assertions passed, including prepare-only, immutable, mutable, missing, noncanonical, placeholder, and private-build cases.
- `pwsh ./tests/contracts/Test-AcrTaskAgentPoolFirewallContract.ps1` — 7/7 checks passed.
- `pwsh ./tests/contracts/Test-FoundrySharedPrivateLinkNameContract.ps1` — 30/30 checks passed.
- `pwsh ./.github/scripts/Validate-CopilotAssets.ps1` — passed.
- `pwsh ./tests/scripts/Validate-CopilotAssets.Tests.ps1` — 3/3 fixtures passed.
- `pwsh ./scripts/Invoke-PreflightChecks.ps1 -SkipAzureLookups` — exit 0; 0 failures, one existing Foundry IQ warning, two informational findings.
- `git diff --check` — passed.
- Independent read-only code review — no remaining findings after digest canonicalization and rollback-guidance remediations.

Azure What-If and live deployment were not run because this change was explicitly source-only. Residual release evidence remains an approved disposable standard and network-isolated deployment.

## Compatibility and release impact

Both flags default to `false`. Existing callers that set only `deployHostedAgent=true` retain prior RBAC/output behavior because deployment implies preparation. Existing disabled callers keep the prior resource graph and empty/null output fallbacks. The ACR Task agent-pool, firewall, private endpoint, DNS, and subnet gates are unchanged.

This is an additive minor-version contract. No manifest version, tag, release, `main` branch, or Azure resource was changed. Portal and Terraform parity review is required before release.

## Code quality checklist

- [x] I verified the changes locally to ensure they work as expected
- [x] I tested the new functionality and ensured existing features still work
- [x] I preserved parameter, output, naming, identity, and network-isolation contracts or documented the migration
- [x] I updated `CHANGELOG.md` and all affected documentation
- [ ] I added at least one reviewer to this Pull Request
