### PR TITLE
Fix deployment names for long environment names

### DIFF
--- a/.github/workflows/bicep-validate.yml
+++ b/.github/workflows/bicep-validate.yml
@@ -118,6 +118,10 @@ jobs:
         shell: pwsh
         run: pwsh ./tests/contracts/Test-ComponentDeploymentFlagsContract.ps1
 
+      - name: Validate Cosmos DB deployment names
+        shell: pwsh
+        run: pwsh ./tests/contracts/Test-CosmosDeploymentNameContract.ps1
+
       - name: Run deterministic preflight tests
         shell: pwsh
         run: pwsh ./tests/scripts/Invoke-PreflightChecks.Tests.ps1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed provisioning for long azd/CAF environment names by replacing resource-name-derived Foundry deployment names and moving Cosmos DB SQL database/container resources out of the account AVM's name-derived nested deployment. All replacement deployment names stay below ARM's 64-character limit while preserving the configured Azure resource names (fixes #119).
+
 ## [v2.6.0] - 2026-08-20
 
 ### Added

--- a/main.bicep
+++ b/main.bicep
@@ -2273,7 +2273,7 @@ module aiFoundryStorageAccount 'modules/ai-foundry/storage-account.bicep' = if (
 
 // 16.1 AI Foundry Configuration
 module aiFoundry 'modules/ai-foundry/main.bicep' = if (deployAiFoundry) {
-  name: '${resourceNames.aiFoundryAccountName}-${resourceToken}-deployment'
+  name: 'aiFoundryDeployment'
   params: {
     // Required
     baseName: substring(resourceToken, 0, 10)
@@ -2453,7 +2453,7 @@ module bingSearchConnection 'modules/bing-search/main.bicep' = if (deployAiFound
 
 // Bing Search Connection
 module aiFoundryBingConnection 'modules/ai-foundry/connection-bing-search-tool.bicep' = if (deployAiFoundry && deployGroundingWithBing) {
-  name: '${resourceNames.bingSearchName}-connection'
+  name: 'aiFoundryBingConnection'
   params: {
     account_name: aiFoundry!.outputs.aiServicesName
     project_name: aiFoundry!.outputs.aiProjectName
@@ -2937,25 +2937,36 @@ module cosmosDBAccount 'br/public:avm/res/document-db/database-account:0.15.1' =
       ] : []
     }
     tags: _tags
-    sqlDatabases: [
-      {
-        name: resourceNames.dbDatabaseName
-        throughput: dbDatabaseThroughput
-        containers: [
-          for container in databaseContainersList: {
-            name: container.name
-            paths: [container.partitionKey]
-            defaultTtl: -1
-            throughput: container.?throughput
-            indexingPolicy: container.?indexingPolicy
-          }
-        ]
-      }
-    ]
   }
   dependsOn: [
     #disable-next-line BCP321
     (_networkIsolation) ? virtualNetwork : null
+  ]
+}
+
+// The Cosmos DB AVM composes its SQL database deployment name from the full
+// database resource name. CAF environment names can therefore push that nested
+// deployment beyond ARM's 64-character limit. Keep the account in AVM, but
+// deploy its database and containers through a fixed-name local module so
+// resource names remain unchanged and deployment-name length is constant.
+module cosmosSqlDatabase 'modules/cosmos-db/sql-database.bicep' = if (deployCosmosDb) {
+  name: 'cosmosSqlDatabase'
+  params: {
+    databaseAccountName: resourceNames.dbAccountName
+    databaseName: resourceNames.dbDatabaseName
+    databaseThroughput: dbDatabaseThroughput
+    containers: [
+      for container in databaseContainersList: {
+        name: container.name
+        paths: [container.partitionKey]
+        defaultTtl: -1
+        throughput: container.?throughput
+        indexingPolicy: container.?indexingPolicy
+      }
+    ]
+  }
+  dependsOn: [
+    cosmosDBAccount
   ]
 }
 

--- a/modules/cosmos-db/sql-database.bicep
+++ b/modules/cosmos-db/sql-database.bicep
@@ -1,0 +1,62 @@
+@description('Name of the existing Azure Cosmos DB account.')
+param databaseAccountName string
+
+@description('Name of the Azure Cosmos DB for NoSQL database to deploy.')
+param databaseName string
+
+@description('Optional database-level throughput. Ignored for serverless accounts.')
+param databaseThroughput int?
+
+@description('Azure Cosmos DB for NoSQL containers to deploy.')
+param containers array
+
+resource databaseAccount 'Microsoft.DocumentDB/databaseAccounts@2024-11-15' existing = {
+  name: databaseAccountName
+}
+
+resource sqlDatabase 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2024-11-15' = {
+  name: databaseName
+  parent: databaseAccount
+  properties: {
+    resource: {
+      id: databaseName
+    }
+    options: contains(databaseAccount.properties.capabilities, { name: 'EnableServerless' })
+      ? null
+      : {
+          throughput: databaseThroughput
+          autoscaleSettings: null
+        }
+  }
+}
+
+resource sqlContainers 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2024-11-15' = [
+  for container in containers: {
+    name: container.name
+    parent: sqlDatabase
+    properties: {
+      resource: {
+        conflictResolutionPolicy: {}
+        defaultTtl: container.?defaultTtl ?? -1
+        id: container.name
+        indexingPolicy: empty(container.?indexingPolicy ?? {}) ? null : container.indexingPolicy
+        partitionKey: {
+          paths: [
+            for path in container.paths: startsWith(path, '/') ? path : '/${path}'
+          ]
+          kind: 'Hash'
+          version: 1
+        }
+        uniqueKeyPolicy: null
+      }
+      options: contains(databaseAccount.properties.capabilities, { name: 'EnableServerless' })
+        ? null
+        : {
+            throughput: databaseThroughput != null && container.?throughput == null
+              ? null
+              : container.?throughput ?? 400
+            autoscaleSettings: null
+          }
+    }
+  }
+]

--- a/tests/README.md
+++ b/tests/README.md
@@ -30,6 +30,7 @@ tests/
 │   ├── Test-FoundrySharedPrivateLinkNameContract.ps1
 │   ├── Test-MaintenanceConfigurationWrapperContract.ps1
 │   ├── Test-ComponentDeploymentFlagsContract.ps1
+│   ├── Test-CosmosDeploymentNameContract.ps1
 │   └── fixtures/
 │       ├── hosted-agent-resource-graph.json
 │       └── maintenance-configuration/
@@ -54,6 +55,7 @@ pwsh tests/contracts/Test-AcrTaskAgentPoolFirewallContract.ps1
 pwsh tests/contracts/Test-FoundrySharedPrivateLinkNameContract.ps1
 pwsh tests/contracts/Test-MaintenanceConfigurationWrapperContract.ps1
 pwsh tests/contracts/Test-ComponentDeploymentFlagsContract.ps1
+pwsh tests/contracts/Test-CosmosDeploymentNameContract.ps1
 pwsh tests/scripts/Measure-MainJsonSize.Tests.ps1
 pwsh tests/scripts/Invoke-PreflightChecks.Tests.ps1
 ```
@@ -85,6 +87,11 @@ dependency, API-key prerequisite, and BYO subnet/NSG configurations without
 accessing Azure. The component deployment flag contract proves the matching
 Bicep validation expressions and defensive resource, DNS, secret, and
 configuration gates.
+The Cosmos DB deployment-name contract proves that no top-level deployment
+embeds an environment-derived resource name and that SQL databases and
+containers use direct resources behind a fixed nested deployment name. Long CAF
+environment names therefore cannot exceed ARM's 64-character deployment-name
+limit while configured Azure resource names remain unchanged.
 The compiled-template size tests prove that the script's default 3.5 MB warning,
 4.7 MB failure, and 5.0 MB hard ceiling remain aligned with the workflow's bare
 command and exercise each exit path without compiling or accessing Azure.

--- a/tests/contracts/Test-CosmosDeploymentNameContract.ps1
+++ b/tests/contracts/Test-CosmosDeploymentNameContract.ps1
@@ -1,0 +1,215 @@
+<#
+.SYNOPSIS
+    Validates Cosmos DB nested deployment names stay within ARM's 64-character limit.
+
+.DESCRIPTION
+    Regression test for issue #119. The Cosmos DB account AVM previously received
+    the SQL database collection inline and composed a nested deployment name from
+    the complete database resource name. CAF environment names of 19 or more
+    characters could therefore make the deployment name exceed 64 characters.
+
+    The test compiles main.bicep and proves that:
+      - the account AVM no longer creates its unbounded SQL database deployment;
+      - a fixed, bounded local module deploys the SQL database and containers;
+      - the database and container resource names remain parameter-driven; and
+      - the local module waits for the Cosmos DB account deployment.
+#>
+
+[CmdletBinding()]
+param(
+    [string]$MainFile = (Join-Path (Split-Path -Parent (Split-Path -Parent $PSScriptRoot)) 'main.bicep')
+)
+
+$ErrorActionPreference = 'Stop'
+$failures = [System.Collections.Generic.List[string]]::new()
+$compiledFile = Join-Path ([System.IO.Path]::GetTempPath()) "cosmos-deployment-name-contract-$([guid]::NewGuid()).json"
+
+function Add-Failure {
+    param([Parameter(Mandatory)] [string]$Message)
+    $failures.Add($Message) | Out-Null
+    Write-Host "  [FAIL] $Message" -ForegroundColor Red
+}
+
+function Add-Pass {
+    param([Parameter(Mandatory)] [string]$Message)
+    Write-Host "  [PASS] $Message" -ForegroundColor Green
+}
+
+function Assert-True {
+    param(
+        [Parameter(Mandatory)] [bool]$Condition,
+        [Parameter(Mandatory)] [string]$Message
+    )
+
+    if ($Condition) {
+        Add-Pass $Message
+    }
+    else {
+        Add-Failure $Message
+    }
+}
+
+Write-Host 'Cosmos DB deployment-name contract' -ForegroundColor Cyan
+
+try {
+    az bicep build --file $MainFile --outfile $compiledFile | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw "Bicep compilation failed with exit code $LASTEXITCODE."
+    }
+
+    $template = Get-Content -Path $compiledFile -Raw | ConvertFrom-Json -Depth 100
+    $accountDeployment = $template.resources.cosmosDBAccount
+    $databaseDeployment = $template.resources.cosmosSqlDatabase
+
+    $topLevelDeployments = @(
+        foreach ($resourceProperty in $template.resources.PSObject.Properties) {
+            if ($resourceProperty.Value.type -eq 'Microsoft.Resources/deployments') {
+                $resourceProperty.Value
+            }
+        }
+    )
+    $resourceNameDerivedDeployments = @(
+        $topLevelDeployments |
+            Where-Object { ([string]$_.name).Contains("variables('resourceNames')") }
+    )
+    Assert-True `
+        -Condition ($resourceNameDerivedDeployments.Count -eq 0) `
+        -Message 'Top-level deployment names do not embed environment-derived resource names'
+
+    $oversizedStaticDeployments = @(
+        $topLevelDeployments |
+            Where-Object {
+                $name = [string]$_.name
+                -not $name.StartsWith('[') -and $name.Length -gt 64
+            }
+    )
+    Assert-True `
+        -Condition ($oversizedStaticDeployments.Count -eq 0) `
+        -Message 'Every static top-level deployment name is within the 64-character ARM limit'
+
+    Assert-True `
+        -Condition (
+            [string]$template.resources.aiFoundry.name -eq 'aiFoundryDeployment' -and
+            [string]$template.resources.aiFoundryBingConnection.name -eq 'aiFoundryBingConnection'
+        ) `
+        -Message 'Foundry deployment names remain bounded when CAF resource names are long'
+
+    Assert-True `
+        -Condition ($null -ne $accountDeployment) `
+        -Message 'Cosmos DB account AVM deployment remains present'
+
+    $accountSqlDeployment = $accountDeployment.properties.template.resources.databaseAccount_sqlDatabases
+    Assert-True `
+        -Condition (
+            $null -eq $accountDeployment.properties.parameters.sqlDatabases -and
+            [string]$accountSqlDeployment.copy.count -eq "[length(coalesce(parameters('sqlDatabases'), createArray()))]"
+        ) `
+        -Message 'Account AVM receives no SQL databases, so its unbounded deployment loop has zero instances'
+
+    Assert-True `
+        -Condition ($null -ne $databaseDeployment) `
+        -Message 'Fixed-name Cosmos SQL database deployment is present'
+
+    $deploymentName = [string]$databaseDeployment.name
+    Assert-True `
+        -Condition ($deploymentName -eq 'cosmosSqlDatabase' -and $deploymentName.Length -le 64) `
+        -Message 'Cosmos SQL deployment name is constant and within the 64-character ARM limit'
+
+    $databaseParameters = $databaseDeployment.properties.parameters
+    Assert-True `
+        -Condition ([string]$databaseParameters.databaseName.value -eq "[variables('resourceNames').dbDatabaseName]") `
+        -Message 'Database resource name remains the configured resource name'
+
+    Assert-True `
+        -Condition ([string]$databaseParameters.databaseAccountName.value -eq "[variables('resourceNames').dbAccountName]") `
+        -Message 'Database deployment targets the configured Cosmos DB account'
+
+    $localResources = $databaseDeployment.properties.template.resources
+    $sqlDatabase = $localResources.sqlDatabase
+    $sqlContainers = $localResources.sqlContainers
+    Assert-True `
+        -Condition (
+            [string]$sqlDatabase.type -eq 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases' -and
+            [string]$sqlDatabase.apiVersion -eq '2024-11-15' -and
+            [string]$sqlDatabase.name -eq "[format('{0}/{1}', parameters('databaseAccountName'), parameters('databaseName'))]"
+        ) `
+        -Message 'Local module preserves the direct SQL database resource contract'
+
+    Assert-True `
+        -Condition (
+            [string]$sqlContainers.type -eq 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers' -and
+            [string]$sqlContainers.apiVersion -eq '2024-11-15' -and
+            [string]$sqlContainers.name -eq "[format('{0}/{1}/{2}', parameters('databaseAccountName'), parameters('databaseName'), parameters('containers')[copyIndex()].name)]"
+        ) `
+        -Message 'Local module preserves the direct container resource contract'
+
+    $serializedLocalTemplate = $databaseDeployment.properties.template | ConvertTo-Json -Depth 100 -Compress
+    Assert-True `
+        -Condition ($serializedLocalTemplate -notmatch '"type":"Microsoft.Resources/deployments"') `
+        -Message 'Local Cosmos module introduces no additional nested deployments'
+
+    $databaseOptions = [string]$sqlDatabase.properties.options
+    Assert-True `
+        -Condition (
+            $databaseOptions.Contains("'EnableServerless'") -and
+            $databaseOptions.Contains("parameters('databaseThroughput')")
+        ) `
+        -Message 'Database throughput remains disabled for serverless and parameter-driven otherwise'
+
+    $containerResource = $sqlContainers.properties.resource
+    $partitionKeyJson = $containerResource.partitionKey | ConvertTo-Json -Depth 20 -Compress
+    Assert-True `
+        -Condition (
+            [string]$containerResource.defaultTtl -match 'defaultTtl.*-1' -and
+            [string]$containerResource.indexingPolicy -match 'indexingPolicy' -and
+            $partitionKeyJson.Contains("startsWith(parameters('containers')") -and
+            $partitionKeyJson.Contains('"kind":"Hash"') -and
+            $partitionKeyJson.Contains('"version":1')
+        ) `
+        -Message 'Container TTL, indexing, and partition-key semantics remain intact'
+
+    $containerOptions = [string]$sqlContainers.properties.options
+    Assert-True `
+        -Condition (
+            $containerOptions.Contains("'EnableServerless'") -and
+            $containerOptions.Contains("parameters('databaseThroughput')") -and
+            $containerOptions.Contains("'throughput'") -and
+            $containerOptions.Contains('400')
+        ) `
+        -Message 'Container throughput preserves serverless, database-level, and default branches'
+
+    $containerParameterCopy = $databaseParameters.containers.copy | ConvertTo-Json -Depth 20 -Compress
+    Assert-True `
+        -Condition (
+            $containerParameterCopy.Contains("'name'") -and
+            $containerParameterCopy.Contains("'paths'") -and
+            $containerParameterCopy.Contains("'defaultTtl', -1") -and
+            $containerParameterCopy.Contains("'throughput'") -and
+            $containerParameterCopy.Contains("'indexingPolicy'")
+        ) `
+        -Message 'Main template forwards every supported container setting'
+
+    $dependsOn = @($databaseDeployment.dependsOn)
+    Assert-True `
+        -Condition ($dependsOn -contains 'cosmosDBAccount') `
+        -Message 'SQL database deployment waits for the Cosmos DB account'
+
+    Assert-True `
+        -Condition (@($sqlContainers.dependsOn) -contains 'sqlDatabase') `
+        -Message 'Container resources wait for the SQL database'
+
+    $reportedEnvironmentName = 'gpt-rag-consolidate-v350'
+    Assert-True `
+        -Condition ($reportedEnvironmentName.Length -ge 19 -and $deploymentName.Length -le 64) `
+        -Message 'Issue #119 long environment-name reproduction cannot affect the fixed deployment name'
+}
+finally {
+    Remove-Item -Path $compiledFile -Force -ErrorAction SilentlyContinue
+}
+
+if ($failures.Count -gt 0) {
+    Write-Host "`nCosmos DB deployment-name contract failed with $($failures.Count) error(s)." -ForegroundColor Red
+    exit 1
+}
+
+Write-Host "`nCosmos DB deployment-name contract checks passed." -ForegroundColor Green

--- a/tests/contracts/fixtures/hosted-agent-resource-graph.json
+++ b/tests/contracts/fixtures/hosted-agent-resource-graph.json
@@ -7,6 +7,7 @@
   ],
   "allowedPostBaselineMutations": [
     "aiFoundry",
+    "aiFoundryBingConnection",
     "appConfigKeyVaultPopulate",
     "appConfigPopulate",
     "assignContainerAppRoles",
@@ -15,6 +16,8 @@
     "containerApps",
     "containerAppsSettings",
     "containerAppsUAI",
+    "cosmosDBAccount",
+    "cosmosSqlDatabase",
     "virtualNetworkSubnets"
   ],
   "normalizedResourceHashes": {


### PR DESCRIPTION
## Purpose

Long azd/CAF environment names can make nested ARM deployment names exceed the 64-character platform limit, preventing otherwise valid environments from provisioning. This change bounds the internal deployment names without changing the configured names of any deployed Azure resource.

The Cosmos DB account remains on AVM, while its SQL database and containers move to a focused local module with a fixed deployment name. The top-level Foundry and Bing connection deployments also use fixed names. A compiled-template contract verifies the 64-character limit and preserves Cosmos throughput, TTL, indexing, partition-key, parameter-forwarding, and dependency behavior.

## Type of change 

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Documentation content changes
- [ ] Other (please describe):

## Related Backlog Item or Issue

Closes #119

## Documentation

Updated `CHANGELOG.md` and `tests/README.md`. No public landing-zone narrative or consumer-facing parameter, output, resource-name, or deployment procedure changed, so no companion `Azure/AI-Landing-Zones` PR is required.

## Validation evidence

- `pwsh ./tests/contracts/Test-CosmosDeploymentNameContract.ps1` - passed.
- `pwsh ./tests/contracts/Test-HostedAgentContract.ps1` - passed.
- All `tests/contracts/Test-*.ps1` scripts - passed.
- `pwsh ./tests/scripts/Invoke-PreflightChecks.Tests.ps1` - 73 tests passed, 0 failures.
- `pwsh ./.github/scripts/Validate-CopilotAssets.ps1` - passed.
- `pwsh ./tests/scripts/Validate-CopilotAssets.Tests.ps1` - passed.
- `az bicep build --file ./main.bicep` - passed with existing unrelated warnings.
- `az bicep lint --file ./main.bicep` - passed with existing unrelated warnings.
- `pwsh ./scripts/Measure-MainJsonSize.ps1` - 4.672 MB, below the 4.7 MB CI threshold.
- `git diff --check` - passed.
- Azure What-If and live deployment were not run because no approved Azure test environment was authorized.

## Code quality checklist

- [x] I verified the changes locally to ensure they work as expected
- [x] I tested the new functionality and ensured existing features still work
- [x] I preserved parameter, output, naming, identity, and network-isolation contracts or documented the migration
- [x] I updated `CHANGELOG.md` and all affected documentation
- [ ] I added at least one reviewer to this Pull Request