### PR TITLE
Fix maintenance wrapper parameter forwarding

### DIFF
--- a/.github/workflows/bicep-validate.yml
+++ b/.github/workflows/bicep-validate.yml
@@ -110,6 +110,10 @@ jobs:
         shell: pwsh
         run: pwsh ./tests/contracts/Test-FoundrySharedPrivateLinkNameContract.ps1
 
+      - name: Validate Maintenance Configuration wrapper forwarding
+        shell: pwsh
+        run: pwsh ./tests/contracts/Test-MaintenanceConfigurationWrapperContract.ps1
+
       - name: Run deterministic preflight tests
         shell: pwsh
         run: pwsh ./tests/scripts/Invoke-PreflightChecks.Tests.ps1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
 
 ## [Unreleased]
 
+### Fixed
+
+- **A release source for the Portal Maintenance Configuration wrapper now
+  forwards its complete typed object to AVM 0.3.1.** `maintenanceScope`, `maintenanceWindow`,
+  `extensionProperties`, `installPatches`, `namespace`, `visibility`,
+  `enableTelemetry`, `lock`, and `roleAssignments` are no longer dropped.
+  Omitted non-nullable values retain the AVM defaults, while nullable lock,
+  role assignments, and tags remain nullable. Regenerated Portal wrappers can
+  therefore retain an `InGuestPatch` configuration's schedule and reboot
+  settings instead of silently falling back to `Host`. The corresponding
+  generated Portal wrapper is updated through the normal downstream release
+  adoption process.
+
 ## [v2.5.1] - 2026-08-11
 
 ### Fixed

--- a/modules/maintenance/README.md
+++ b/modules/maintenance/README.md
@@ -1,0 +1,17 @@
+# Maintenance Configuration Portal wrapper
+
+`avm.res.maintenance.maintenance-configuration.bicep` is the release source for
+the generated Maintenance Configuration wrapper consumed by
+`Azure/AI-Landing-Zones`.
+
+After publishing a release of this repository:
+
+1. Open a companion issue in `Azure/AI-Landing-Zones`.
+2. Update its Portal release reference.
+3. Regenerate
+   `portal/wrappers/avm.res.maintenance.maintenance-configuration.json` from this
+   source.
+4. Validate both jump and build VM assignments with
+   `maintenanceScope: 'InGuestPatch'` on a non-isolated VM SKU.
+
+The downstream generated JSON is not edited in this repository.

--- a/modules/maintenance/avm.res.maintenance.maintenance-configuration.bicep
+++ b/modules/maintenance/avm.res.maintenance.maintenance-configuration.bicep
@@ -1,0 +1,38 @@
+targetScope = 'resourceGroup'
+
+import { vmMaintenanceDefinitionType } from 'types.bicep'
+
+// Release source consumed when the Portal repository refreshes its generated
+// portal/wrappers/avm.res.maintenance.maintenance-configuration.json artifact.
+@description('Maintenance Configuration.')
+param maintenanceConfig vmMaintenanceDefinitionType
+
+module inner 'br/public:avm/res/maintenance/maintenance-configuration:0.3.1' = {
+  name: 'maint-avm-${maintenanceConfig.name}'
+  params: {
+    name: maintenanceConfig.name
+    enableTelemetry: maintenanceConfig.?enableTelemetry ?? true
+    extensionProperties: maintenanceConfig.?extensionProperties ?? {}
+    installPatches: maintenanceConfig.?installPatches ?? {}
+    location: maintenanceConfig.?location ?? resourceGroup().location
+    lock: maintenanceConfig.?lock
+    maintenanceScope: maintenanceConfig.?maintenanceScope ?? 'Host'
+    maintenanceWindow: maintenanceConfig.?maintenanceWindow ?? {}
+    namespace: maintenanceConfig.?namespace ?? ''
+    roleAssignments: maintenanceConfig.?roleAssignments
+    tags: maintenanceConfig.?tags
+    visibility: maintenanceConfig.?visibility ?? ''
+  }
+}
+
+@description('The resource ID of the Maintenance Configuration.')
+output resourceId string = inner.outputs.resourceId
+
+@description('The resource name of the Maintenance Configuration.')
+output name string = inner.outputs.name
+
+@description('The resource group the Maintenance Configuration was deployed into.')
+output resourceGroupName string = inner.outputs.resourceGroupName
+
+@description('The location the resource was deployed into.')
+output location string = inner.outputs.location

--- a/modules/maintenance/types.bicep
+++ b/modules/maintenance/types.bicep
@@ -1,0 +1,101 @@
+@export()
+@description('Configuration object for a VM Maintenance Configuration resource.')
+type vmMaintenanceDefinitionType = {
+  @description('Required. Name of the Maintenance Configuration.')
+  name: string
+
+  @description('Optional. Enable or disable usage telemetry for the module. Default is true.')
+  enableTelemetry: bool?
+
+  @description('Optional. Extension properties of the Maintenance Configuration.')
+  extensionProperties: {
+    @description('Optional. Arbitrary key for each extension property.')
+    *: string
+  }?
+
+  @description('Optional. Configuration settings for VM guest patching with Azure Update Manager.')
+  installPatches: {
+    @description('Optional. Linux patch classifications and package masks.')
+    linuxParameters: {
+      @description('Optional. Linux update classifications to include.')
+      classificationsToInclude: string[]?
+      @description('Optional. Linux package name masks to exclude.')
+      packageNameMasksToExclude: string[]?
+      @description('Optional. Linux package name masks to include.')
+      packageNameMasksToInclude: string[]?
+    }?
+    @description('Optional. Reboot preference after patch installation.')
+    rebootSetting: 'Always' | 'IfRequired' | 'Never'?
+    @description('Optional. Windows patch classifications and KB filters.')
+    windowsParameters: {
+      @description('Optional. Windows update classifications to include.')
+      classificationsToInclude: string[]?
+      @description('Optional. Exclude patches that require a reboot.')
+      excludeKbsRequiringReboot: bool?
+      @description('Optional. Windows KB numbers to exclude.')
+      kbNumbersToExclude: string[]?
+      @description('Optional. Windows KB numbers to include.')
+      kbNumbersToInclude: string[]?
+    }?
+  }?
+
+  @description('Optional. Resource location. Defaults to the resource group location.')
+  location: string?
+
+  @description('Optional. Lock configuration for the Maintenance Configuration.')
+  lock: {
+    @description('Optional. Lock type.')
+    kind: 'CanNotDelete' | 'None' | 'ReadOnly'?
+    @description('Optional. Lock name.')
+    name: string?
+  }?
+
+  @description('Optional. Maintenance scope of the configuration. Default is Host.')
+  maintenanceScope: 'Extension' | 'Host' | 'InGuestPatch' | 'OSImage' | 'SQLDB' | 'SQLManagedInstance'?
+
+  @description('Optional. Definition of the Maintenance Window.')
+  maintenanceWindow: {
+    @description('Optional. Duration of the maintenance window in HH:mm format.')
+    duration: string?
+    @description('Optional. Expiration date and time of the maintenance window.')
+    expirationDateTime: string?
+    @description('Optional. Recurrence expression for the maintenance window.')
+    recurEvery: string?
+    @description('Optional. Start date and time of the maintenance window.')
+    startDateTime: string?
+    @description('Optional. Time zone used by the maintenance window.')
+    timeZone: string?
+  }?
+
+  @description('Optional. Namespace of the resource.')
+  namespace: string?
+
+  @description('Optional. Role assignments to apply to the Maintenance Configuration.')
+  roleAssignments: {
+    @description('Required. Principal ID of the identity being assigned.')
+    principalId: string
+    @description('Required. Role to assign (display name, GUID, or full resource ID).')
+    roleDefinitionIdOrName: string
+    @description('Optional. Condition for the role assignment.')
+    condition: string?
+    @description('Optional. Condition version.')
+    conditionVersion: '2.0'?
+    @description('Optional. Delegated managed identity resource ID.')
+    delegatedManagedIdentityResourceId: string?
+    @description('Optional. Description of the role assignment.')
+    description: string?
+    @description('Optional. Role assignment name (GUID). If omitted, a GUID is generated.')
+    name: string?
+    @description('Optional. Principal type of the assigned identity.')
+    principalType: 'Device' | 'ForeignGroup' | 'Group' | 'ServicePrincipal' | 'User'?
+  }[]?
+
+  @description('Optional. Tags to apply to the Maintenance Configuration resource.')
+  tags: {
+    @description('Required. Arbitrary key for each tag.')
+    *: string
+  }?
+
+  @description('Optional. Visibility of the configuration. Default is Custom.')
+  visibility: '' | 'Custom' | 'Public'?
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -28,8 +28,11 @@ tests/
 │   ├── Test-HostedAgentContract.ps1
 │   ├── Test-AcrTaskAgentPoolFirewallContract.ps1
 │   ├── Test-FoundrySharedPrivateLinkNameContract.ps1
+│   ├── Test-MaintenanceConfigurationWrapperContract.ps1
 │   └── fixtures/
-│       └── hosted-agent-resource-graph.json
+│       ├── hosted-agent-resource-graph.json
+│       └── maintenance-configuration/
+│           └── main.bicep
 ├── hub/
 │   ├── main.bicep            (test hub: VNet, Firewall, Bastion, LAW)
 │   ├── main.parameters.json
@@ -48,6 +51,7 @@ Run from the repository root:
 pwsh tests/contracts/Test-HostedAgentContract.ps1
 pwsh tests/contracts/Test-AcrTaskAgentPoolFirewallContract.ps1
 pwsh tests/contracts/Test-FoundrySharedPrivateLinkNameContract.ps1
+pwsh tests/contracts/Test-MaintenanceConfigurationWrapperContract.ps1
 pwsh tests/scripts/Measure-MainJsonSize.Tests.ps1
 pwsh tests/scripts/Invoke-PreflightChecks.Tests.ps1
 ```
@@ -68,9 +72,13 @@ gated, ordered, and scoped to the devops build agents subnet — independent of
 the opaque hash check above. The Foundry shared private-link naming contract
 proves valid legacy child IDs remain unchanged, both long suffix variants stay
 within 60 characters, output is deterministic, and distinct tested long inputs
-do not collide. The deterministic preflight tests cover disabled, prepare-only,
-valid immutable deployment, mutable/missing image digest, private build, and
-missing-prerequisite configurations without accessing Azure.
+do not collide. The Maintenance Configuration wrapper contract compiles default
+and InGuestPatch calls and proves every typed property is forwarded to AVM
+0.3.1, with schedules and reboot settings retaining their required nesting and
+omitted values retaining AVM defaults. The deterministic preflight tests cover
+disabled, prepare-only, valid immutable deployment, mutable/missing image
+digest, private build, and missing-prerequisite configurations without
+accessing Azure.
 The compiled-template size tests prove that the script's default 3.5 MB warning,
 4.7 MB failure, and 5.0 MB hard ceiling remain aligned with the workflow's bare
 command and exercise each exit path without compiling or accessing Azure.

--- a/tests/contracts/Test-MaintenanceConfigurationWrapperContract.ps1
+++ b/tests/contracts/Test-MaintenanceConfigurationWrapperContract.ps1
@@ -1,0 +1,151 @@
+<#
+.SYNOPSIS
+    Validates the AVM Maintenance Configuration wrapper parameter forwarding.
+
+.DESCRIPTION
+    Regression test for Azure/bicep-ptn-aiml-landing-zone#122. It compiles a
+    default and an InGuestPatch invocation, then proves the wrapper forwards
+    every typed property to AVM 0.3.1 without flattening maintenanceWindow or
+    installPatches. Omitted non-nullable properties retain AVM 0.3.1 defaults;
+    nullable lock, roleAssignments, and tags remain nullable.
+#>
+
+[CmdletBinding()]
+param(
+    [string]$FixtureFile = (Join-Path $PSScriptRoot 'fixtures/maintenance-configuration/main.bicep')
+)
+
+$ErrorActionPreference = 'Stop'
+$failures = [System.Collections.Generic.List[string]]::new()
+$compiledFile = Join-Path ([System.IO.Path]::GetTempPath()) "maintenance-wrapper-contract-$([guid]::NewGuid()).json"
+
+function Add-Failure {
+    param([Parameter(Mandatory)] [string]$Message)
+    $failures.Add($Message) | Out-Null
+    Write-Host "  [FAIL] $Message" -ForegroundColor Red
+}
+
+function Add-Pass {
+    param([Parameter(Mandatory)] [string]$Message)
+    Write-Host "  [PASS] $Message" -ForegroundColor Green
+}
+
+function Assert-Equal {
+    param(
+        [Parameter(Mandatory)] [string]$Description,
+        [AllowNull()] $Actual,
+        [AllowNull()] $Expected
+    )
+    $actualJson = ConvertTo-Json -InputObject $Actual -Depth 30 -Compress
+    $expectedJson = ConvertTo-Json -InputObject $Expected -Depth 30 -Compress
+    if ($actualJson -cne $expectedJson) {
+        Add-Failure "$Description Expected '$Expected', got '$Actual'."
+    }
+    else {
+        Add-Pass $Description
+    }
+}
+
+Write-Host 'Maintenance Configuration wrapper contract (issue #122)' -ForegroundColor Cyan
+
+try {
+    if (Get-Command az -ErrorAction SilentlyContinue) {
+        $env:PYTHONIOENCODING = 'utf-8'
+        & az bicep build --file $FixtureFile --outfile $compiledFile
+    }
+    elseif (Get-Command bicep -ErrorAction SilentlyContinue) {
+        & bicep build $FixtureFile --outfile $compiledFile
+    }
+    else {
+        throw 'Neither bicep nor az is available on PATH.'
+    }
+    if ($LASTEXITCODE -ne 0) {
+        throw "Bicep compilation failed with exit code $LASTEXITCODE."
+    }
+
+    $template = Get-Content -LiteralPath $compiledFile -Raw | ConvertFrom-Json -Depth 100
+    $defaultDeployment = $template.resources |
+        Where-Object { $_.name -eq 'maintenance-default-contract' } |
+        Select-Object -First 1
+    $inGuestDeployment = $template.resources |
+        Where-Object { $_.name -eq 'maintenance-in-guest-patch-contract' } |
+        Select-Object -First 1
+
+    if ($null -eq $defaultDeployment -or $null -eq $inGuestDeployment) {
+        Add-Failure 'Compiled fixture does not contain both default and InGuestPatch wrapper deployments.'
+    }
+    else {
+        $defaultInput = $defaultDeployment.properties.parameters.maintenanceConfig.value
+        Assert-Equal 'Default invocation supplies only the required name.' @($defaultInput.PSObject.Properties.Name) @('name')
+
+        $inGuestInput = $inGuestDeployment.properties.parameters.maintenanceConfig.value
+        Assert-Equal 'InGuestPatch scope remains in the typed maintenanceConfig object.' $inGuestInput.maintenanceScope 'InGuestPatch'
+        Assert-Equal 'Schedule fields remain nested under maintenanceWindow.' $inGuestInput.maintenanceWindow ([ordered]@{
+                duration      = '03:00'
+                recurEvery    = '1Week Saturday'
+                startDateTime = '2024-06-15 22:00'
+                timeZone      = 'UTC'
+            })
+        Assert-Equal 'Patch settings remain nested under installPatches.' $inGuestInput.installPatches ([ordered]@{
+                linuxParameters = [ordered]@{
+                    classificationsToInclude = @('Critical', 'Security')
+                    packageNameMasksToExclude = @('kernel*')
+                    packageNameMasksToInclude = @('openssl*')
+                }
+                rebootSetting = 'IfRequired'
+                windowsParameters = [ordered]@{
+                    classificationsToInclude = @('Critical', 'Security')
+                    excludeKbsRequiringReboot = $true
+                    kbNumbersToExclude = @('KB0000001')
+                    kbNumbersToInclude = @('KB0000002')
+                }
+            })
+        Assert-Equal 'InGuestPatchMode remains nested under extensionProperties.' $inGuestInput.extensionProperties ([ordered]@{
+                InGuestPatchMode = 'User'
+            })
+
+        $wrapperTemplate = $defaultDeployment.properties.template
+        $innerParameters = $wrapperTemplate.resources.inner.properties.parameters
+        $expectedParameterNames = @(
+            'enableTelemetry', 'extensionProperties', 'installPatches', 'location',
+            'lock', 'maintenanceScope', 'maintenanceWindow', 'name', 'namespace',
+            'roleAssignments', 'tags', 'visibility'
+        )
+        $actualParameterNames = @($innerParameters.PSObject.Properties.Name | Sort-Object)
+        Assert-Equal 'Nested AVM deployment forwards the complete wrapper contract.' $actualParameterNames $expectedParameterNames
+
+        $expectedDefaults = [ordered]@{
+            enableTelemetry     = "[coalesce(tryGet(parameters('maintenanceConfig'), 'enableTelemetry'), true())]"
+            extensionProperties = "[coalesce(tryGet(parameters('maintenanceConfig'), 'extensionProperties'), createObject())]"
+            installPatches      = "[coalesce(tryGet(parameters('maintenanceConfig'), 'installPatches'), createObject())]"
+            location            = "[coalesce(tryGet(parameters('maintenanceConfig'), 'location'), resourceGroup().location)]"
+            maintenanceScope    = "[coalesce(tryGet(parameters('maintenanceConfig'), 'maintenanceScope'), 'Host')]"
+            maintenanceWindow   = "[coalesce(tryGet(parameters('maintenanceConfig'), 'maintenanceWindow'), createObject())]"
+            namespace           = "[coalesce(tryGet(parameters('maintenanceConfig'), 'namespace'), '')]"
+            visibility          = "[coalesce(tryGet(parameters('maintenanceConfig'), 'visibility'), '')]"
+        }
+        foreach ($parameterName in $expectedDefaults.Keys) {
+            Assert-Equal "Omitted $parameterName preserves the AVM 0.3.1 default." $innerParameters.$parameterName.value $expectedDefaults[$parameterName]
+        }
+
+        foreach ($parameterName in @('lock', 'roleAssignments', 'tags')) {
+            Assert-Equal "Nullable $parameterName is forwarded without a synthetic default." $innerParameters.$parameterName.value "[tryGet(parameters('maintenanceConfig'), '$parameterName')]"
+        }
+
+        $unexpectedFlattenedParameters = @(
+            'duration', 'rebootSetting', 'recurEvery', 'startDateTime', 'timeZone'
+        ) | Where-Object { $_ -in @($innerParameters.PSObject.Properties.Name) }
+        Assert-Equal 'Schedule and reboot fields are not flattened into AVM parameters.' @($unexpectedFlattenedParameters) @()
+    }
+}
+finally {
+    Remove-Item -LiteralPath $compiledFile -Force -ErrorAction SilentlyContinue
+}
+
+if ($failures.Count -gt 0) {
+    Write-Host "`n$($failures.Count) maintenance wrapper contract check(s) failed." -ForegroundColor Red
+    exit 1
+}
+
+Write-Host "`nMaintenance Configuration wrapper contract checks passed." -ForegroundColor Green
+exit 0

--- a/tests/contracts/fixtures/maintenance-configuration/main.bicep
+++ b/tests/contracts/fixtures/maintenance-configuration/main.bicep
@@ -1,0 +1,75 @@
+targetScope = 'resourceGroup'
+
+module defaultMaintenance '../../../../modules/maintenance/avm.res.maintenance.maintenance-configuration.bicep' = {
+  name: 'maintenance-default-contract'
+  params: {
+    maintenanceConfig: {
+      name: 'mc-default'
+    }
+  }
+}
+
+module inGuestPatchMaintenance '../../../../modules/maintenance/avm.res.maintenance.maintenance-configuration.bicep' = {
+  name: 'maintenance-in-guest-patch-contract'
+  params: {
+    maintenanceConfig: {
+      name: 'mc-in-guest-patch'
+      enableTelemetry: false
+      extensionProperties: {
+        InGuestPatchMode: 'User'
+      }
+      installPatches: {
+        linuxParameters: {
+          classificationsToInclude: [
+            'Critical'
+            'Security'
+          ]
+          packageNameMasksToExclude: [
+            'kernel*'
+          ]
+          packageNameMasksToInclude: [
+            'openssl*'
+          ]
+        }
+        rebootSetting: 'IfRequired'
+        windowsParameters: {
+          classificationsToInclude: [
+            'Critical'
+            'Security'
+          ]
+          excludeKbsRequiringReboot: true
+          kbNumbersToExclude: [
+            'KB0000001'
+          ]
+          kbNumbersToInclude: [
+            'KB0000002'
+          ]
+        }
+      }
+      location: 'eastus2'
+      lock: {
+        kind: 'CanNotDelete'
+        name: 'maintenance-lock'
+      }
+      maintenanceScope: 'InGuestPatch'
+      maintenanceWindow: {
+        duration: '03:00'
+        recurEvery: '1Week Saturday'
+        startDateTime: '2024-06-15 22:00'
+        timeZone: 'UTC'
+      }
+      namespace: 'Microsoft.Maintenance'
+      roleAssignments: [
+        {
+          principalId: '00000000-0000-0000-0000-000000000001'
+          roleDefinitionIdOrName: 'Contributor'
+          principalType: 'ServicePrincipal'
+        }
+      ]
+      tags: {
+        scenario: 'in-guest-patch'
+      }
+      visibility: 'Custom'
+    }
+  }
+}


### PR DESCRIPTION
## Purpose

The Portal Maintenance Configuration wrapper drops every optional property except `location` and `tags`, causing `InGuestPatch` requests to fall back silently to the AVM `Host` default and fail when assigned to non-isolated VMs.

This change adds the release source consumed by the downstream Portal refresh, forwards the complete AVM 0.3.1 contract with behavior-compatible defaults, and adds compiled-template regression coverage for both default and `InGuestPatch` configurations. Schedule values remain nested under `maintenanceWindow`, while reboot and operating-system patch options remain under `installPatches`.

## Type of change 

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation content changes
- [ ] Other (please describe):

## Related Backlog Item or Issue

Closes #122

## Documentation

Updated `CHANGELOG.md`, `tests/README.md`, and added `modules/maintenance/README.md` describing the release and downstream Portal adoption workflow. The companion `Azure/AI-Landing-Zones` issue will be created after this repository publishes the release; no downstream PR exists yet.

## Validation evidence

- `pwsh ./tests/contracts/Test-MaintenanceConfigurationWrapperContract.ps1`: passed all 18 assertions.
- `az bicep build --file ./modules/maintenance/avm.res.maintenance.maintenance-configuration.bicep`: passed.
- `az bicep lint --file ./modules/maintenance/avm.res.maintenance.maintenance-configuration.bicep`: passed without wrapper diagnostics.
- `az bicep build --file ./main.bicep`: passed with existing unrelated warnings.
- `az bicep lint --file ./main.bicep`: passed with existing unrelated warnings.
- `pwsh ./scripts/Measure-MainJsonSize.ps1`: passed at 4,890,001 bytes, below the 4.7 MB failure threshold; the existing 3.5 MB working-budget warning remains.
- `pwsh ./.github/scripts/Validate-CopilotAssets.ps1`: passed.
- `pwsh ./tests/scripts/Validate-CopilotAssets.Tests.ps1`: passed.
- Workflow YAML parsing and `git diff --check`: passed.
- Azure What-If and live deployment were not run. Downstream wrapper regeneration and live jump/build VM assignment remain part of the Portal release-adoption validation.

## Code quality checklist

- [x] I verified the changes locally to ensure they work as expected
- [x] I tested the new functionality and ensured existing features still work
- [x] I preserved parameter, output, naming, identity, and network-isolation contracts or documented the migration
- [x] I updated `CHANGELOG.md` and all affected documentation
- [ ] I added at least one reviewer to this Pull Request