### PR TITLE
fix: backfill parity assessment for PR 150

### DIFF
--- a/docs/terraform-parity-ownership.md
+++ b/docs/terraform-parity-ownership.md
@@ -52,12 +52,12 @@ owner from documentation alone.
   absolute `https` review decision URL, and a review timestamp, both require an
   already recorded outcome, and neither can later change to anything except
   `superseded`. A superseded review is final.
-- The seven backfilled records under `parity/assessments/` are a hand-assessed
+- The eight backfilled records under `parity/assessments/` are a hand-assessed
   seed with `review.status=pending`. Their outcomes and rationales were written
-  by hand before workflow activation. The seventh record covers PR #149, whose
-  assessment event could not run because the workflow was not yet present on
-  the default branch. No approver, approval URL, or approval time is recorded,
-  and no automation may treat these records as approved.
+  by hand before workflow activation. The seventh and eighth records cover PRs
+  #149 and #150, whose assessment events could not run because the workflow was
+  not yet present on the default branch. No approver, approval URL, or approval
+  time is recorded, and no automation may treat these records as approved.
 - Only `proposal-required` assessments may reference handoffs, and only an approved
   `proposal-required` assessment can authorize an alignment-provenance handoff.
 - A rejected or closed Terraform proposal leaves its inventory gap open until a

--- a/parity/assessments/assessment-150-cb5abfd.json
+++ b/parity/assessments/assessment-150-cb5abfd.json
@@ -1,0 +1,20 @@
+{
+  "baselineId": "baseline-v2.6.1-v0.5.1",
+  "changedCapabilities": [],
+  "handoffIds": [],
+  "id": "assessment-150-cb5abfd",
+  "outcome": "no-terraform-impact",
+  "rationale": "PR #150 added and linked repository-only documentation for the Terraform parity process and backfilled the transition assessment for PR #149. It changed no Bicep deployment parameter, resource, output, identity, networking, or runtime contract, so no Terraform implementation proposal is required.",
+  "review": {
+    "status": "pending"
+  },
+  "schemaVersion": "1.0.0",
+  "sourcePr": {
+    "baseBranch": "develop",
+    "mergeCommitSha": "cb5abfd90216bc70f9585429e71a49c3170abd01",
+    "mergedAt": "2026-08-23T21:26:43Z",
+    "number": 150,
+    "repository": "Azure/bicep-ptn-aiml-landing-zone",
+    "url": "https://github.com/Azure/bicep-ptn-aiml-landing-zone/pull/150"
+  }
+}

--- a/specs/001-terraform-foundry-parity/validation.md
+++ b/specs/001-terraform-foundry-parity/validation.md
@@ -210,7 +210,7 @@ Corrective changes applied in this pass:
 
 `parity/assessments/adoption-marker.json` pins adoption commit
 `5a30a4fbb8338b6d1623fdaa7b8e79425b1f4d3b` (the PR #140 merge). Every pull
-request merged into `develop` after it has one hand-assessed record. The seven
+request merged into `develop` after it has one hand-assessed record. The eight
 records are a hand-assessed seed with `review.status=pending`: the outcome and
 rationale were written by hand before workflow activation, and no approver,
 approval URL, or approval time is recorded.
@@ -224,8 +224,9 @@ approval URL, or approval time is recorded.
 | #147 | `66a0d76` | `no-terraform-impact` | pending | Parity coordination assets only. |
 | #148 | `479000e` | `no-terraform-impact` | pending | Reviewed proposal references and approved handoff provenance only. |
 | #149 | `ebfeb29` | `no-terraform-impact` | pending | Continuous parity coordination automation and documentation only; no Bicep deployment contract changed. This transition record was added because `pull_request_target` could not load the newly added workflow until it reaches the default branch. |
+| #150 | `cb5abfd` | `no-terraform-impact` | pending | Plain-language parity process documentation and the PR #149 transition record only; no Bicep deployment contract changed. This transition record was added because `pull_request_target` still could not load the workflow before its promotion to the default branch. |
 
-The seven-record seed lives on `develop` so the dedicated
+The eight-record seed lives on `develop` so the dedicated
 `terraform-parity-assessments` ledger branch can be created from the reviewed
 commit that contains it. After that branch exists and the assessment workflow
 is available on the default branch, the workflow appends every later record
@@ -278,7 +279,7 @@ no deployment, release, or parity claim.
   reviewers, the single-repository GitHub App, and the `PARITY_DISPATCH_APP_ID`
   and `PARITY_DISPATCH_APP_PRIVATE_KEY` environment secrets. Sections 3 to 7 of
   `docs/terraform-parity-ownership.md` record the required values.
-- The seven backfilled assessments carry `review.status=pending`. Recording an
+- The eight backfilled assessments carry `review.status=pending`. Recording an
   approver, approval URL, and approval time is a human act; this pass did not
   fabricate one. A reviewer records it with
   `pwsh ./scripts/parity/Set-AlignmentAssessment.ps1 -Path <record> -ReviewStatus approved -Reviewer <handle> -ApprovalUrl <review-url> -ReviewedAt <utc>`.


### PR DESCRIPTION
## Purpose

Backfill the transition assessment for documentation PR #150 so the `develop` to `main` promotion in #151 has complete ledger coverage.

PR #150 merged into `develop` before `.github/workflows/terraform-parity-assess.yml` reached the default branch. Because `pull_request_target` workflows are loaded from `main`, GitHub could not run the new assessment workflow for that merge. The promotion check correctly detected the missing record.

This change adds `assessment-150-cb5abfd.json` with outcome `no-terraform-impact` and `review.status=pending`. The record states only that PR #150 changed repository documentation and the prior transition seed; it does not claim approval. The ownership runbook and validation evidence now describe the complete eight-record transition seed.

## Type of change

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Documentation content changes
- [x] Other: immutable transition-ledger backfill

## Related Backlog Item or Issue

#136

Unblocks #151.

## Documentation

Updated `docs/terraform-parity-ownership.md` and `specs/001-terraform-foundry-parity/validation.md` from seven to eight transition records and documented why PR #150 required backfill.

## Validation evidence

Validated commit `910f06b`:

- `npm run test:parity` - all 17 suites passed.
- `pwsh ./scripts/parity/Test-AssessmentCoverage.ps1 -LedgerPath parity/assessments -MarkerPath parity/assessments/adoption-marker.json -Branch origin/develop` - 8 merged PRs, 8 records, 0 unattributed commits.
- `pwsh ./scripts/parity/Test-ParityJson.ps1 -Path parity/assessments/assessment-150-cb5abfd.json -Schema assessment` - passed.
- `git diff --check` - passed.

No Bicep build, Azure What-If, deployment, release, or Terraform action was run because this change adds only a repository assessment record and matching documentation.

## Compatibility and approval boundary

No Bicep parameter, output, default, module interface, identity, networking, naming, or runtime behavior changes. The assessment review remains pending: no reviewer, approval URL, or approval timestamp was fabricated. No merge, deployment, release, or parity claim is performed by this PR.

## Code quality checklist

- [x] I verified the changes locally to ensure they work as expected
- [x] I tested the new functionality and ensured existing features still work
- [x] I preserved parameter, output, naming, identity, and network-isolation contracts or documented the migration
- [x] I updated `CHANGELOG.md` and all affected documentation (no changelog entry required for transition seed correction)
- [ ] I added at least one reviewer to this Pull Request