### PR TITLE
chore: finalize Terraform parity proposals

### DIFF
--- a/parity/handoffs/ai-foundry/foundry-baseline.json
+++ b/parity/handoffs/ai-foundry/foundry-baseline.json
@@ -3,7 +3,10 @@
     "The target proposal is human-reviewable, links this handoff and both baselines, and contains no unrelated contract change."
   ],
   "approval": {
-    "status": "pending"
+    "status": "approved",
+    "approvalUrl": "https://github.com/Azure/bicep-ptn-aiml-landing-zone/pull/147#issuecomment-5375280499",
+    "approvedBy": "placerda",
+    "approvedAt": "2026-08-21T20:51:57Z"
   },
   "avmRequirements": [
     "Run the target repository formatting, lint, documentation, examples, test, and AVM pattern-module compliance checks."
@@ -61,9 +64,11 @@
     "baselineId": "baseline-v2.6.1-v0.5.1",
     "inventoryDigest": {
       "algorithm": "sha256",
-      "value": "33fa2bae3144b79c632a0e8f142a85600989ecd04de8cca8b1a49de5edff44b4"
+      "value": "5dd04b6ebb7faa4554954ee9fe27cd3589943f724e9d14e5c799dea0a93bdf75"
     },
-    "type": "baseline-inventory"
+    "type": "baseline-inventory",
+    "inventoryCommitSha": "54d18f53273082dd12f0cab0689ec7968e845950",
+    "inventoryReviewUrl": "https://github.com/Azure/bicep-ptn-aiml-landing-zone/pull/147"
   },
   "rbacRequirements": [
     "Apply least-privilege RBAC and preserve explicit control-plane and data-plane role boundaries.",
@@ -102,5 +107,6 @@
     "commitSha": "abe337894f93de3ddda525ea44898b33e1484070",
     "ref": "main",
     "repository": "Azure/terraform-azurerm-avm-ptn-aiml-landing-zone"
-  }
+  },
+  "terraformPullRequestUrl": "https://github.com/Azure/terraform-azurerm-avm-ptn-aiml-landing-zone/pull/166"
 }

--- a/parity/handoffs/application-platform/application-platform-baseline.json
+++ b/parity/handoffs/application-platform/application-platform-baseline.json
@@ -3,7 +3,10 @@
     "The target proposal is human-reviewable, links this handoff and both baselines, and contains no unrelated contract change."
   ],
   "approval": {
-    "status": "pending"
+    "status": "approved",
+    "approvalUrl": "https://github.com/Azure/bicep-ptn-aiml-landing-zone/pull/147#issuecomment-5375280499",
+    "approvedBy": "placerda",
+    "approvedAt": "2026-08-21T20:51:57Z"
   },
   "avmRequirements": [
     "Run the target repository formatting, lint, documentation, examples, test, and AVM pattern-module compliance checks."
@@ -70,9 +73,11 @@
     "baselineId": "baseline-v2.6.1-v0.5.1",
     "inventoryDigest": {
       "algorithm": "sha256",
-      "value": "33fa2bae3144b79c632a0e8f142a85600989ecd04de8cca8b1a49de5edff44b4"
+      "value": "5dd04b6ebb7faa4554954ee9fe27cd3589943f724e9d14e5c799dea0a93bdf75"
     },
-    "type": "baseline-inventory"
+    "type": "baseline-inventory",
+    "inventoryCommitSha": "54d18f53273082dd12f0cab0689ec7968e845950",
+    "inventoryReviewUrl": "https://github.com/Azure/bicep-ptn-aiml-landing-zone/pull/147"
   },
   "rbacRequirements": [
     "Apply least-privilege RBAC and preserve explicit control-plane and data-plane role boundaries.",
@@ -125,5 +130,6 @@
     "commitSha": "abe337894f93de3ddda525ea44898b33e1484070",
     "ref": "main",
     "repository": "Azure/terraform-azurerm-avm-ptn-aiml-landing-zone"
-  }
+  },
+  "terraformPullRequestUrl": "https://github.com/Azure/terraform-azurerm-avm-ptn-aiml-landing-zone/pull/164"
 }

--- a/parity/handoffs/data-and-ai-services/data-and-ai-services-baseline.json
+++ b/parity/handoffs/data-and-ai-services/data-and-ai-services-baseline.json
@@ -3,7 +3,10 @@
     "The target proposal is human-reviewable, links this handoff and both baselines, and contains no unrelated contract change."
   ],
   "approval": {
-    "status": "pending"
+    "status": "approved",
+    "approvalUrl": "https://github.com/Azure/bicep-ptn-aiml-landing-zone/pull/147#issuecomment-5375280499",
+    "approvedBy": "placerda",
+    "approvedAt": "2026-08-21T20:51:57Z"
   },
   "avmRequirements": [
     "Run the target repository formatting, lint, documentation, examples, test, and AVM pattern-module compliance checks."
@@ -59,9 +62,11 @@
     "baselineId": "baseline-v2.6.1-v0.5.1",
     "inventoryDigest": {
       "algorithm": "sha256",
-      "value": "33fa2bae3144b79c632a0e8f142a85600989ecd04de8cca8b1a49de5edff44b4"
+      "value": "5dd04b6ebb7faa4554954ee9fe27cd3589943f724e9d14e5c799dea0a93bdf75"
     },
-    "type": "baseline-inventory"
+    "type": "baseline-inventory",
+    "inventoryCommitSha": "54d18f53273082dd12f0cab0689ec7968e845950",
+    "inventoryReviewUrl": "https://github.com/Azure/bicep-ptn-aiml-landing-zone/pull/147"
   },
   "rbacRequirements": [
     "Apply least-privilege RBAC and preserve explicit control-plane and data-plane role boundaries.",
@@ -100,5 +105,6 @@
     "commitSha": "abe337894f93de3ddda525ea44898b33e1484070",
     "ref": "main",
     "repository": "Azure/terraform-azurerm-avm-ptn-aiml-landing-zone"
-  }
+  },
+  "terraformPullRequestUrl": "https://github.com/Azure/terraform-azurerm-avm-ptn-aiml-landing-zone/pull/167"
 }

--- a/parity/handoffs/networking/networking-baseline.json
+++ b/parity/handoffs/networking/networking-baseline.json
@@ -3,7 +3,10 @@
     "The target proposal is human-reviewable, links this handoff and both baselines, and contains no unrelated contract change."
   ],
   "approval": {
-    "status": "pending"
+    "status": "approved",
+    "approvalUrl": "https://github.com/Azure/bicep-ptn-aiml-landing-zone/pull/147#issuecomment-5375280499",
+    "approvedBy": "placerda",
+    "approvedAt": "2026-08-21T20:51:57Z"
   },
   "avmRequirements": [
     "Run the target repository formatting, lint, documentation, examples, test, and AVM pattern-module compliance checks."
@@ -73,9 +76,11 @@
     "baselineId": "baseline-v2.6.1-v0.5.1",
     "inventoryDigest": {
       "algorithm": "sha256",
-      "value": "33fa2bae3144b79c632a0e8f142a85600989ecd04de8cca8b1a49de5edff44b4"
+      "value": "5dd04b6ebb7faa4554954ee9fe27cd3589943f724e9d14e5c799dea0a93bdf75"
     },
-    "type": "baseline-inventory"
+    "type": "baseline-inventory",
+    "inventoryCommitSha": "54d18f53273082dd12f0cab0689ec7968e845950",
+    "inventoryReviewUrl": "https://github.com/Azure/bicep-ptn-aiml-landing-zone/pull/147"
   },
   "rbacRequirements": [
     "Apply least-privilege RBAC and preserve explicit control-plane and data-plane role boundaries.",
@@ -129,5 +134,6 @@
     "commitSha": "abe337894f93de3ddda525ea44898b33e1484070",
     "ref": "main",
     "repository": "Azure/terraform-azurerm-avm-ptn-aiml-landing-zone"
-  }
+  },
+  "terraformPullRequestUrl": "https://github.com/Azure/terraform-azurerm-avm-ptn-aiml-landing-zone/pull/162"
 }

--- a/parity/handoffs/security/security-baseline.json
+++ b/parity/handoffs/security/security-baseline.json
@@ -3,7 +3,10 @@
     "The target proposal is human-reviewable, links this handoff and both baselines, and contains no unrelated contract change."
   ],
   "approval": {
-    "status": "pending"
+    "status": "approved",
+    "approvalUrl": "https://github.com/Azure/bicep-ptn-aiml-landing-zone/pull/147#issuecomment-5375280499",
+    "approvedBy": "placerda",
+    "approvedAt": "2026-08-21T20:51:57Z"
   },
   "avmRequirements": [
     "Run the target repository formatting, lint, documentation, examples, test, and AVM pattern-module compliance checks."
@@ -57,9 +60,11 @@
     "baselineId": "baseline-v2.6.1-v0.5.1",
     "inventoryDigest": {
       "algorithm": "sha256",
-      "value": "33fa2bae3144b79c632a0e8f142a85600989ecd04de8cca8b1a49de5edff44b4"
+      "value": "5dd04b6ebb7faa4554954ee9fe27cd3589943f724e9d14e5c799dea0a93bdf75"
     },
-    "type": "baseline-inventory"
+    "type": "baseline-inventory",
+    "inventoryCommitSha": "54d18f53273082dd12f0cab0689ec7968e845950",
+    "inventoryReviewUrl": "https://github.com/Azure/bicep-ptn-aiml-landing-zone/pull/147"
   },
   "rbacRequirements": [
     "Apply least-privilege RBAC and preserve explicit control-plane and data-plane role boundaries.",
@@ -95,5 +100,6 @@
     "commitSha": "abe337894f93de3ddda525ea44898b33e1484070",
     "ref": "main",
     "repository": "Azure/terraform-azurerm-avm-ptn-aiml-landing-zone"
-  }
+  },
+  "terraformPullRequestUrl": "https://github.com/Azure/terraform-azurerm-avm-ptn-aiml-landing-zone/pull/163"
 }

--- a/parity/inventory.json
+++ b/parity/inventory.json
@@ -3731,7 +3731,9 @@
             "migrationRequired": false
           },
           "blockedReason": "Terraform v0.5.1 structurally requires a VNet, subnets, private endpoints, and mostly disabled public network access, so it cannot represent Bicep standalone-standard.",
-          "proposalIds": [],
+          "proposalIds": [
+            "handoff-application-platform-baseline"
+          ],
           "evidenceIds": []
         },
         {
@@ -3757,7 +3759,9 @@
             ],
             "migrationRequired": false
           },
-          "proposalIds": [],
+          "proposalIds": [
+            "handoff-application-platform-baseline"
+          ],
           "evidenceIds": []
         }
       ],
@@ -3825,7 +3829,9 @@
             "migrationRequired": false
           },
           "blockedReason": "Terraform's naming contract is only usable inside its mandatory VNet/private-endpoint topology, which cannot produce standalone-standard.",
-          "proposalIds": [],
+          "proposalIds": [
+            "handoff-application-platform-baseline"
+          ],
           "evidenceIds": []
         },
         {
@@ -3847,7 +3853,9 @@
             "defaultDifferences": [],
             "migrationRequired": false
           },
-          "proposalIds": [],
+          "proposalIds": [
+            "handoff-application-platform-baseline"
+          ],
           "evidenceIds": []
         }
       ],
@@ -3904,7 +3912,9 @@
             "migrationRequired": false
           },
           "blockedReason": "Terraform v0.5.1 always creates Foundry private endpoints and requires VNet/subnet inputs; its service defaults disable public access, so networkIsolation=false has no analogue.",
-          "proposalIds": [],
+          "proposalIds": [
+            "handoff-networking-baseline"
+          ],
           "evidenceIds": []
         },
         {
@@ -3925,7 +3935,9 @@
             "defaultDifferences": [],
             "migrationRequired": false
           },
-          "proposalIds": [],
+          "proposalIds": [
+            "handoff-networking-baseline"
+          ],
           "evidenceIds": []
         }
       ],
@@ -3994,7 +4006,9 @@
             "migrationRequired": false
           },
           "blockedReason": "Required Terraform vnet_definition and always-created private endpoints prevent a no-VNet standalone-standard deployment.",
-          "proposalIds": [],
+          "proposalIds": [
+            "handoff-networking-baseline"
+          ],
           "evidenceIds": []
         },
         {
@@ -4016,7 +4030,9 @@
             "defaultDifferences": [],
             "migrationRequired": false
           },
-          "proposalIds": [],
+          "proposalIds": [
+            "handoff-networking-baseline"
+          ],
           "evidenceIds": []
         }
       ],
@@ -4067,7 +4083,9 @@
             "migrationRequired": false
           },
           "blockedReason": "Terraform's required private network means its routing and firewall choices cannot yield Bicep's no-mandatory-network standalone-standard topology.",
-          "proposalIds": [],
+          "proposalIds": [
+            "handoff-networking-baseline"
+          ],
           "evidenceIds": []
         },
         {
@@ -4088,7 +4106,9 @@
             "defaultDifferences": [],
             "migrationRequired": false
           },
-          "proposalIds": [],
+          "proposalIds": [
+            "handoff-networking-baseline"
+          ],
           "evidenceIds": []
         }
       ],
@@ -4136,7 +4156,9 @@
             "migrationRequired": false
           },
           "blockedReason": "Terraform still requires its spoke VNet and private endpoints; peering options cannot remove them for standalone-standard.",
-          "proposalIds": [],
+          "proposalIds": [
+            "handoff-networking-baseline"
+          ],
           "evidenceIds": []
         },
         {
@@ -4156,7 +4178,9 @@
             "defaultDifferences": [],
             "migrationRequired": false
           },
-          "proposalIds": [],
+          "proposalIds": [
+            "handoff-networking-baseline"
+          ],
           "evidenceIds": []
         }
       ],
@@ -4217,7 +4241,9 @@
             "migrationRequired": false
           },
           "blockedReason": "Mandatory Terraform private endpoints require private DNS decisions, unlike Bicep standalone-standard's public topology.",
-          "proposalIds": [],
+          "proposalIds": [
+            "handoff-networking-baseline"
+          ],
           "evidenceIds": []
         },
         {
@@ -4238,7 +4264,9 @@
             ],
             "migrationRequired": false
           },
-          "proposalIds": [],
+          "proposalIds": [
+            "handoff-networking-baseline"
+          ],
           "evidenceIds": []
         }
       ],
@@ -4283,7 +4311,9 @@
             "migrationRequired": false
           },
           "blockedReason": "Foundry create_private_endpoints=true and required private endpoint subnet structure make private endpoints structural in Terraform v0.5.1.",
-          "proposalIds": [],
+          "proposalIds": [
+            "handoff-networking-baseline"
+          ],
           "evidenceIds": []
         },
         {
@@ -4302,7 +4332,9 @@
             "defaultDifferences": [],
             "migrationRequired": false
           },
-          "proposalIds": [],
+          "proposalIds": [
+            "handoff-networking-baseline"
+          ],
           "evidenceIds": []
         }
       ],
@@ -4372,7 +4404,9 @@
             "migrationRequired": false
           },
           "blockedReason": "Terraform cannot remove the underlying private topology to produce standalone-standard; jumpbox/Bastion flags do not change that constraint.",
-          "proposalIds": [],
+          "proposalIds": [
+            "handoff-networking-baseline"
+          ],
           "evidenceIds": []
         },
         {
@@ -4395,7 +4429,9 @@
             "defaultDifferences": [],
             "migrationRequired": false
           },
-          "proposalIds": [],
+          "proposalIds": [
+            "handoff-networking-baseline"
+          ],
           "evidenceIds": []
         }
       ],
@@ -4451,7 +4487,9 @@
             "migrationRequired": false
           },
           "blockedReason": "Terraform's Application Gateway option cannot be combined with a no-VNet/no-private-endpoint standard deployment.",
-          "proposalIds": [],
+          "proposalIds": [
+            "handoff-networking-baseline"
+          ],
           "evidenceIds": []
         },
         {
@@ -4473,7 +4511,9 @@
             "defaultDifferences": [],
             "migrationRequired": false
           },
-          "proposalIds": [],
+          "proposalIds": [
+            "handoff-networking-baseline"
+          ],
           "evidenceIds": []
         }
       ],
@@ -4540,7 +4580,9 @@
             "migrationRequired": false
           },
           "blockedReason": "Terraform Foundry create_private_endpoints=true plus mandatory VNet/subnet inputs prevents the standalone-standard Foundry account topology.",
-          "proposalIds": [],
+          "proposalIds": [
+            "handoff-ai-foundry-baseline"
+          ],
           "evidenceIds": []
         },
         {
@@ -4565,7 +4607,9 @@
             ],
             "migrationRequired": true
           },
-          "proposalIds": [],
+          "proposalIds": [
+            "handoff-ai-foundry-baseline"
+          ],
           "evidenceIds": []
         }
       ],
@@ -4619,7 +4663,9 @@
             "migrationRequired": false
           },
           "blockedReason": "Terraform cannot deploy these Foundry nested resources without its structurally required VNet and private endpoints.",
-          "proposalIds": [],
+          "proposalIds": [
+            "handoff-ai-foundry-baseline"
+          ],
           "evidenceIds": []
         },
         {
@@ -4642,7 +4688,9 @@
             ],
             "migrationRequired": false
           },
-          "proposalIds": [],
+          "proposalIds": [
+            "handoff-ai-foundry-baseline"
+          ],
           "evidenceIds": []
         }
       ],
@@ -4709,7 +4757,9 @@
             "migrationRequired": false
           },
           "blockedReason": "Terraform service topology depends on required VNet/private endpoints and mostly disabled public access, preventing standalone-standard.",
-          "proposalIds": [],
+          "proposalIds": [
+            "handoff-data-and-ai-services-baseline"
+          ],
           "evidenceIds": []
         },
         {
@@ -4732,7 +4782,9 @@
             "defaultDifferences": [],
             "migrationRequired": false
           },
-          "proposalIds": [],
+          "proposalIds": [
+            "handoff-data-and-ai-services-baseline"
+          ],
           "evidenceIds": []
         }
       ],
@@ -4794,7 +4846,9 @@
             "migrationRequired": false
           },
           "blockedReason": "Terraform v0.5.1 requires the landing-zone VNet/private endpoints and has no Container Apps workload resources, so it cannot represent Bicep standalone-standard workloads.",
-          "proposalIds": [],
+          "proposalIds": [
+            "handoff-application-platform-baseline"
+          ],
           "evidenceIds": []
         },
         {
@@ -4816,7 +4870,9 @@
             "defaultDifferences": [],
             "migrationRequired": false
           },
-          "proposalIds": [],
+          "proposalIds": [
+            "handoff-application-platform-baseline"
+          ],
           "evidenceIds": []
         }
       ],
@@ -4888,7 +4944,9 @@
             "migrationRequired": false
           },
           "blockedReason": "Terraform's required private topology prevents the standard scenario, and no App Configuration key-value population/runtime-mode implementation exists.",
-          "proposalIds": [],
+          "proposalIds": [
+            "handoff-application-platform-baseline"
+          ],
           "evidenceIds": []
         },
         {
@@ -4910,7 +4968,9 @@
             "defaultDifferences": [],
             "migrationRequired": false
           },
-          "proposalIds": [],
+          "proposalIds": [
+            "handoff-application-platform-baseline"
+          ],
           "evidenceIds": []
         }
       ],
@@ -5014,7 +5074,9 @@
             "migrationRequired": false
           },
           "blockedReason": "Terraform requires private topology and has no Foundry IQ/retrieval-backend runtime configuration contract, so standalone-standard cannot be represented.",
-          "proposalIds": [],
+          "proposalIds": [
+            "handoff-application-platform-baseline"
+          ],
           "evidenceIds": []
         },
         {
@@ -5038,7 +5100,9 @@
             "defaultDifferences": [],
             "migrationRequired": false
           },
-          "proposalIds": [],
+          "proposalIds": [
+            "handoff-application-platform-baseline"
+          ],
           "evidenceIds": []
         }
       ],
@@ -5116,7 +5180,9 @@
             "migrationRequired": false
           },
           "blockedReason": "Terraform GenAI Storage, Cosmos, and Key Vault default to disabled public access and private endpoints in the mandatory VNet, preventing standalone-standard.",
-          "proposalIds": [],
+          "proposalIds": [
+            "handoff-data-and-ai-services-baseline"
+          ],
           "evidenceIds": []
         },
         {
@@ -5141,7 +5207,9 @@
             ],
             "migrationRequired": false
           },
-          "proposalIds": [],
+          "proposalIds": [
+            "handoff-data-and-ai-services-baseline"
+          ],
           "evidenceIds": []
         }
       ],
@@ -5200,7 +5268,9 @@
             "migrationRequired": false
           },
           "blockedReason": "Terraform registry public_network_access_enabled defaults false with a private endpoint in the mandatory VNet, preventing standalone-standard.",
-          "proposalIds": [],
+          "proposalIds": [
+            "handoff-application-platform-baseline"
+          ],
           "evidenceIds": []
         },
         {
@@ -5222,7 +5292,9 @@
             "defaultDifferences": [],
             "migrationRequired": false
           },
-          "proposalIds": [],
+          "proposalIds": [
+            "handoff-application-platform-baseline"
+          ],
           "evidenceIds": []
         }
       ],
@@ -5289,7 +5361,9 @@
             "migrationRequired": false
           },
           "blockedReason": "Terraform observability remains part of a mandatory private landing-zone topology, so it cannot represent standalone-standard.",
-          "proposalIds": [],
+          "proposalIds": [
+            "handoff-data-and-ai-services-baseline"
+          ],
           "evidenceIds": []
         },
         {
@@ -5312,7 +5386,9 @@
             "defaultDifferences": [],
             "migrationRequired": false
           },
-          "proposalIds": [],
+          "proposalIds": [
+            "handoff-data-and-ai-services-baseline"
+          ],
           "evidenceIds": []
         }
       ],
@@ -5369,7 +5445,9 @@
             "migrationRequired": false
           },
           "blockedReason": "Terraform identity/RBAC constructs are deployed only in its VNet/private-endpoint topology and cannot produce standalone-standard.",
-          "proposalIds": [],
+          "proposalIds": [
+            "handoff-security-baseline"
+          ],
           "evidenceIds": []
         },
         {
@@ -5391,7 +5469,9 @@
             "defaultDifferences": [],
             "migrationRequired": false
           },
-          "proposalIds": [],
+          "proposalIds": [
+            "handoff-security-baseline"
+          ],
           "evidenceIds": []
         }
       ],
@@ -5448,7 +5528,9 @@
             "migrationRequired": false
           },
           "blockedReason": "Terraform has no hosted-agent prerequisite/handoff contract and its Foundry resources require the private topology, preventing standalone-standard.",
-          "proposalIds": [],
+          "proposalIds": [
+            "handoff-ai-foundry-baseline"
+          ],
           "evidenceIds": []
         },
         {
@@ -5471,7 +5553,9 @@
             "defaultDifferences": [],
             "migrationRequired": false
           },
-          "proposalIds": [],
+          "proposalIds": [
+            "handoff-ai-foundry-baseline"
+          ],
           "evidenceIds": []
         }
       ],
@@ -5519,7 +5603,9 @@
             "migrationRequired": false
           },
           "blockedReason": "Terraform's structural private topology means no preflight selection can produce Bicep standalone-standard.",
-          "proposalIds": [],
+          "proposalIds": [
+            "handoff-application-platform-baseline"
+          ],
           "evidenceIds": []
         },
         {
@@ -5540,7 +5626,9 @@
             "defaultDifferences": [],
             "migrationRequired": false
           },
-          "proposalIds": [],
+          "proposalIds": [
+            "handoff-application-platform-baseline"
+          ],
           "evidenceIds": []
         }
       ],

--- a/specs/001-terraform-foundry-parity/quickstart.md
+++ b/specs/001-terraform-foundry-parity/quickstart.md
@@ -94,8 +94,9 @@ Expected result:
 - the handoff contains no Terraform source, credential, tenant ID, or subscription ID.
 
 Issue #136 supplies design context only; it is not inventory review or handoff approval evidence.
-The five checked-in baseline handoffs remain pending drafts until a later reviewed commit and
-explicit T033 authorization exist.
+The five checked-in baseline handoffs are approved against the reviewed inventory commit, carry
+separate T033 authorization, and link their upstream draft Terraform proposals. Proposal status
+does not claim deployment or functional parity.
 
 ## 5. Validate repository assets
 

--- a/specs/001-terraform-foundry-parity/tasks.md
+++ b/specs/001-terraform-foundry-parity/tasks.md
@@ -108,7 +108,7 @@ Terraform repository; no Terraform source exists in this repository.
 - [X] T030 [US2] Add a read-only Terraform parity coding-agent profile that consumes only approved handoffs and cannot merge or deploy in `.github/agents/terraform-parity.agent.md`
 - [X] T031 [US2] Add the agent workflow, acceptance checklist, target-repository boundary, and exit conditions in `.github/skills/terraform-parity-proposal/SKILL.md`
 - [X] T032 [US2] Validate the new agent and skill surfaces through `.github/scripts/Validate-CopilotAssets.ps1` and add focused cases to `tests/scripts/Validate-CopilotAssets.Tests.ps1`
-- [ ] T033 [US2] After explicit human approval, use the approved initial-baseline handoffs and the target repository's existing contribution path to raise draft proposals covering 100 percent of actionable gaps in `Azure/terraform-azurerm-avm-ptn-aiml-landing-zone`, then record each proposal URL or reviewed deferral in `parity/inventory.json`; do not depend on the ongoing dispatch workflow introduced in US3
+- [X] T033 [US2] After explicit human approval, use the approved initial-baseline handoffs and the target repository's existing contribution path to raise draft proposals covering 100 percent of actionable gaps in `Azure/terraform-azurerm-avm-ptn-aiml-landing-zone`, then record each proposal URL or reviewed deferral in `parity/inventory.json`; do not depend on the ongoing dispatch workflow introduced in US3
 
 **Checkpoint**: User Story 2 satisfies this feature's definition of done for gap proposals. Merging,
 deploying, and recording parity evidence remain target-repository follow-up work.

--- a/specs/001-terraform-foundry-parity/validation.md
+++ b/specs/001-terraform-foundry-parity/validation.md
@@ -100,3 +100,35 @@ rechecked because dependencies did not change.
 - Static validation does not prove runtime behavior, effective RBAC, DNS,
   endpoint reachability, or isolation. Each scenario still requires its own
   approved target-repository deployment and reviewed comparison.
+
+# User Story 2 proposal publication
+
+Completed on 2026-08-22 after PR
+[`#147`](https://github.com/Azure/bicep-ptn-aiml-landing-zone/pull/147)
+merged the reviewed inventory and the maintainer recorded separate T033
+authorization in
+[comment `#issuecomment-5375280499`](https://github.com/Azure/bicep-ptn-aiml-landing-zone/pull/147#issuecomment-5375280499).
+Inventory commit `54d18f53273082dd12f0cab0689ec7968e845950`
+contains the exact proposal-linked inventory bytes with SHA-256
+`5dd04b6ebb7faa4554954ee9fe27cd3589943f724e9d14e5c799dea0a93bdf75`.
+
+| Handoff | Upstream draft proposal | Target commit | Local validation |
+| --- | --- | --- | --- |
+| Networking | [`#162`](https://github.com/Azure/terraform-azurerm-avm-ptn-aiml-landing-zone/pull/162) | `2455d2f289baa69787965a82ce1ffcc8c4b07e5c` | `avm test` and `avm pre-commit` passed. |
+| Security | [`#163`](https://github.com/Azure/terraform-azurerm-avm-ptn-aiml-landing-zone/pull/163) | `ecff99f` | `avm pre-commit`, three unit tests, and `terraform validate` passed. |
+| Application Platform | [`#164`](https://github.com/Azure/terraform-azurerm-avm-ptn-aiml-landing-zone/pull/164) | `5a896b6c6d5ef644ea90a616ca566e56b3a414ba` | `terraform validate`, five unit tests, `avm pre-commit`, and `avm test` passed. |
+| AI Foundry | [`#166`](https://github.com/Azure/terraform-azurerm-avm-ptn-aiml-landing-zone/pull/166) | `94965df` | `terraform validate`, three focused tests, and `avm pre-commit` passed. |
+| Data and AI Services | [`#167`](https://github.com/Azure/terraform-azurerm-avm-ptn-aiml-landing-zone/pull/167) | `b742d8b` | `avm pre-commit`, `avm test`, six unit tests, and Terraform validation/tests passed. |
+
+All five proposals are open drafts from the `placerda` fork to upstream
+`main`, are mergeable, and passed the upstream basic check, CodeQL analysis,
+and CLA check. Their bodies record the implemented safe subset and exact
+deferrals. Repository-wide `avm pr-check` lint remains affected by pre-existing
+AzureRM-to-AzAPI compliance findings outside these proposal changes.
+
+The 22 capabilities and both scenario assessments now reference exactly one
+approved handoff, covering all 44 actionable gaps. Every
+`parityDeclared` value remains `false`. No proposal was merged and no Terraform
+apply, Azure deployment, release, publication, or runtime parity claim was
+performed. Each scenario still requires an independently approved deployment
+and reviewed comparison before parity can be declared.

--- a/tests/parity/Test-NewTerraformHandoff.Tests.ps1
+++ b/tests/parity/Test-NewTerraformHandoff.Tests.ps1
@@ -39,7 +39,7 @@ try {
     Assert-Result 'Pending provenance contains baseline ID and exact-byte digest only' (
         $generated.approval.status -eq 'pending' -and
         $generated.provenance.baselineId -eq 'baseline-v2.6.1-v0.5.1' -and
-        $generated.provenance.inventoryDigest.value -eq '33fa2bae3144b79c632a0e8f142a85600989ecd04de8cca8b1a49de5edff44b4' -and
+        $generated.provenance.inventoryDigest.value -eq '5dd04b6ebb7faa4554954ee9fe27cd3589943f724e9d14e5c799dea0a93bdf75' -and
         $generated.provenance.PSObject.Properties.Name -notcontains 'inventoryCommitSha' -and
         $generated.provenance.PSObject.Properties.Name -notcontains 'inventoryReviewUrl'
     ) ($generated.provenance | ConvertTo-Json -Compress)


### PR DESCRIPTION
## Purpose

Complete issue #136 User Story 2 task T033 by binding the reviewed parity inventory to five separately approved handoffs and recording the five upstream draft Terraform proposals. This remains proposal-only coordination: it does not declare parity, merge Terraform changes, or authorize deployment.

## Type of change 

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Documentation content changes
- [x] Other (please describe): parity governance and proposal provenance

## Related Backlog Item or Issue

Closes #136 task T033; follow-up evidence and ongoing-drift tasks remain tracked in the feature task list.

Reviewed baseline: #147

Terraform draft proposals:
- Azure/terraform-azurerm-avm-ptn-aiml-landing-zone#162
- Azure/terraform-azurerm-avm-ptn-aiml-landing-zone#163
- Azure/terraform-azurerm-avm-ptn-aiml-landing-zone#164
- Azure/terraform-azurerm-avm-ptn-aiml-landing-zone#166
- Azure/terraform-azurerm-avm-ptn-aiml-landing-zone#167

## Documentation

Updated the feature quickstart, task ledger, and validation record. No deployed Bicep behavior or public landing-zone narrative changed, so no `Azure/AI-Landing-Zones` companion PR or changelog entry is required.

## Validation evidence

Passed:
- `npm run test:parity`
- `pwsh -NoProfile -File ./scripts/parity/Test-ParityAssets.ps1`
- `pwsh -NoProfile -File ./scripts/parity/Export-ParityMarkdown.ps1 -Check`
- `git diff --check`

Validated 1 inventory, 22 capabilities, 5 approved proposal-eligible handoffs, 44 proposal references, and 0 parity declarations. No Azure deployment or Terraform apply was run because this change only records proposal provenance and explicit deferrals.

## Code quality checklist

- [x] I verified the changes locally to ensure they work as expected
- [x] I tested the new functionality and ensured existing features still work
- [x] I preserved parameter, output, naming, identity, and network-isolation contracts or documented the migration
- [ ] I updated `CHANGELOG.md` and all affected documentation
- [ ] I added at least one reviewer to this Pull Request