### PR TITLE
Sync v2.6.1 release to develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
 
 ## [Unreleased]
 
+## [v2.6.1] - 2026-08-21
+
 ### Fixed
 
 - Fixed provisioning for long azd/CAF environment names by replacing resource-name-derived Foundry deployment names and moving Cosmos DB SQL database/container resources out of the account AVM's name-derived nested deployment. All replacement deployment names stay below ARM's 64-character limit while preserving the configured Azure resource names (fixes #119).

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
-  "tag": "v2.6.0",
+  "tag": "v2.6.1",
   "repo": "https://github.com/azure/bicep-ptn-aiml-landing-zone.git",
-  "ailz_tag": "v2.6.0",
+  "ailz_tag": "v2.6.1",
   "components": []
 }


### PR DESCRIPTION
## Purpose

Synchronize `develop` with the published `v2.6.1` patch release from `main`. This carries only the release metadata that pins `manifest.json` and `CHANGELOG.md` to the released version.

## Type of change 

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Documentation content changes
- [ ] Other (please describe):

## Related Backlog Item or Issue

#119

## Documentation

Carries the `v2.6.1` changelog and manifest alignment already merged and published from `main`. No additional documentation changes are introduced.

## Validation evidence

Release commit `64195c0` was verified against tag and GitHub Release `v2.6.1`. Before publication, Bicep build/lint, all contract tests, 73 preflight tests, Copilot asset validation, template-size measurement, and `git diff --check` passed.

Azure What-If and live deployment were not run because no approved Azure test environment was authorized.

## Code quality checklist

- [x] I verified the changes locally to ensure they work as expected
- [x] I tested the new functionality and ensured existing features still work
- [x] I preserved parameter, output, naming, identity, and network-isolation contracts or documented the migration
- [x] I updated `CHANGELOG.md` and all affected documentation
- [ ] I added at least one reviewer to this Pull Request