### PR TITLE
chore(release): v2.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
 
 ## [Unreleased]
 
+## [v2.5.2] - 2026-08-20
+
 ### Fixed
 
 - **A release source for the Portal Maintenance Configuration wrapper now

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
-  "tag": "v2.5.1",
+  "tag": "v2.5.2",
   "repo": "https://github.com/azure/bicep-ptn-aiml-landing-zone.git",
-  "ailz_tag": "v2.5.1",
+  "ailz_tag": "v2.5.2",
   "components": []
 }


### PR DESCRIPTION
## Release v2.5.2 (patch)

Backward-compatible bug-fix release for #122 / #137. The Portal Maintenance Configuration release-source wrapper now forwards its complete typed object to AVM 0.3.1 instead of dropping maintenance scope, schedule, patch, namespace, visibility, telemetry, lock, role-assignment, and tag settings.

- `manifest.json`: `tag` and `ailz_tag` aligned at `v2.5.2`.
- `CHANGELOG.md`: empty `[Unreleased]` retained and release entry dated 2026-08-20.
- Jumpbox/bootstrap structure and component pins are unchanged.

## Validation
Exact commit: `8e65cb5c2d1f317b282ea57d92459a50a052c302`

- Copilot asset validation: 5 agents and 16 skills validated.
- Copilot validator tests: passed.
- `az bicep build --file main.bicep`: passed with pre-existing warnings only.
- `az bicep lint --file main.bicep`: passed with pre-existing warnings only.
- `pwsh ./scripts/Measure-MainJsonSize.ps1`: 4.663 MB, below 4.7 MB fail threshold.
- Size-gate tests: passed.
- Targeted `Test-MaintenanceConfigurationWrapperContract.ps1`: passed.
- Existing hosted-agent, ACR Task firewall, Agent365 observability, and shared private-link contract tests: passed.
- Deterministic preflight tests: 53/53 passed.
- No Azure deployment was performed.

## Compatibility and documentation
Patch classification: the fix restores already-declared wrapper values and AVM defaults; it adds no parameter, resource, default, or migration requirement. Repository module/test documentation and changelog are current. The generated Portal wrapper in `Azure/AI-Landing-Zones` remains a downstream adoption action after publication; no issue is created by this PR. Terraform parity is not required for this patch-level Portal wrapper bug fix.