### PR TITLE
chore: sync v2.5.2 release to develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
 
 ## [Unreleased]
 
+## [v2.5.2] - 2026-08-20
+
 ### Fixed
 
 - **A release source for the Portal Maintenance Configuration wrapper now

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
-  "tag": "v2.5.1",
+  "tag": "v2.5.2",
   "repo": "https://github.com/azure/bicep-ptn-aiml-landing-zone.git",
-  "ailz_tag": "v2.5.1",
+  "ailz_tag": "v2.5.2",
   "components": []
 }


### PR DESCRIPTION
## Post-release reconciliation

Merge released `main` at `54186742215d28eeb893fccc55647eb74aa3beee` into `develop` immediately after publishing v2.5.2.

This carries only the v2.5.2 release-artifact changes (`CHANGELOG.md` and aligned `manifest.json` tags). The issue #122 implementation was already synced by #138. No force push or Azure deployment is involved.