### PR TITLE
fix: align compiled-template size gate defaults

### DIFF
--- a/.github/workflows/bicep-validate.yml
+++ b/.github/workflows/bicep-validate.yml
@@ -10,6 +10,7 @@ on:
       - 'scripts/Measure-MainJsonSize.ps1'
       - 'scripts/Invoke-PreflightChecks.ps1'
       - 'tests/contracts/**'
+      - 'tests/scripts/Measure-MainJsonSize.Tests.ps1'
       - 'tests/scripts/Invoke-PreflightChecks.Tests.ps1'
       - 'AGENTS.md'
       - '.github/agents/**'
@@ -28,8 +29,10 @@ on:
       - 'modules/**'
       - 'constants/**'
       - 'main.parameters.json'
+      - 'scripts/Measure-MainJsonSize.ps1'
       - 'scripts/Invoke-PreflightChecks.ps1'
       - 'tests/contracts/**'
+      - 'tests/scripts/Measure-MainJsonSize.Tests.ps1'
       - 'tests/scripts/Invoke-PreflightChecks.Tests.ps1'
       - 'AGENTS.md'
       - '.github/agents/**'
@@ -81,17 +84,12 @@ jobs:
       - name: Compile main.bicep and check size
         shell: pwsh
         run: |
-          # v2.0.0 baseline at branch creation: 4.589 MB.
-          # The "ratchet" approach: prevent regressions from the baseline now,
-          # tighten to the issue #58 acceptance target (3.5 MB working / 3.8 MB
-          # fail) once the compression phase lands. ArmHardCeilingMB is 5.0
-          # because the current 4.589 MB template DOES deploy successfully
-          # (modules get nested-deployed at runtime), so the docs' 4 MB limit
-          # applies per nested deployment, not the root JSON.
-          pwsh ./scripts/Measure-MainJsonSize.ps1 `
-            -WorkingBudgetMB 3.5 `
-            -FailThresholdMB 4.7 `
-            -ArmHardCeilingMB 5.0
+          # The script defaults are the single source of truth for local and CI gates.
+          pwsh ./scripts/Measure-MainJsonSize.ps1
+
+      - name: Test compiled-template size gate
+        shell: pwsh
+        run: pwsh ./tests/scripts/Measure-MainJsonSize.Tests.ps1
 
       - name: Validate hosted-agent resource contract
         shell: pwsh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
 
 ### Fixed
 
+- **Compiled-template size validation now uses one release gate locally and in
+  CI.** The bare `pwsh ./scripts/Measure-MainJsonSize.ps1` command now preserves
+  the 3.5 MB working warning while failing at the repository-authoritative
+  4.7 MB ratchet and 5.0 MB ARM ceiling. GitHub Actions calls the bare command
+  instead of overriding stale script defaults, and deterministic regression
+  coverage prevents the local and CI contracts from diverging again.
 - **Foundry IQ shared private-link names now stay within Azure AI Search's
   60-character resource-name limit for every Search service name, without
   requiring short (<=7 character) environment names.** Network-isolated

--- a/README.md
+++ b/README.md
@@ -52,6 +52,19 @@ Choose your preferred deployment method based on project requirements and enviro
 
 > Azure CLI is included as a prerequisite for future pre/post provisioning hooks that may depend on it.
 
+### Validate Bicep changes
+
+Before submitting a Bicep change, compile `main.bicep` and apply the same
+compiled-template size gate used by CI:
+
+```pwsh
+pwsh ./scripts/Measure-MainJsonSize.ps1
+```
+
+The script defaults are authoritative for both local and CI validation. The
+gate warns above the 3.5 MB working budget, fails at 4.7 MB, and treats the
+5.0 MB ARM ceiling as an unconditional failure.
+
 ### Basic Deployment
 
 Quick setup for demos without network isolation.

--- a/scripts/Measure-MainJsonSize.ps1
+++ b/scripts/Measure-MainJsonSize.ps1
@@ -1,23 +1,23 @@
 <#
 .SYNOPSIS
-  Measure the compiled main.json size and apply v2.0.0 size budget thresholds.
+  Measure the compiled main.json size and apply the release size gate.
 
 .DESCRIPTION
   Compiles main.bicep (unless -SkipBuild is set), then reports the resulting
   main.json size in bytes, KB and MB. Emits a warning when the size exceeds the
   working budget (3.5 MB by default) and exits non-zero when it exceeds the CI
-  fail threshold (3.8 MB by default). The ARM hard ceiling is 4 MB and is
+  fail threshold (4.7 MB by default). The ARM hard ceiling is 5.0 MB and is
   treated as an unconditional failure.
 
 .PARAMETER WorkingBudgetMB
   Soft warning threshold. Defaults to 3.5 MB per issue #58 acceptance criteria.
 
 .PARAMETER FailThresholdMB
-  CI fail threshold. Defaults to 3.8 MB per issue #58 acceptance criteria.
+  CI fail threshold. Defaults to the 4.7 MB release ratchet.
 
 .PARAMETER ArmHardCeilingMB
   ARM request payload hard ceiling. Should never be crossed; deployments will
-  fail with RequestContentTooLarge. Defaults to 4.0 MB.
+  fail with RequestContentTooLarge. Defaults to 5.0 MB.
 
 .PARAMETER SkipBuild
   Skip `bicep build` and measure the existing main.json. Useful in CI when an
@@ -29,8 +29,8 @@
 [CmdletBinding()]
 param(
   [double]$WorkingBudgetMB = 3.5,
-  [double]$FailThresholdMB = 3.8,
-  [double]$ArmHardCeilingMB = 4.0,
+  [double]$FailThresholdMB = 4.7,
+  [double]$ArmHardCeilingMB = 5.0,
   [switch]$SkipBuild
 )
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -36,6 +36,7 @@ tests/
 │   └── .outputs.json         (gitignored — captured outputs from last deploy)
 └── scripts/
     ├── Deploy-Hub.ps1        (idempotent hub deployer + output capture)
+    ├── Measure-MainJsonSize.Tests.ps1
     └── Invoke-PreflightChecks.Tests.ps1
 ```
 
@@ -47,6 +48,7 @@ Run from the repository root:
 pwsh tests/contracts/Test-HostedAgentContract.ps1
 pwsh tests/contracts/Test-AcrTaskAgentPoolFirewallContract.ps1
 pwsh tests/contracts/Test-FoundrySharedPrivateLinkNameContract.ps1
+pwsh tests/scripts/Measure-MainJsonSize.Tests.ps1
 pwsh tests/scripts/Invoke-PreflightChecks.Tests.ps1
 ```
 
@@ -69,6 +71,9 @@ within 60 characters, output is deterministic, and distinct tested long inputs
 do not collide. The deterministic preflight tests cover disabled, prepare-only,
 valid immutable deployment, mutable/missing image digest, private build, and
 missing-prerequisite configurations without accessing Azure.
+The compiled-template size tests prove that the script's default 3.5 MB warning,
+4.7 MB failure, and 5.0 MB hard ceiling remain aligned with the workflow's bare
+command and exercise each exit path without compiling or accessing Azure.
 
 ## End-to-end test flow
 

--- a/tests/scripts/Measure-MainJsonSize.Tests.ps1
+++ b/tests/scripts/Measure-MainJsonSize.Tests.ps1
@@ -1,0 +1,120 @@
+<#
+.SYNOPSIS
+    Regression tests for the compiled-template size gate defaults and CI caller.
+#>
+
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$sizeGate = Join-Path $repoRoot 'scripts\Measure-MainJsonSize.ps1'
+$workflow = Join-Path $repoRoot '.github\workflows\bicep-validate.yml'
+$mainJson = Join-Path $repoRoot 'main.json'
+$originalBytes = if (Test-Path $mainJson) {
+    [System.IO.File]::ReadAllBytes($mainJson)
+}
+else {
+    $null
+}
+$failures = 0
+
+function Assert-Result {
+    param(
+        [Parameter(Mandatory)] [string]$Name,
+        [Parameter(Mandatory)] [bool]$Condition,
+        [Parameter(Mandatory)] [string]$Detail
+    )
+
+    if ($Condition) {
+        Write-Host "  [PASS] $Name" -ForegroundColor Green
+    }
+    else {
+        Write-Host "  [FAIL] $Name - $Detail" -ForegroundColor Red
+        $script:failures++
+    }
+}
+
+function Set-MainJsonSize {
+    param([Parameter(Mandatory)] [double]$SizeMB)
+
+    $stream = [System.IO.File]::Open(
+        $mainJson,
+        [System.IO.FileMode]::Create,
+        [System.IO.FileAccess]::Write,
+        [System.IO.FileShare]::None
+    )
+    try {
+        $stream.SetLength([long]($SizeMB * 1MB))
+    }
+    finally {
+        $stream.Dispose()
+    }
+}
+
+function Invoke-SizeGate {
+    param([Parameter(Mandatory)] [double]$SizeMB)
+
+    Set-MainJsonSize -SizeMB $SizeMB
+    $output = & pwsh -NoProfile -File $sizeGate -SkipBuild 2>&1 | Out-String
+    [pscustomobject]@{
+        ExitCode = $LASTEXITCODE
+        Output = $output
+    }
+}
+
+try {
+    $workflowText = Get-Content -Path $workflow -Raw
+    $bareCommandPattern = '(?m)^\s*pwsh \./scripts/Measure-MainJsonSize\.ps1\s*$'
+    Assert-Result `
+        -Name 'Workflow uses the bare size-gate command' `
+        -Condition ($workflowText -match $bareCommandPattern) `
+        -Detail 'Expected CI to consume the script defaults without threshold overrides.'
+    Assert-Result `
+        -Name 'Workflow does not duplicate threshold switches' `
+        -Condition ($workflowText -notmatch '-WorkingBudgetMB|-FailThresholdMB|-ArmHardCeilingMB') `
+        -Detail 'Threshold switches in the workflow can diverge from local defaults.'
+
+    $warning = Invoke-SizeGate -SizeMB 4.663
+    Assert-Result `
+        -Name 'Default gate warns and succeeds for the current 4.663 MB template size' `
+        -Condition (
+            $warning.ExitCode -eq 0 -and
+            $warning.Output -match 'main\.json size:.*,\s+4\.663 MB\)' -and
+            $warning.Output -match 'exceeds working budget of 3\.5 MB' -and
+            $warning.Output -match 'Fail threshold\s+: 4\.7 MB' -and
+            $warning.Output -match 'ARM ceiling\s+: 5 MB'
+        ) `
+        -Detail $warning.Output
+
+    $failure = Invoke-SizeGate -SizeMB 4.8
+    Assert-Result `
+        -Name 'Default gate fails at the 4.7 MB ratchet' `
+        -Condition (
+            $failure.ExitCode -eq 1 -and
+            $failure.Output -match 'exceeds CI fail threshold of 4\.7 MB'
+        ) `
+        -Detail $failure.Output
+
+    $ceiling = Invoke-SizeGate -SizeMB 5.1
+    Assert-Result `
+        -Name 'Default gate enforces the 5.0 MB hard ceiling first' `
+        -Condition (
+            $ceiling.ExitCode -ne 0 -and
+            $ceiling.Output -match 'exceeds ARM hard ceiling of 5 MB'
+        ) `
+        -Detail $ceiling.Output
+}
+finally {
+    if ($null -ne $originalBytes) {
+        [System.IO.File]::WriteAllBytes($mainJson, $originalBytes)
+    }
+    elseif (Test-Path $mainJson) {
+        Remove-Item -Path $mainJson -Force
+    }
+}
+
+if ($failures -gt 0) {
+    exit 1
+}
+exit 0


### PR DESCRIPTION
## Purpose

Fix the release-blocking local/CI compiled-template size-gate divergence. The script defaults are now the authoritative 3.5 MB warning, 4.7 MB failure ratchet, and 5.0 MB ceiling, and CI invokes the bare command.

## Type of change

- [x] Bugfix
- [x] Documentation content changes

## Related Backlog Item or Issue

Release-blocking follow-up for v2.5.0; no separate repository issue.

## Documentation

Updated `README.md`, `CHANGELOG.md`, and `tests/README.md`. This changes contributor validation guidance only, so no public Azure/AI-Landing-Zones companion PR is required.

## Validation evidence

- `az bicep build --file main.bicep` — exit 0; existing Bicep warnings only.
- `az bicep lint --file main.bicep` — exit 0; existing Bicep warnings only.
- `pwsh ./scripts/Measure-MainJsonSize.ps1` — exit 0 at 4.663 MB with the expected soft warning.
- `pwsh ./scripts/Measure-MainJsonSize.ps1 -WorkingBudgetMB 3.5 -FailThresholdMB 4.7 -ArmHardCeilingMB 5.0` — exit 0 with identical 4.663 MB warning behavior.
- `pwsh ./tests/scripts/Measure-MainJsonSize.Tests.ps1` — 5/5 pass.
- Hosted-agent, ACR firewall, and Foundry SPL contract suites — pass.
- `pwsh ./tests/scripts/Invoke-PreflightChecks.Tests.ps1` — 53/53 pass.
- Copilot asset validator and validator tests — pass.
- Manifest/changelog metadata alignment — v2.5.0 aligned.
- `git diff --check` and committed-scope review — pass, no findings.

No Azure-aware lookup, preview, deployment, tag, release, or production operation was run; this change does not alter deployment resources or contracts.

## Integration before v2.5.0

1. Merge this PR into `develop`.
2. Include the resulting `develop` commit in the approved release PR to `main`.
3. Re-run required checks against the exact `main` release commit and verify `manifest.json`/changelog remain aligned at v2.5.0.
4. Only then may an authorized human create the `v2.5.0` tag and GitHub Release.

## Code quality checklist

- [x] I verified the changes locally to ensure they work as expected
- [x] I tested the new functionality and ensured existing features still work
- [x] I preserved parameter, output, naming, identity, and network-isolation contracts
- [x] I updated `CHANGELOG.md` and all affected documentation
- [ ] A repository maintainer must add/complete the required PR review